### PR TITLE
Fix Test.randomNumber()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CONTAINERS=node dotnet jvm python ruby alt rust julia systems dart crystal ocaml
 # recent containers should be updated when adding or modifying a language, so that
 # the travis build process will test it. The process cant test all languages
 # without timing out so this is required to get passed that issue.
-RECENT_CONTAINERS=dart
+RECENT_CONTAINERS=node
 
 ALL_CONTAINERS=${CONTAINERS} base
 

--- a/frameworks/javascript/cw-2.js
+++ b/frameworks/javascript/cw-2.js
@@ -416,7 +416,7 @@ try {
       Test.expect(passed, msg, options);
     },
     randomNumber: function() {
-      return Math.round(Math.random() * 100);
+      return Math.floor(Math.random() * 101);
     },
     randomToken: function() {
       return Math.random().toString(36).substr(8);

--- a/test/runners/javascript_spec.js
+++ b/test/runners/javascript_spec.js
@@ -676,6 +676,33 @@ describe('javascript runner', function() {
           });
         });
       });
+
+      describe('Test.randomNumber()', function() {
+        it('should generate random integer in range [0, 100]', function(done) {
+          runner.run({
+            language: 'javascript',
+            languageVersion: '6.6.0',
+            code: 'const a = Array.from({length: 1000}, _ => Test.randomNumber());',
+            fixture: 'Test.expect(a.every(x => Number.isInteger(x) && x >= 0 && x <= 100));',
+            testFramework: 'cw-2'
+          }, function(buffer) {
+            expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+            done();
+          });
+        });
+        it('should be uniformly distributed', function(done) {
+          runner.run({
+            language: 'javascript',
+            languageVersion: '6.6.0',
+            code: 'const a = Array.from({length: 101}, _ => 0); for (let i = 0; i < 1e7; ++i) ++a[Test.randomNumber()];',
+            fixture: 'Test.expect(a.every(x => Math.abs(1 - 100*x/1e7) <= 0.2));',
+            testFramework: 'cw-2'
+          }, function(buffer) {
+            expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+            done();
+          });
+        });
+      });
     });
 
 


### PR DESCRIPTION
Use `Math.floor(101*Math.random())` to fix the non-uniform distribution.