### PR TITLE
Fix for Mocha runner and lack of trailing semicolons.

### DIFF
--- a/lib/runners/javascript.js
+++ b/lib/runners/javascript.js
@@ -56,10 +56,10 @@ module.exports.run = function run(opts, cb)
 function prepareMocha(opts, interfaceType, run) {
     var dir = temp.mkdirSync('javascript');
     var code = `
-        ${opts.setup}
-        ${opts.solution}
+        ${opts.setup};
+        ${opts.solution};
         (function() {
-            ${opts.fixture}
+            ${opts.fixture};
         })();
     `;
 

--- a/test/runners/javascript_spec.js
+++ b/test/runners/javascript_spec.js
@@ -167,6 +167,17 @@ db.close();
                         done();
                     });
             });
+            it( 'should handle no trailing semicolons', function(done){
+                runner.run({
+                    language: 'javascript',
+                    code: 'var a = 2',
+                    fixture: 'var assert = require("chai").assert;describe("test", function(){it("should be 2", function(){assert.equal(2, a);})});',
+                    testFramework: 'mocha_bdd'},
+                    function(buffer) {
+                        expect(buffer.stdout).to.contain('<PASSED::>');
+                        done();
+                    });
+            });
             it( 'should handle failures', function(done){
                 runner.run({
                     language: 'javascript',


### PR DESCRIPTION
Mocha was not adding semicolons between code segments, which could cause errors if the trailing content looked like the start of a function.