### PR TITLE
Haskell <COMPLETEDIN::>

### DIFF
--- a/frameworks/haskell/Test/CodeWars/Formatters.hs
+++ b/frameworks/haskell/Test/CodeWars/Formatters.hs
@@ -23,7 +23,7 @@ specdoc {
     unless (n == 0) newParagraph
     writeLine $ join ["<DESCRIBE::>", name]
 
-, exampleGroupDone = newParagraph
+, exampleGroupDone = writeLine "<COMPLETEDIN::>"
 
 , exampleSucceeded = \(_, requirement) -> do
     writeLine $ join ["<IT::>", requirement]


### PR DESCRIPTION
Now prints "COMPLETEDIN::" whenever a describe group is terminated
