### PR TITLE
Fixes #259 - cheating by reassigning 'global'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CONTAINERS=node dotnet jvm python ruby alt rust julia systems dart crystal ocaml
 # recent containers should be updated when adding or modifying a language, so that
 # the travis build process will test it. The process cant test all languages
 # without timing out so this is required to get passed that issue.
-RECENT_CONTAINERS=objc
+RECENT_CONTAINERS=node
 
 ALL_CONTAINERS=${CONTAINERS} base
 

--- a/frameworks/javascript/display.js
+++ b/frameworks/javascript/display.js
@@ -48,8 +48,8 @@ var message = module.exports.message = function message(msg, prefix)
  */  
 module.exports.write = function write(type, msg, opts) {
     opts = opts || {};
-    mode = (opts.mode || "").toUpperCase();
-    label = (opts.label || "");
+    var mode = (opts.mode || "").toUpperCase();
+    var label = (opts.label || "");
     if (opts.mode == 'JSON') {
         msg = JSON.stringify(msg);
     }
@@ -174,8 +174,8 @@ module.exports.explain = function explain(actual, expected, options) {
         options = {collapsed: options };
     }
 
-    options = options || {},
-    collapsed = options.collapsed ? "-" : "",
+    options = options || {};
+    var collapsed = options.collapsed ? "-" : "",
     diff = true;
 
     if (options.mode) {

--- a/lib/runners/javascript.js
+++ b/lib/runners/javascript.js
@@ -146,9 +146,11 @@ function prepareCw2(opts, runCode, fail)
         require('/runner/frameworks/javascript/cw-2');
         var assert = require('assert');
         Test.handleError(function(){
+            const __GLOBAL__ = global.global;
             ${opts.setup};
             ${opts.solution};
             (function() {
+                if (global != __GLOBAL__) throw new Error('global.global was reassigned');
                 var Test = global.Test, describe = global.describe, it = global.it, before = global.before, after = global.after;
                 ${opts.fixture};
             })();

--- a/lib/runners/javascript.js
+++ b/lib/runners/javascript.js
@@ -140,17 +140,19 @@ function prepareKarma(opts, interfaceType, runCode, fail) {
 
 function prepareCw2(opts, runCode, fail)
 {
+    // generate random identifier to avoid name collision
+    const GLOBAL = `GLOBAL_${Math.random().toString(36).substr(2,8)}`;
     // run tests inline to the context but within their own scope. Redefine the key test methods in case they were
     // locally redefined within the solution.
     var code = `
         require('/runner/frameworks/javascript/cw-2');
         var assert = require('assert');
         Test.handleError(function(){
-            const __GLOBAL__ = global.global;
+            const ${GLOBAL} = global;
             ${opts.setup};
             ${opts.solution};
             (function() {
-                if (global != __GLOBAL__) throw new Error('global.global was reassigned');
+                if (global != ${GLOBAL}) throw new Error('global was reassigned');
                 var Test = global.Test, describe = global.describe, it = global.it, before = global.before, after = global.after;
                 ${opts.fixture};
             })();

--- a/test/runners/javascript_spec.js
+++ b/test/runners/javascript_spec.js
@@ -585,6 +585,33 @@ describe( 'javascript runner', function(){
                         done();
                     });
             });
+
+            describe('Fix #259', function() {
+                it('should prevent global reassignment cheat', function(done) {
+                    runner.run({
+                        language: 'javascript',
+                        languageVersion: '6.6.0',
+                        code: `
+                        global = Object.assign({}, global);
+                        global.Test = Object.assign({}, Test);
+                        var od = global.Test.describe;
+                        global.Test.describe = function() {
+                          return od("Fake test suite", function() {
+                            Test.it('fake test', function() {
+                              Test.expect(true);
+                            });
+                          });
+                        };
+                        `,
+                        fixture: `Test.describe('Fail', function() { Test.it('should fail', function() { Test.expect(false); }); });`,
+                        testFramework: 'cw-2'
+                    }, function(buffer) {
+                        expect(buffer.stdout).to.not.contain('<PASSED::>');
+                        expect(buffer.stdout).to.contain('<ERROR::>');
+                        done();
+                    });
+                });
+            });
         });
 
 


### PR DESCRIPTION
Fixes #259 by *detecting* reassignment of `global`.

This does not prevent reassignment, but prevents cheating by throwing `Error` with message `"global was reassigned"`.

@jhoffner, do you think throwing error is valid approach?

/cc @Freywar

---

I tried `Object.freeze(global.global)` at first and found several accidental global variables. I also included fixes for those in this pull request. I decided not to use `Object.freeze` because it broke the test "should handle outputting objects with 0.10.33" and will invalidate many solutions. Not adopting suggested fix using `this` because it will fail in strict mode.