### PR TITLE
Adding gmpy2 and PyCrypto to python.docker

### DIFF
--- a/docker/python.docker
+++ b/docker/python.docker
@@ -5,10 +5,10 @@
 FROM codewars/base-runner
 
 # Install Additional Python libraries
-RUN apt-get install -y python-pip python-numpy python-scipy python-pandas python-gmpy2
+RUN apt-get install -y python-pip python-numpy python-scipy python-pandas
 
 # Install Python 3
-RUN apt-get install -y python3-pip python3-numpy python3-scipy python3-pandas python3-gmpy2
+RUN apt-get install -y python3-pip python3-numpy python3-scipy python3-pandas
 
 # Install Packages
 RUN pip install pymongo redis
@@ -49,6 +49,9 @@ RUN pip3 install Jinja2
 # Install PyCrypto
 RUN pip install -U pycrypto
 RUN pip3 install -U pycrypto
+
+# Install gmpy2 for Python2/Python3
+RUN apt-get install -y python-gmpy2 python3-gmpy2
 
 # add the package json first to a tmp directory and build, copy over so that we dont rebuild every time
 ADD package.json /tmp/package.json

--- a/docker/python.docker
+++ b/docker/python.docker
@@ -46,6 +46,14 @@ RUN pip3 install mpld3
 RUN pip install Jinja Jinja2
 RUN pip3 install Jinja2
 
+# Install gmpy2 for high-precision arithmetic
+RUN pip install -U gmpy2
+RUN pip3 install -U gmpy2
+
+# Install PyCrypto
+RUN pip install -U pycrypto
+RUN pip3 install -U pycrpyto
+
 # add the package json first to a tmp directory and build, copy over so that we dont rebuild every time
 ADD package.json /tmp/package.json
 RUN cd /tmp && npm install --production

--- a/docker/python.docker
+++ b/docker/python.docker
@@ -5,10 +5,10 @@
 FROM codewars/base-runner
 
 # Install Additional Python libraries
-RUN apt-get install -y python-pip python-numpy python-scipy python-pandas
+RUN apt-get install -y python-pip python-numpy python-scipy python-pandas python-gmpy2
 
 # Install Python 3
-RUN apt-get install -y python3-pip python3-numpy python3-scipy python3-pandas
+RUN apt-get install -y python3-pip python3-numpy python3-scipy python3-pandas python3-gmpy2
 
 # Install Packages
 RUN pip install pymongo redis
@@ -45,10 +45,6 @@ RUN pip3 install mpld3
 
 RUN pip install Jinja Jinja2
 RUN pip3 install Jinja2
-
-# Install gmpy2 for high-precision arithmetic
-RUN pip install -U gmpy2
-RUN pip3 install -U gmpy2
 
 # Install PyCrypto
 RUN pip install -U pycrypto

--- a/docker/python.docker
+++ b/docker/python.docker
@@ -48,7 +48,7 @@ RUN pip3 install Jinja2
 
 # Install PyCrypto
 RUN pip install -U pycrypto
-RUN pip3 install -U pycrpyto
+RUN pip3 install -U pycrypto
 
 # add the package json first to a tmp directory and build, copy over so that we dont rebuild every time
 ADD package.json /tmp/package.json


### PR DESCRIPTION
Codewars does not have a ton of cryptography katas (especially those which relate directly to practical, modern crypto), but I hope to help change that because practical modern crypto is an extremely important topic.

gmpy2 will help with high precision arithmetic needed when performing operations on very large numbers, such as in cryptography. However, it may also come in handy in other types of katas that involve working with extremely large numbers.

PyCrypto will also give users access to basic crypto functions/algorithms that are missing in Python, since Python's built-in crypto is limited to the hashlib and hmac libraries, which is insufficient.