### PR TITLE
Ocaml: Should fix 'spawn utop ENOENT'; Ocaml/FSharp: fix support for 'Preloaded' code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -474,7 +474,7 @@ services:
       - ./examples:/runner/examples
       - ./frameworks:/runner/frameworks
       - ./test:/runner/test
-    entrypoint: 'bash /home/codewarrior/run_ocaml.sh node run -l ocaml'
+    entrypoint: 'node run -l ocaml'
 
   ocaml_test:
     image: codewars/ocaml-runner

--- a/lib/runners/fsharp.js
+++ b/lib/runners/fsharp.js
@@ -23,7 +23,13 @@ module.exports.run = function(opts, cb)
     shovel.start(opts, cb, {
         solutionOnly: function (run)
         {
-            var file = util.codeWriteSync('fsharp', opts.solution, dir, 'solution.fsx');
+            let fileContents;
+            if (opt.setup) {
+                fileContents = opts.setup + "\n" + opts.solution;
+            } else {
+                fileContents = opts.solution;
+            }
+            var file = util.codeWriteSync('fsharp', fileContents, dir, 'solution.fsx');
             run({name: 'fsharpi', 'args': [file]});
         },
         testIntegration: function (run)
@@ -50,6 +56,7 @@ let codeWarsTestPrinter: Fuchu.Impl.TestPrinters = {
 let _ =
     Fuchu.Impl.eval codeWarsTestPrinter Seq.map Tests.suite;;`
             var stdin = [
+                opts.setup ? opts.setup : ""
                 opts.solution,
                 opts.fixture,
                 runFixtureUsingFuchu

--- a/lib/runners/ocaml.js
+++ b/lib/runners/ocaml.js
@@ -3,10 +3,16 @@ var shovel = require('../shovel');
 module.exports.run = function run(opts, cb) {
     shovel.start(opts, cb, {
         solutionOnly: function (run) {
+            let stdin;
+            if (opts.setup) {
+                stdin = opts.setup + "\n" + opts.solution
+            } else {
+                stdin = opts.solution
+            }
             run({
                 name: 'bash',
                 args: ['/home/codewarrior/run_ocaml.sh', 'utop', '-require', 'core', '-require', 'batteries', '-require', 'oUnit', '-stdin'],
-                stdin: opts.solution
+                stdin: stdin
             });
         },
         testIntegration: function(run) {
@@ -38,6 +44,7 @@ module.exports.run = function run(opts, cb) {
                 '    List.map TestRunner.run_test Tests.suite |> ignore',
             ].join("\n");
             var stdin = [
+                opts.setup ? opts.setup : "",
                 opts.solution,
                 opts.fixture,
                 runFixtureUsingOUnit

--- a/lib/runners/ocaml.js
+++ b/lib/runners/ocaml.js
@@ -4,8 +4,8 @@ module.exports.run = function run(opts, cb) {
     shovel.start(opts, cb, {
         solutionOnly: function (run) {
             run({
-                name: 'utop',
-                args: ['-require', 'core', '-require', 'batteries', '-require', 'oUnit', '-stdin'],
+                name: 'bash',
+                args: ['/home/codewarrior/run_ocaml.sh', 'utop', '-require', 'core', '-require', 'batteries', '-require', 'oUnit', '-stdin'],
                 stdin: opts.solution
             });
         },
@@ -44,8 +44,8 @@ module.exports.run = function run(opts, cb) {
             ].join("\n");
             var test = opts.fixture
             run({
-                name: 'utop',
-                args: ['-require', 'core', '-require', 'batteries', '-require', 'oUnit', '-stdin'],
+                name: 'bash',
+                args: ['/home/codewarrior/run_ocaml.sh', 'utop', '-require', 'core', '-require', 'batteries', '-require', 'oUnit', '-stdin'],
                 stdin: stdin
             });
         }


### PR DESCRIPTION
I've updated the `ocaml.js` runner file to call the bash script that sets up environment variables properly; mocha tests still pass, and I can now `docker-compose run ocaml-runner -c 'print_endline "Hello World!";;'` and see output (before I saw no output when I tried to do that).