### PR TITLE
Upgrade to Go 1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CONTAINERS=node dotnet jvm python ruby alt rust julia systems dart crystal ocaml
 # recent containers should be updated when adding or modifying a language, so that
 # the travis build process will test it. The process cant test all languages
 # without timing out so this is required to get passed that issue.
-RECENT_CONTAINERS=lua
+RECENT_CONTAINERS=go
 
 ALL_CONTAINERS=${CONTAINERS} base
 

--- a/docker/go.docker
+++ b/docker/go.docker
@@ -1,6 +1,6 @@
 FROM codewars/base-runner
 
-# <https://github.com/docker-library/golang/blob/master/1.7/Dockerfile>
+# <https://github.com/docker-library/golang/blob/master/1.8/stretch/Dockerfile>
 # gcc for cgo
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		g++ \
@@ -10,9 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pkg-config \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.7.5
+ENV GOLANG_VERSION 1.8
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 2e4dd6c44f0693bef4e7b46cc701513d74c3cc44f2419bf519d7868b12931ac3
+ENV GOLANG_DOWNLOAD_SHA256 53ab94104ee3923e228a2cb2116e5e462ad3ebaeea06ff04463479d7f12d27ca
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
Upgrade to [Go 1.8](https://golang.org/doc/go1.8) as planned. Simply replacing 1.7.5 with 1.8 should be [fine](https://golang.org/doc/go1compat).