### PR TITLE
Start using ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+frameworks/javascript/angular/

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,8 +12,7 @@ rules:
     - error
     - unix
   quotes:
-    - error
-    - single
+    - off
   semi:
     - error
     - always

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,8 @@
+root: true
 env:
   es6: true
   node: true
+  mocha: true
 extends: 'eslint:recommended'
 rules:
   indent:
@@ -15,3 +17,5 @@ rules:
   semi:
     - error
     - always
+  no-console:
+    - off

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,21 @@
+env:
+  es6: true
+  node: true
+extends: 'eslint:recommended'
+rules:
+  indent:
+    - error
+    - 2
+    - VariableDeclarator:
+        var: 2
+        let: 2
+        const: 3
+  linebreak-style:
+    - error
+    - unix
+  quotes:
+    - error
+    - single
+  semi:
+    - error
+    - always

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,10 +6,6 @@ rules:
   indent:
     - error
     - 2
-    - VariableDeclarator:
-        var: 2
-        let: 2
-        const: 3
   linebreak-style:
     - error
     - unix

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CONTAINERS=node dotnet jvm python ruby alt rust julia systems dart crystal ocaml
 # recent containers should be updated when adding or modifying a language, so that
 # the travis build process will test it. The process cant test all languages
 # without timing out so this is required to get passed that issue.
-RECENT_CONTAINERS=go
+RECENT_CONTAINERS=node
 
 ALL_CONTAINERS=${CONTAINERS} base
 

--- a/frameworks/javascript/karma-coderunner-reporter.js
+++ b/frameworks/javascript/karma-coderunner-reporter.js
@@ -1,5 +1,3 @@
-/* eslint node: true */
-
 'use strict';
 var util = require('util');
 


### PR DESCRIPTION
Start using [ESLint](http://eslint.org/) with this simple configuration and configure as necessary:

```yaml
root: true
env:
  es6: true
  node: true
  mocha: true
extends: 'eslint:recommended'
rules:
  indent:
    - error
    - 2
  linebreak-style:
    - error
    - unix
  quotes:
    - off
  semi:
    - error
    - always
  no-console:
    - off
```

Indentation can be fixed by using `eslint --fix`. This doesn't seem to fix the comments so I need to look into this or fix comments manually.