### PR TITLE
Added the -lm flag to the args array in the solutionOnly function

### DIFF
--- a/lib/runners/c.js
+++ b/lib/runners/c.js
@@ -9,7 +9,7 @@ module.exports.run = function run(opts, cb) {
         solutionOnly: function (run) {
             var executable = path.join(dir, 'solution'),
                 solutionFile = util.codeWriteSync('c', opts.solution, dir, 'solution.c'),
-                args = ['clang-3.6', '-std=c11', solutionFile, '-o', executable];
+                args = ['clang-3.6', '-std=c11', solutionFile, '-o', executable, '-lm'];
             if (opts.setup) {
                 var setupFile = util.codeWriteSync('c', opts.setup, dir, 'setup.c');
                 args.push(setupFile);


### PR DESCRIPTION
Added the -lm flag to the "args" array in the solutionOnly function to provide math library linkage.

Earlier, I overlooked the "args" array in the solutionOnly function and only added the "-lm" flag to the "args" array in the testIntegration function. Hope this finally resolves
https://github.com/Codewars/codewars.com/issues/658

If not, please let me know. Thank you.