### PR TITLE
clojure fix (HACK)

### DIFF
--- a/lib/runners/clojure.js
+++ b/lib/runners/clojure.js
@@ -17,6 +17,14 @@ module.exports.run = function run(opts, cb) {
                 args: ['-jar', uberJar],
                 stdin: JSON.stringify(opts)
             });
+        },
+        // HACK: don't know clojure well enough to fix issue within actual runner, but it is escaping line breaks when it shouldn't
+        sanitizeStdOut: function(stdout) {
+            return stdout
+                .replace(/\<:LF:\>\<PASSED::\>/g, '\n<PASSED::>')
+                .replace(/\<:LF:\>\<FAILED::\>/g, '\n<FAILED::>')
+                .replace(/\<:LF:\>\<ERROR::\>/g, '\n<ERROR::>')
+
         }
     });
 };

--- a/test/runners/clojure_spec.js
+++ b/test/runners/clojure_spec.js
@@ -92,7 +92,7 @@ describe('clojure runner', function () {
                 console.log(buffer.stderr);
                 expect(buffer.stdout).to.contain('<DESCRIBE::>printing');
                 expect(buffer.stdout).to.contain('yolo<IT::>foo/bar');
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+                expect(buffer.stdout).to.contain('\n<PASSED::>Test Passed');
                 expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
                 done();
             });


### PR DESCRIPTION
Clojure was escaping line breaks, causing passed/failed tokens to be treated as non-data. This is a hacky fix since i don't understand clojure well enough to fix it properly. Also cannot determine what changed that would have caused this.