### PR TITLE
Avoid DD + empty string

### DIFF
--- a/jvm-runner/src/java/codewars/java/CwRunListener.java
+++ b/jvm-runner/src/java/codewars/java/CwRunListener.java
@@ -7,21 +7,18 @@ import org.junit.runner.Description;
 public class CwRunListener extends RunListener
 {
     private boolean failed;
-    public void testFailure(Failure failure)
+    public void testFailure(final Failure failure)
     {
         failed = true;
-        String msg = failure.getMessage();
-        if (msg == null) {
-            msg = "Unknown Test Failure";
-        }
-        System.out.println(String.format("<FAILED::>%s<:LF:>", formatMessage(msg)));
+        final String msg = failure.getMessage();
+        System.out.println(String.format("<FAILED::>%s<:LF:>", formatMessage(msg != null && msg.length() > 0 ? msg : "Unknown Test Failure")));
     }
-    public void testStarted(Description description)
+    public void testStarted(final Description description)
     {
         System.out.println(String.format("<DESCRIBE::>%s<:LF:>", formatMessage(description.getDisplayName())));
         failed = false;
     }
-    public void testFinished(Description description)
+    public void testFinished(final Description description)
     {
         if(!failed)
         {
@@ -29,12 +26,8 @@ public class CwRunListener extends RunListener
         }
         System.out.println("<COMPLETEDIN::>");
     }
-    private static String formatMessage(String s)
+    private static String formatMessage(final String s)
     {
-        if(s == null){
-            s = "";
-        }
-
-        return s.replaceAll("\n", "<:LF:>");
+        return s == null?"":s.replaceAll("\n", "<:LF:>");
     }
 }

--- a/jvm-runner/src/java/codewars/java/CwRunListener.java
+++ b/jvm-runner/src/java/codewars/java/CwRunListener.java
@@ -28,6 +28,9 @@ public class CwRunListener extends RunListener
     }
     private static String formatMessage(final String s)
     {
-        return s == null?"":s.replaceAll("\n", "<:LF:>");
+        if(s == null){
+            return "";
+        }
+        return s.replaceAll("\n", "<:LF:>");
     }
 }


### PR DESCRIPTION
Preventing failure.getMessage to show empty message.
Code runs faster if you define a variable value only once ( final reserved word constraints compiler  to define only once in case of future modifications).
I haven't runned so please review on any branch first :$