### PR TITLE
Escape stderr 

### DIFF
--- a/lib/shovel.js
+++ b/lib/shovel.js
@@ -3,6 +3,7 @@ var util = require('util'),
     config = require('./config'),
     os = require('os'),
     utf8 = require('utf8'),
+    escapeHtml = require('escape-html'),
     codeWriteSync = require('./util').codeWriteSync,
     temp = require('temp');
 
@@ -236,6 +237,10 @@ function reportBuffer(opts, buffer, strategies)
     if (opts.shellResult) {
         buffer.shellResult = opts.shellResult;
     }
+
+    // escape the stderr output after strategies have been run
+    // and before the it is written to the process stream
+    buffer.stderr = escapeHtml(buffer.stderr);
 
     if (opts.format == 'json')
     {

--- a/package.json
+++ b/package.json
@@ -19,15 +19,16 @@
     "url": "http://github.com/codewars/runner.git"
   },
   "dependencies": {
+    "bluebird": "*",
     "chai": "1.9.x",
+    "escape-html": "1.0.3",
+    "js-yaml": "*",
     "lodash": "*",
     "mocha": "1.19.x",
+    "mocha-reporter": "git://github.com/codewars/mocha-reporter",
     "nomnom": "1.6.x",
     "temp": "*",
-    "bluebird": "*",
-    "js-yaml": "*",
-    "utf8": "^2.1.1",
-    "mocha-reporter": "git://github.com/codewars/mocha-reporter"
+    "utf8": "^2.1.1"
   },
   "devDependencies": {
     "babel-core": "*",
@@ -60,7 +61,6 @@
     "nlp_compromise": "^4.10.6",
     "quickcheck": "0.0.4",
     "react": "^15.0.2",
-    "react-canvas": "^1.1.0",
     "react-dom": "^15.0.2",
     "redis": "^2.6.0-2",
     "rx": "^4.1.0",

--- a/test/runners/cpp_spec.js
+++ b/test/runners/cpp_spec.js
@@ -56,8 +56,8 @@ describe('cpp runner', function () {
             `;
 
             runner.run({language: 'cpp', code: code}, function (buffer) {
-                expect(buffer.stderr).to.contain("use of undeclared identifier 'fudge'");
-                expect(buffer.stderr).to.contain("use of undeclared identifier 'doubleFudge'");
+                expect(buffer.stderr).to.contain("use of undeclared identifier &#39;fudge&#39;");
+                expect(buffer.stderr).to.contain("use of undeclared identifier &#39;doubleFudge&#39;");
                 expect(buffer.stderr).to.contain("2 errors generated.");
                 done();
             });


### PR DESCRIPTION
escapes stderr output so it's not interpreted as HTML