### PR TITLE
Improved JVM runner output:

### DIFF
--- a/jvm-runner/project.clj
+++ b/jvm-runner/project.clj
@@ -1,4 +1,4 @@
-(defproject jvm-runner "0.1.2"
+(defproject jvm-runner "0.1.3"
   :description "JVM Runner for codewars"
   :url "http://www.codewars.com/"
   :javac-target "1.8"

--- a/jvm-runner/src/java/codewars/java/CwRunListener.java
+++ b/jvm-runner/src/java/codewars/java/CwRunListener.java
@@ -3,6 +3,8 @@ package codewars.java;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.Description;
+import java.io.StringWriter;
+import java.io.PrintWriter;
 
 public class CwRunListener extends RunListener
 {
@@ -11,7 +13,11 @@ public class CwRunListener extends RunListener
     {
         failed = true;
         final String msg = failure.getMessage();
-        System.out.println(String.format("<FAILED::>%s<:LF:>", formatMessage(msg != null && msg.length() > 0 ? msg : "Unknown Test Failure")));
+        final boolean hasMessage =  msg != null && msg.length() > 0;
+        System.out.println(String.format("<FAILED::>%s<:LF:>", formatMessage(hasMessage ? msg : "Runtime Error Occurred")));
+        if(!hasMessage && failure.getException() != null) {
+            System.out.println(formatException(failure.getException()));
+        }
     }
     public void testStarted(final Description description)
     {
@@ -26,11 +32,21 @@ public class CwRunListener extends RunListener
         }
         System.out.println("<COMPLETEDIN::>");
     }
+    private static String formatException(final Throwable ex)
+    {
+        if(ex == null){
+            return "";
+        }
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ex.printStackTrace(pw);
+        return sw.toString().replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+    }
     private static String formatMessage(final String s)
     {
         if(s == null){
             return "";
         }
-        return s.replaceAll("\n", "<:LF:>");
+        return s.replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll("\n", "<:LF:>");
     }
 }

--- a/jvm-runner/test/codewars/runners/java_test.clj
+++ b/jvm-runner/test/codewars/runners/java_test.clj
@@ -92,7 +92,7 @@
       (let [test-out-string (with-java-out-str (-main))]
         (is (.contains test-out-string "<DESCRIBE::>sadPath(TestForFailure)<:LF:>"))
         (is (.contains test-out-string "<FAILED::>Failed Message expected:"))
-        (is (.contains test-out-string "<5> but was:<3>"))
+        (is (.contains test-out-string "&lt;5&gt; but was:&lt;3&gt;"))
         (is (not (.contains test-out-string "Shouldn't get here")))
         (is (not (.contains test-out-string "<PASSED::>Test Passed<:LF:>")))))))
 

--- a/lib/runners/clojure.js
+++ b/lib/runners/clojure.js
@@ -2,7 +2,7 @@ var shovel = require('../shovel'),
     path = require('path');
 
 module.exports.run = function run(opts, cb) {
-    var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.2-standalone.jar');
+    var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.3-standalone.jar');
     shovel.start(opts, cb, {
         solutionOnly: function (run) {
             run({

--- a/lib/runners/groovy.js
+++ b/lib/runners/groovy.js
@@ -2,7 +2,7 @@ var shovel = require('../shovel'),
     path = require('path');
 
 module.exports.run = function run(opts, cb) {
-    var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.2-standalone.jar');
+    var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.3-standalone.jar');
     shovel.start(opts, cb, {
         solutionOnly: function (run) {
             run({

--- a/lib/runners/java.js
+++ b/lib/runners/java.js
@@ -2,7 +2,7 @@ var shovel = require('../shovel'),
     path = require('path');
 
 module.exports.run = function run(opts, cb) {
-    var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.2-standalone.jar');
+    var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.3-standalone.jar');
     shovel.start(opts, cb, {
         solutionOnly: function (run) {
             run({

--- a/test/runners/java_spec.js
+++ b/test/runners/java_spec.js
@@ -59,7 +59,28 @@ describe('java runner', function () {
                     + '        System.out.println("test out");\n'
                     + '}}'
             }, function (buffer) {
-                expect(buffer.stdout).to.contain('<DESCRIBE::>myTestFunction(TestFixture)<:LF:>\n<FAILED::>Failed Message expected:<5> but was:<3><:LF:>\n');
+                expect(buffer.stdout).to.contain('<DESCRIBE::>myTestFunction(TestFixture)<:LF:>\n<FAILED::>Failed Message expected:&lt;5&gt; but was:&lt;3&gt;<:LF:>\n');
+                done();
+            });
+        });
+        it('should report junit messages', function (done) {
+            runner.run({language: 'java',
+                code: 'public class Solution {\n'
+                    + '    public Solution(){}\n'
+                    + '    public String testthing(){ return null; }\n'
+                    + '}\n',
+                fixture: 'import static org.junit.Assert.assertEquals;\n'
+                    + 'import org.junit.Test;\n'
+                    + 'import org.junit.runners.JUnit4;\n'
+                    + 'public class TestFixture {\n'
+                    + '    @Test\n'
+                    + '    public void myTestFunction(){\n'
+                    + '        Solution s = new Solution();\n'
+                    + '        assertEquals("Failed Message", 1, s.testthing().length());\n'
+                    + '}}'
+            }, function (buffer) {
+                expect(buffer.stdout).to.contain('<FAILED::>Runtime Error Occurred');
+                expect(buffer.stdout).to.contain('NullPointerException');
                 done();
             });
         });


### PR DESCRIPTION
- HTML Escapes `<` and `>` within descriptions, errors and failures
- Renders runtime exceptions if the error was not an assertion error