### PR TITLE
Remove .git from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,5 @@ target/*
 /README.md
 node_modules/*
 docker/*
+.git/
+**/.DS_Store


### PR DESCRIPTION
Remove `.git` (and `.DS_Store`) from build context.

---

I'm going to look into reducing image sizes.
For `alt-runner`, `/frameworks` is `46M`, but only `/frameworks/php` (`24K`) is used.
I think modifying `.docker` files will be the easier than maintaining separate `.dockerignore`.