### PR TITLE
[ObjC] Add handling for math functions from standard library

### DIFF
--- a/lib/runners/objc.js
+++ b/lib/runners/objc.js
@@ -6,7 +6,7 @@ var shovel = require('../shovel'),
     exec = require('child_process').exec;
 
 function compile(args, cb) {
-    args.unshift('clang', '-I `gnustep-config --variable=GNUSTEP_SYSTEM_HEADERS` -L `gnustep-config --variable=GNUSTEP_SYSTEM_LIBRARIES` -lgnustep-base -fconstant-string-class=NSConstantString -D_NATIVE_OBJC_EXCEPTIONS -fblocks -lobjc');
+    args.unshift('clang', '-I `gnustep-config --variable=GNUSTEP_SYSTEM_HEADERS` -L `gnustep-config --variable=GNUSTEP_SYSTEM_LIBRARIES` -lgnustep-base -fconstant-string-class=NSConstantString -D_NATIVE_OBJC_EXCEPTIONS -fblocks -lobjc -lm');
     args.push('-lBlocksRuntime');
     exec(args.join(' '), cb);
 }

--- a/test/runners/objc_spec.js
+++ b/test/runners/objc_spec.js
@@ -260,5 +260,23 @@ describe( 'objc runner', function(){
 				done();
 			});
 		});
+        it('should handle functions from standard library <math.h>', function(done) {
+           runner.run({
+               language: 'objc',
+               setup: false,
+               code:[
+                   '#import <Foundation/Foundation.h>',
+                   '#include <math.h>',
+                   'int main (int argc, const char * argv[]) {',
+                   'NSLog([NSNumber numberWithDouble: sqrt(pow(5, 2))]);',
+                   'return 0;',
+                   '}'
+               ].join('\n')
+            }, function(buffer) {
+                console.log("buffer", buffer);
+                expect(buffer.stdout).to.contain('5');
+                done();
+            });
+        });
 	});
 });


### PR DESCRIPTION
Add new clang compiler option (-lm) for the handling math function from
the standard library <math.h>; add an appropriate test.