### PR TITLE
Improved PHP runner output. Fixes #221 and #223

### DIFF
--- a/frameworks/php/phpunit/CodewarsListener.php
+++ b/frameworks/php/phpunit/CodewarsListener.php
@@ -17,14 +17,14 @@
         {
             $this->writeOutput($test);
             $message = preg_replace('/\n/', '<:LF:>', self::exceptionToString($e));
-            printf("<FAILED::>%s\n", $message);
+            printf("\n<FAILED::>%s\n", $message);
         }
 
         public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
         {
             $this->writeOutput($test);
             $message = preg_replace('/\n/', '<:LF:>', self::exceptionToString($e));
-            printf("<FAILED::>%s\n", $message);
+            printf("\n<FAILED::>%s\n", $message);
         }
 
         public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
@@ -44,21 +44,21 @@
 
         public function startTest(PHPUnit_Framework_Test $test)
         {
-            printf("<IT::>%s\n", $test->getName());
+            printf("\n<IT::>%s\n", $test->getName());
         }
 
         public function endTest(PHPUnit_Framework_Test $test, $time)
         {
             if ($test !== null && method_exists($test, 'hasFailed') && !$test->hasFailed()) {
                 $this->writeOutput($test);
-                printf("<PASSED::>%s\n", $test->getName());
+                printf("\n<PASSED::>%s\n", $test->getName());
             }
-            printf("<COMPLETEDIN::>%s\n", number_format($time * 1000, 2, '.', ''));
+            printf("\n<COMPLETEDIN::>%s\n", number_format($time * 1000, 2, '.', ''));
         }
 
         public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
         {
-            printf("<DESCRIBE::>%s\n", $suite->getName());
+            printf("\n<DESCRIBE::>%s\n", $suite->getName());
         }
 
         public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
@@ -88,8 +88,10 @@
                 $buffer = $e->getMessage() . "\n";
             } elseif ($e instanceof PHPUnit_Framework_ExceptionWrapper) {
                 $buffer = $e->getClassname() . ': ' . $e->getMessage() . "\n";
-            } else {
+            } else if(method_exists($e, 'getMessage')) {
                 $buffer = get_class($e) . ': ' . $e->getMessage() . "\n";
+            } else {
+                $buffer = $e . "\n";
             }
 
             return $buffer;

--- a/frameworks/php/phpunit/phpunit.xml
+++ b/frameworks/php/phpunit/phpunit.xml
@@ -19,6 +19,8 @@
      stopOnSkipped="false"
      testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
 
+     beStrictAboutTestsThatDoNotTestAnything="true"
+
      strict="false"
      verbose="false"
     >

--- a/lib/runners/php.js
+++ b/lib/runners/php.js
@@ -10,7 +10,7 @@ module.exports.run = function run(opts, cb)
         {
             var code = opts.solution;
 
-            if (opts.setup) 
+            if (opts.setup)
             {
                 code = opts.setup + ';\n' + code;
             }
@@ -80,7 +80,6 @@ var filterLines = (function () {
         /^There was \d+ failure/,
         /^FAILURES!$/,
         /^Tests: \d+, Assertions:/,
-        /\/tmp.*\.php/,
     ];
 
     /**
@@ -90,10 +89,18 @@ var filterLines = (function () {
      * @return array
      */
     return function (lines) {
-        return lines.filter(function (line) {
-            return blacklist.every(function (regex) {
-                return !regex.test(line);
+        return lines
+            .filter(function (line) {
+                return blacklist.every(function (regex) {
+                    return !regex.test(line);
+                });
+            })
+            .map(function(line) {
+                // clean up filenames
+                if(/\/tmp.*\.php/.test(line)) {
+                    line = line.replace(/\/tmp\/[^\/]+\//, '');
+                }
+                return line;
             });
-        });
     };
 }());

--- a/test/runners/php_spec.js
+++ b/test/runners/php_spec.js
@@ -238,6 +238,34 @@ describe( 'php runner', function(){
 	            });
 	        });
 
+	        it( 'should handle console output without linewraps', function(done){
+		        runner.run({
+	                language: 'php',
+	                code: `
+	                  function double($a) {
+	                    print("this was a triumph");
+	                    return $a * 2;
+	                  }
+	                `,
+	                fixture: `
+	                    class DoubleMethod extends TestCase
+	                    {
+	                        public function testDouble() {
+	                            print("I'm making a note here, huge success");
+	                            $this->assertEquals(double(1), 2);
+	                        }
+	                    }
+	                `,
+	                testFramework: 'phpunit'
+	            },
+	            function(buffer) {
+	                expect(buffer.stdout).to.contain('\n<PASSED::>');
+		            expect(buffer.stdout).to.contain('huge success');
+		            expect(buffer.stdout).to.contain('this was a triumph');
+	                done();
+	            });
+	        });
+
         	it('should be able to reference preloaded code', function(done) {
 		        runner.run({
 	                language: 'php',
@@ -364,6 +392,31 @@ describe( 'php runner', function(){
 	                done();
 	            });
 	        });
+
+	        it('should fail on PHP errors', function(done) {
+		        runner.run({
+	                language: 'php',
+	                code: `
+						function double($a) {
+							return $a * 2;
+						}
+	                `,
+	                fixture: `
+			            class Double extends TestCase
+			            {
+		                	public function testBadDouble() {
+	                			$this->assertEquals(double(), 2);
+		                	}
+			            }
+	                `,
+	                testFramework: 'phpunit'
+	            },
+	            function(buffer) {
+	                expect(buffer.stdout).to.contain('<FAILED::>');
+		            expect(buffer.stdout).to.not.contain('<PASSED::>');
+	                done();
+	            });
+        	});
     	});
 
     });


### PR DESCRIPTION
- Fixes bug causing PHP errors to get swallowed, also swallowing the `<FAILED::>` tag
    - Was caused by overzealous blacklist, those lines are now cleaned up without filtering them out
- Adds newlines before each test result, to make sure that echoing content without a newline doesn't swallow answers