### PR TITLE
Add bc & mlocate to shell

### DIFF
--- a/docker/ruby.docker
+++ b/docker/ruby.docker
@@ -156,6 +156,9 @@ USER root
 # install the tcsh shell
 RUN apt-get update && apt-get -y install csh tcsh
 
+# Install extra shell packages
+RUN apt-get update && apt-get -y install mlocate bc
+
 # add the package json first to a tmp directory and build, copy over so that we dont rebuild every time
 ADD package.json /tmp/package.json
 RUN cd /tmp && npm install --production


### PR DESCRIPTION
Hello,
This adds an update to install two extra packages that are used everyday to extend the functionality of the shell. Bc (basic calculator) allows for complex math functions to be performed, as well as allowing the shell to support floating-point numbers. The mlocate package contains the locate command, allowing for files to be quickly indexed. The absence of mlocate has been pointed out to me before: https://www.codewars.com/kata/bash-basics-check-for-file-existence/discuss/shell.

Thanks,
DHDawson