### PR TITLE
Criterion signal support

### DIFF
--- a/frameworks/c/criterion.c
+++ b/frameworks/c/criterion.c
@@ -40,7 +40,7 @@ ReportHook(ASSERT)(struct criterion_assert_stats *stats) {
 
 // when a test crashes unexpectedly
 ReportHook(TEST_CRASH)(struct criterion_test_stats *stats) {
-  puts("\n<FAILED::>Test Crashed");
+  printf("\n<FAILED::>Test Crashed<:LF:>Exit code: %d<:LF:>Signal code: %d",stats->exit_code, stats->signal);
 }
 
 //  after a test ends

--- a/test/runners/c_spec.js
+++ b/test/runners/c_spec.js
@@ -181,6 +181,7 @@ describe('.run', function() {
                     `
             }, function(buffer) {
                 expect(buffer.stdout).to.contain('<FAILED::>Test Crashed');
+                expect(buffer.stdout).to.contain('<:LF:>Signal code: 11');
                 done();
             });
         });


### PR DESCRIPTION
This adds the exit code and signal to the Test Crashed report message