### PR TITLE
Fixes testing output for failures and errors

### DIFF
--- a/lib/runners/dart.js
+++ b/lib/runners/dart.js
@@ -92,11 +92,11 @@ var _writeCode = function(code) {
       if (err) reject(err);
       else {
         // Write code & close
-        fs.write(info.fd, code, err => reject(err));
-        fs.close(info.fd, err => reject(err));
+        fs.writeSync(info.fd, code);
+        fs.closeSync(info.fd);
 
         // Also write this test config
-        fs.writeFile(path.join(dir, 'dart_test.yaml'), 'reporter: json');
+        fs.writeFileSync(path.join(dir, 'dart_test.yaml'), 'reporter: json');
 
         resolve(info.path);
       }
@@ -118,7 +118,7 @@ var _format = function(stdout) {
       stdout += `<COMPLETEDIN::>${test.runTime}\n`;
     };
   } catch (err) {
-    stdout = `<ERROR::>${err.split('error: ')[1]}`;
+    stdout = `<ERROR::>${err.split(/(error|warning): /)[2]}`;
   }
   return stdout;
 }

--- a/lib/runners/dart.js
+++ b/lib/runners/dart.js
@@ -150,7 +150,7 @@ var _coerceObjects = function(lines) {
         // Remove this test by id
         delete tests[line.testID];
       } else {
-        if (line.error) throw line.error;
+        if (line.error && line.isFailure === false) throw line.error;
 
         // Set the test values
         test = tests[line.testID];

--- a/test/runners/dart_spec.js
+++ b/test/runners/dart_spec.js
@@ -104,7 +104,7 @@ describe('dart runner', function() {
           }
           `,
         fixture: `
-          test('function returns 50, () async {
+          test('can create a new Person object, () async {
             expect(new Person('Bill','Smith'), new isInstanceOf<Person>());
           });
           `,
@@ -137,6 +137,25 @@ describe('dart runner', function() {
       }, function(buffer) {
         expect(buffer.stdout).to.contain(`<ERROR::>`);
         expect(buffer.stdout).to.contain(`unterminated string literal`);
+        done();
+      });
+    });
+
+    it('should be a simple failed test example', function(done) {
+      runner.run({
+        language: 'dart',
+        setup: `import 'dart:async';`,
+        code: `
+          returnFive() => 5;
+          `,
+        fixture: `
+        test('Should fail', () {
+          expect(returnFive(), equals(4));
+        });
+          `,
+        testFramework: 'test'
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain(`<FAILED::>`);
         done();
       });
     });

--- a/test/runners/dart_spec.js
+++ b/test/runners/dart_spec.js
@@ -91,6 +91,31 @@ describe('dart runner', function() {
       });
     });
 
+    it('should handle invalid code', function(done) {
+      runner.run({
+        language: 'dart',
+        setup: `import 'dart:async';`,
+        code: `
+          class Person {
+            String firstName;
+            String lastName;
+
+            Person(this.firstName,this.lastName
+          }
+          `,
+        fixture: `
+          test('function returns 50, () async {
+            expect(new Person('Bill','Smith'), new isInstanceOf<Person>());
+          });
+          `,
+        testFramework: 'test'
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain(`<ERROR::>`);
+        expect(buffer.stdout).to.contain(`unbalanced`);
+        done();
+      });
+    });
+
     it('should handle errors in testIntegration', function(done) {
       runner.run({
         language: 'dart',


### PR DESCRIPTION
**Fixes:**
- #189 Check for `warning:` or `error:` to output the error text for tests flagged as in error
- #191 Include `isFailure === false` when determining if result is an error or test failure

**Other Changes:**
- Use sync file writing as per most of the other runners since there is an occasional issue where some files are not written fully before accessed. As other runners use sync write I implemented the same rather than callbacks or promisifying it
- Added test case for #189 fix
- Added test case for #191 fix