### PR TITLE
Introducing testing system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get install -y mono-csharp-shell --fix-missing
 # Install Coffeescript
 RUN npm -g install coffee-script
 RUN npm -g install chai
-#RUN npm -g install mocha
+RUN npm -g install mocha
 
 # Install Python 3
 

--- a/test.js
+++ b/test.js
@@ -1,0 +1,36 @@
+var opts = require("nomnom")
+    .options({
+        language: {
+            abbr: 'l',
+            help: 'The language to execute the code in'
+        },
+        // Not used...
+        languageVersion: {
+            abbr: 'V',
+            full: 'language-version',
+            help: 'The version of the language that you wish to use'
+        },
+        timeout: {
+            help: 'The timeout to be used for running the code. If not specified a language specific default will be used',
+            abbr: 't',
+            default: '5000'
+        },
+        format: {
+            help: 'The output format that will be returned. Options are "default" and "json"',
+            default: 'default',
+            choices: ['default', 'json'],
+            abbr: 'fmt'
+        }
+    })
+    .help('This utility will run unit tests for a specified language, or all of the tests.')
+    .parse(),
+    spec = opts.language ? ['test/runners/', opts.language, '_spec.js'].join('') : 'test/runners/*_spec.js',
+    proc = require('child_process').spawn('mocha',[spec, '-t', opts.timeout]);
+
+proc.stdout.on('data', function (data) {
+    console.log(data.toString());
+});
+
+proc.on('close', function (code) {
+    console.log('process exit code ' + code);
+});


### PR DESCRIPTION
`docker run codewars/cli-runner test` currently tries to run all of the tests and times out.

I didn't want to tamper with the timeout, not sure how to work around...
