### PR TITLE
Fix indentation

### DIFF
--- a/frameworks/javascript/chai-display.js
+++ b/frameworks/javascript/chai-display.js
@@ -1,31 +1,31 @@
 var display = require('./display'),
-    chai = require('chai');
+  chai = require('chai');
 
 // setup chai to render success messages, which it normally doesn't do when used with CW-2
 chai.use(function(_chai, util){
-    var _assert = chai.Assertion.prototype.assert;
-    chai.Assertion.prototype.assert = function (expr, msg, negateMsg, expected, _actual, showDiff) {
-        var ok = util.test(this, arguments),
-            result = ok ? 'passed' : 'failed';
+  var _assert = chai.Assertion.prototype.assert;
+  chai.Assertion.prototype.assert = function (expr, msg, negateMsg, expected, _actual, showDiff) {
+    var ok = util.test(this, arguments),
+      result = ok ? 'passed' : 'failed';
 
-        display.write(result, util.getMessage(this, arguments));
+    display.write(result, util.getMessage(this, arguments));
 
-        if (showDiff) {
-            display.explain(_actual, expected, {
-                collapsed: true,
-                className: result,
-                arguments: this._arguments,
-                context: this._context
-            });
-        }
+    if (showDiff) {
+      display.explain(_actual, expected, {
+        collapsed: true,
+        className: result,
+        arguments: this._arguments,
+        context: this._context
+      });
     }
+  }
 
-    chai.Assertion.addMethod('withArguments', function() {
-        this._arguments = [].slice.apply(arguments);
-    });
+  chai.Assertion.addMethod('withArguments', function() {
+    this._arguments = [].slice.apply(arguments);
+  });
 
-    chai.Assertion.addMethod('withContext', function() {
-        this._context= [].slice.apply(arguments);
-    });
+  chai.Assertion.addMethod('withContext', function() {
+    this._context= [].slice.apply(arguments);
+  });
 });
 

--- a/frameworks/javascript/cw-2.js
+++ b/frameworks/javascript/cw-2.js
@@ -4,9 +4,9 @@ try
     var util = require('util'),
         deepEquals = require('lodash').isEqual,
         Promise = require("bluebird");
-    
+
     require('./chai-display');
-    
+
     var fnToString = Function.toString;
     Function.prototype.toString = function ()
     {
@@ -109,7 +109,7 @@ try
         },
 
         display: require('./display'),
-        
+
         // we use this instead of util.inspect so that we can support the indent option and json options
         stringify: function(obj, indent)
         {
@@ -382,7 +382,7 @@ try
                 Test.expect(false, msg, options);
             }
         },
-		    assertNotDeepEquals: function (actual, expected, msg, options) {
+        assertNotDeepEquals: function (actual, expected, msg, options) {
             if (!deepEquals(actual, expected)) {
                 options = options || {};
                 options.successMsg = options.successMsg || 'Value not deep equals ' + Test.inspect(expected);
@@ -501,7 +501,7 @@ try
 
     Object.freeze(Test.display);
     Object.freeze(Test);
-    
+
     Object.defineProperty(global, 'Test', {
         writable: false,
         configurable: false,

--- a/frameworks/javascript/cw-2.js
+++ b/frameworks/javascript/cw-2.js
@@ -1,293 +1,293 @@
 
 try
 {
-    var util = require('util'),
-        deepEquals = require('lodash').isEqual,
-        Promise = require("bluebird");
+  var util = require('util'),
+    deepEquals = require('lodash').isEqual,
+    Promise = require("bluebird");
 
-    require('./chai-display');
+  require('./chai-display');
 
-    var fnToString = Function.toString;
-    Function.prototype.toString = function ()
+  var fnToString = Function.toString;
+  Function.prototype.toString = function ()
     {
-        switch (this)
+    switch (this)
         {
-            case Test.expect:
-            case Test.randomNumber:
-            case Test.randomize:
-            case Test.randomToken:
-                return '[Codewars Code]';
+    case Test.expect:
+    case Test.randomNumber:
+    case Test.randomize:
+    case Test.randomToken:
+      return '[Codewars Code]';
 
-            default:
-                return fnToString.call(this);
-        }
-    };
-
-    var methodCalls = {},
-        describing = [],
-        async = false,
-        asyncIts = null,
-        asyncDone = null,
-        correct = 0,
-        incorrect = 0,
-        failed = [],
-        beforeCallbacks = [],
-        afterCallbacks = [],
-        alwaysExplain = false;
-
-    $$_SUCCESS__ = null;
-    $STDOUT = [];
-
-    process.on('uncaughtException', function (err) {
-        if (async) {
-            Test.handleError(err);
-            if (asyncDone) asyncDone();
-        }
-    });
-
-    describeNext = function() {
-        if (asyncIts.length > 0) {
-            asyncIts.shift()();
-        }
-        else if(describing.length) {
-            describing.pop()();
-        }
+    default:
+      return fnToString.call(this);
     }
+  };
 
-    var _expect = function (passed, failMsg, options)
+  var methodCalls = {},
+    describing = [],
+    async = false,
+    asyncIts = null,
+    asyncDone = null,
+    correct = 0,
+    incorrect = 0,
+    failed = [],
+    beforeCallbacks = [],
+    afterCallbacks = [],
+    alwaysExplain = false;
+
+  $$_SUCCESS__ = null;
+  $STDOUT = [];
+
+  process.on('uncaughtException', function (err) {
+    if (async) {
+      Test.handleError(err);
+      if (asyncDone) asyncDone();
+    }
+  });
+
+  describeNext = function() {
+    if (asyncIts.length > 0) {
+      asyncIts.shift()();
+    }
+    else if(describing.length) {
+      describing.pop()();
+    }
+  }
+
+  var _expect = function (passed, failMsg, options)
     {
-        options = options || {};
+    options = options || {};
 
-        if (passed)
+    if (passed)
         {
-            var successMsg = "Test Passed";
-            if (options.successMsg)
+      var successMsg = "Test Passed";
+      if (options.successMsg)
             {
-                successMsg += ": " + options.successMsg;
-            }
-            Test.display.write("PASSED", successMsg);
+        successMsg += ": " + options.successMsg;
+      }
+      Test.display.write("PASSED", successMsg);
 
-            if (options.passed) {
-                options.passed(successMsg, options);
-            }
+      if (options.passed) {
+        options.passed(successMsg, options);
+      }
 
-            correct++;
-        }
-        else
-        {
-            failMsg = failMsg || 'Value is not what was expected';
-
-            Test.display.write("FAILED", failMsg);
-
-            if (options.failed) {
-                options.failed(failMsg, options);
-            }
-
-            var error = new Test.Error(failMsg);
-            if (describing)
-            {
-                failed.push(error);
-            }
-            else
-            {
-                throw error;
-            }
-        }
+      correct++;
     }
+    else
+        {
+      failMsg = failMsg || 'Value is not what was expected';
+
+      Test.display.write("FAILED", failMsg);
+
+      if (options.failed) {
+        options.failed(failMsg, options);
+      }
+
+      var error = new Test.Error(failMsg);
+      if (describing)
+            {
+        failed.push(error);
+      }
+      else
+            {
+        throw error;
+      }
+    }
+  }
 
     // convenience method for adding a default failed callback to an options
-    var _failed = function(options, callback) {
-        options = options || {}
-        options.failed = options.failed || callback;
-        return options;
-    }
+  var _failed = function(options, callback) {
+    options = options || {}
+    options.failed = options.failed || callback;
+    return options;
+  }
 
-    var Test = {
+  var Test = {
         // when called, it will set a flag to cause all failed tests to explain the expected/actual results
-        explainAll: function(mode) {
-            alwaysExplain = mode || true;
-        },
+    explainAll: function(mode) {
+      alwaysExplain = mode || true;
+    },
 
-        display: require('./display'),
+    display: require('./display'),
 
         // we use this instead of util.inspect so that we can support the indent option and json options
-        stringify: function(obj, indent)
+    stringify: function(obj, indent)
         {
-            var cache = [];
-            return JSON.stringify(obj, function(key, value){
-                if (typeof value === 'object' && value !== null) {
+      var cache = [];
+      return JSON.stringify(obj, function(key, value){
+        if (typeof value === 'object' && value !== null) {
                     // Circular reference found, discard key
-                    if (cache.indexOf(value) !== -1) return "[Circular]";
-                }
+          if (cache.indexOf(value) !== -1) return "[Circular]";
+        }
                 // Store value in our collection
-                cache.push(value);
-                return value;
-            }, indent);
-        },
+        cache.push(value);
+        return value;
+      }, indent);
+    },
 
         // backwards compatibility
-        format: function (obj, options)
+    format: function (obj, options)
         {
-            Test.display.format(obj, options);
-        },
-        inspect: function (obj)
+      Test.display.format(obj, options);
+    },
+    inspect: function (obj)
         {
             // format arrays ourselves since long arrays end up getting broken out into separate lines, which is often a
             // bad format for typical use cases.
-            if (Array.isArray(obj)) {
-                return "[" + obj.map(function(v) { return Test.inspect(v) }).join(", ") + "]";
-            }
-            else {
-                return util.inspect(obj);
-            }
-        },
-        log: function(msg, opts) {
-            Test.display.log(msg, opts);
-        },
-        describe: function (msg, asyncTimeout, fn)
+      if (Array.isArray(obj)) {
+        return "[" + obj.map(function(v) { return Test.inspect(v) }).join(", ") + "]";
+      }
+      else {
+        return util.inspect(obj);
+      }
+    },
+    log: function(msg, opts) {
+      Test.display.log(msg, opts);
+    },
+    describe: function (msg, asyncTimeout, fn)
         {
-            return new Promise(function(resolve, reject) {
-                if (!fn) {
-                    fn = asyncTimeout;
-                    asyncTimeout = false;
-                } else if (asyncTimeout === true) {
-                    asyncTimeout = 2000; // default timeout to 2 seconds
-                }
+      return new Promise(function(resolve, reject) {
+        if (!fn) {
+          fn = asyncTimeout;
+          asyncTimeout = false;
+        } else if (asyncTimeout === true) {
+          asyncTimeout = 2000; // default timeout to 2 seconds
+        }
 
-                var start = new Date();
-                try {
-                    async = asyncTimeout;
-                    asyncIts = [];
-                    describing.push(function () {
-                        var ms = new Date() - start;
-                        Test.display.write("COMPLETEDIN", ms);
+        var start = new Date();
+        try {
+          async = asyncTimeout;
+          asyncIts = [];
+          describing.push(function () {
+            var ms = new Date() - start;
+            Test.display.write("COMPLETEDIN", ms);
 
                         // TODO: right now before/after blocks don't work very well with multi level describes so they
                         // should only be used at the top level
-                        if (!describing.length) {
-                            beforeCallbacks = [];
-                            afterCallbacks = [];
-                        }
+            if (!describing.length) {
+              beforeCallbacks = [];
+              afterCallbacks = [];
+            }
 
-                        if (failed.length > 0) throw failed[0];
+            if (failed.length > 0) throw failed[0];
 
-                        async = false;
-                        resolve();
-                    });
+            async = false;
+            resolve();
+          });
 
-                    Test.display.write("DESCRIBE", msg);
-                    fn();
-                    if (async) describeNext();
-                }
-                catch (ex)
+          Test.display.write("DESCRIBE", msg);
+          fn();
+          if (async) describeNext();
+        }
+        catch (ex)
                 {
-                    Test.handleError(ex);
-                }
-                finally
+          Test.handleError(ex);
+        }
+        finally
                 {
-                    if (!async && describing.length) describing.pop()();
-                }
+          if (!async && describing.length) describing.pop()();
+        }
+      });
+
+    },
+    it: function (msg, fn)
+        {
+      if (!describing.length) throw '"it" calls must be invoked within a parent "describe" context';
+      var asyncIt = (async && fn.length > 0);
+
+      var begin = function() {
+        Test.display.write("IT", msg);
+
+        beforeCallbacks.forEach(function (cb) {
+          cb();
+        });
+
+        var start = new Date(),
+          timeout,
+          done = function () {
+            if (timeout) clearTimeout(timeout)
+
+            var ms = new Date() - start;
+            Test.display.write("COMPLETEDIN", ms);
+
+            afterCallbacks.forEach(function (cb) {
+              cb();
             });
 
-        },
-        it: function (msg, fn)
-        {
-            if (!describing.length) throw '"it" calls must be invoked within a parent "describe" context';
-            var asyncIt = (async && fn.length > 0);
+            done = null;
 
-            var begin = function() {
-                Test.display.write("IT", msg);
+            if (asyncIt) describeNext();
+          };
 
-                beforeCallbacks.forEach(function (cb) {
-                    cb();
-                });
-
-                var start = new Date(),
-                    timeout,
-                    done = function () {
-                        if (timeout) clearTimeout(timeout)
-
-                        var ms = new Date() - start;
-                        Test.display.write("COMPLETEDIN", ms);
-
-                        afterCallbacks.forEach(function (cb) {
-                            cb();
-                        });
-
-                        done = null;
-
-                        if (asyncIt) describeNext();
-                    };
-
-                if (asyncIt) {
-                    timeout = setTimeout(function() {
-                        if (done) {
-                            throw "`it` function timed out. Function ran longer than " + async + "ms";
-                        }
-                    }, async);
-
-                    asyncDone = done;
-                }
-
-                try {
-                    fn(asyncIt ? done : undefined);
-                }
-                catch (ex) {
-                    Test.handleError(ex);
-                }
-                finally {
-                    if (!asyncIt) done();
-                }
+        if (asyncIt) {
+          timeout = setTimeout(function() {
+            if (done) {
+              throw "`it` function timed out. Function ran longer than " + async + "ms";
             }
+          }, async);
+
+          asyncDone = done;
+        }
+
+        try {
+          fn(asyncIt ? done : undefined);
+        }
+        catch (ex) {
+          Test.handleError(ex);
+        }
+        finally {
+          if (!asyncIt) done();
+        }
+      }
 
             // if async then we queue everything up first
-            if (async) {
-                asyncIts.push(begin);
-            }
+      if (async) {
+        asyncIts.push(begin);
+      }
             // otherwise just run it
-            else {
-                begin();
-            }
-        },
-        before: function (cb)
+      else {
+        begin();
+      }
+    },
+    before: function (cb)
         {
-            beforeCallbacks.push(cb);
-        },
-        after: function (cb)
+      beforeCallbacks.push(cb);
+    },
+    after: function (cb)
         {
-            afterCallbacks.push(cb);
-        },
+      afterCallbacks.push(cb);
+    },
         // handles an error and writes the appropriate output. If a function is provided it will handle the error
         // if the function errors, and then rethrow the exception
-        handleError: function (ex)
+    handleError: function (ex)
         {
-            if (typeof ex == "function")
+      if (typeof ex == "function")
             {
-                try
+        try
                 {
-                    ex();
-                }
-                catch(ex)
+          ex();
+        }
+        catch(ex)
                 {
-                    this.handleError(ex);
-                    throw ex;
-                }
-            }
-            else if (ex.name == 'AssertionError')
+          this.handleError(ex);
+          throw ex;
+        }
+      }
+      else if (ex.name == 'AssertionError')
             {
-                this.fail(ex.message);
-            }
-            else if (ex.name != "TestError")
+        this.fail(ex.message);
+      }
+      else if (ex.name != "TestError")
             {
-                Test.display.write("ERROR", Test.trace(ex));
-            }
-        },
+        Test.display.write("ERROR", Test.trace(ex));
+      }
+    },
         // clean up the stack trace of the exception so that it doesn't give confusing results.
         // Results would be confusing because the user submitted code is compiled into a script where
         // additional code is injected and line numbers will not match.
-        trace: function (ex)
+    trace: function (ex)
         {
-            return (ex.stack || ex.toString() || '')
+      return (ex.stack || ex.toString() || '')
                 .toString()
                 // remove file names (ie: (/cli-runner/...))
                 .replace(/\s\(.*\)/g, '')
@@ -300,233 +300,233 @@ try
                 // handleError is used to wrap top level code, so lets remove it so that it doesn't
                 // confuse users who won't understand why it is there.
                 .replace('at Object.Test.handleError', '');
-        },
-        pass: function ()
+    },
+    pass: function ()
         {
-            _expect(true);
-        },
-        fail: function (message)
+      _expect(true);
+    },
+    fail: function (message)
         {
-            _expect(false, message);
-        },
-        expect: function (passed, message, options)
+      _expect(false, message);
+    },
+    expect: function (passed, message, options)
         {
-            _expect(passed, message, options)
-        },
-        assertSimilar: function (actual, expected, msg, options)
+      _expect(passed, message, options)
+    },
+    assertSimilar: function (actual, expected, msg, options)
         {
-            this.assertEquals(Test.inspect(actual), Test.inspect(expected), msg, options)
-        },
-        assertNotSimilar: function (actual, expected, msg, options)
+      this.assertEquals(Test.inspect(actual), Test.inspect(expected), msg, options)
+    },
+    assertNotSimilar: function (actual, expected, msg, options)
         {
-            this.assertNotEquals(Test.inspect(actual), Test.inspect(expected), msg, options)
-        },
-        assertEquals: function (actual, expected, msg, options) {
-            if (typeof(msg) == 'object') {
-                options = msg;
-                msg = null;
-            }
+      this.assertNotEquals(Test.inspect(actual), Test.inspect(expected), msg, options)
+    },
+    assertEquals: function (actual, expected, msg, options) {
+      if (typeof(msg) == 'object') {
+        options = msg;
+        msg = null;
+      }
 
-            if (actual !== expected) {
-                explain = options && options.explain ? options.explain : alwaysExplain;
+      if (actual !== expected) {
+        explain = options && options.explain ? options.explain : alwaysExplain;
 
-                if (explain) {
-                    Test.expect(false, msg || "Values should be equal", _failed(options, function() {
-                        Test.display.explain(actual, expected, { mode: explain, className: 'failed' });
-                    }));
-                }
-                else {
-                    Test.expect(false, Test.display.message('Expected: ' + Test.inspect(expected) + ', instead got: ' + Test.inspect(actual), msg));
-                }
-            }
-            else {
-                options = options || {};
-                options.successMsg = options.successMsg || 'Value == ' + Test.inspect(expected);
-                Test.expect(true, null, options);
-            }
-        },
-        assertNotEquals: function (a, b, msg, options) {
-            if (typeof(msg) == 'object') {
-                options = msg;
-                msg = null;
-            }
-
-            if (a === b) {
-                explain = options && options.explain ? options.explain : alwaysExplain;
-
-                if (explain) {
-                    Test.expect(false, msg || "Values should not equal each other", _failed(options, function() {
-                        Test.display.explain(actual, expected, { mode: explain, className: 'failed' });
-                    }));
-                }
-                else {
-                    msg = Test.display.message('Values should not be equal: ' + Test.inspect(a), msg);
-                    Test.expect(false, msg, options);
-                }
-
-            }
-            else {
-                options = options || {};
-                options.successMsg = options.successMsg || 'Value != ' + Test.inspect(b);
-                Test.expect(true, null, options);
-            }
-        },
-        assertDeepEquals: function (actual, expected, msg, options) {
-            if (deepEquals(actual, expected)) {
-                options = options || {};
-                options.successMsg = options.successMsg || 'Value deep equals ' + Test.inspect(expected);
-                Test.expect(true, null, options);
-            }
-            else {
-                msg = Test.display.message('Expected: ' + Test.inspect(expected) + ', instead got: ' + Test.inspect(actual), msg);
-                Test.expect(false, msg, options);
-            }
-        },
-        assertNotDeepEquals: function (actual, expected, msg, options) {
-            if (!deepEquals(actual, expected)) {
-                options = options || {};
-                options.successMsg = options.successMsg || 'Value not deep equals ' + Test.inspect(expected);
-                Test.expect(true, null, options);
-            }
-            else {
-                msg = Test.display.message('Value should not deep equal ' + Test.inspect(actual), msg);
-                Test.expect(false, msg, options);
-            }
-        },
-        assertContains: function(actual, expected, msg, options) {
-            if (actual.indexOf(expected) >= 0) {
-                options = options || {};
-                options.successMsg = options.successMsg || 'Value ' + Test.inspect(actual) + ' contains ' + Test.inspect(expected);
-                Test.expect(true, null, options);
-            }
-            else {
-                msg = Test.display.message('Value ' + Test.inspect(actual) + ' should contain ' + Test.inspect(expected), msg);
-                Test.expect(false, msg, options);
-            }
-        },
-        assertNotContains: function(actual, expected, msg, options) {
-            if (actual.indexOf(expected) === -1) {
-                options = options || {};
-                options.successMsg = options.successMsg || 'Value ' + Test.inspect(actual) + ' does not contain ' + Test.inspect(expected);
-                Test.expect(true, null, options);
-            }
-            else {
-                msg = Test.display.message('Value ' + Test.inspect(actual) + ' should not contain ' + Test.inspect(expected), msg);
-                Test.expect(false, msg, options);
-            }
-        },
-        expectNoError: function (msg, fn)
-        {
-            if (!fn)
-            {
-                fn = msg;
-                msg = 'Unexpected error was thrown';
-            }
-
-            try
-            {
-                fn();
-                Test.expect(true)
-            }
-            catch (ex)
-            {
-                if (ex.name == 'TestError')
-                {
-                    throw ex;
-                }
-                else
-                {
-                    msg += ': ' + ex.toString()
-                    Test.expect(false, msg)
-                }
-            }
-        },
-        expectError: function (msg, fn, options)
-        {
-            if (!fn)
-            {
-                fn = msg;
-                msg = 'Expected an error to be thrown'
-            }
-
-            var passed = false;
-            try
-            {
-                fn();
-            }
-            catch (ex)
-            {
-                console.log('<b>Expected error was thrown:</b> ' + ex.toString());
-                passed = true
-            }
-
-            Test.expect(passed, msg, options)
-        },
-        randomNumber: function ()
-        {
-            return Math.round(Math.random() * 100)
-        },
-        randomToken: function ()
-        {
-            return Math.random().toString(36).substr(8)
-        },
-        randomize: function (array)
-        {
-            var arr = array.concat(), i = arr.length, j, x;
-            while (i)
-            {
-                j = (Math.random() * i) | 0;
-                x = arr[--i];
-                arr[i] = arr[j];
-                arr[j] = x;
-            }
-            return arr;
-        },
-        sample: function (array)
-        {
-            return array[~~(array.length * Math.random())]
-        },
-        escapeHtml: function (html) {
-            return Test.display.escapeHtml(html);
-        },
-        Error: function (message)
-        {
-            this.name = "TestError";
-            this.message = (message || "");
+        if (explain) {
+          Test.expect(false, msg || "Values should be equal", _failed(options, function() {
+            Test.display.explain(actual, expected, { mode: explain, className: 'failed' });
+          }));
         }
+        else {
+          Test.expect(false, Test.display.message('Expected: ' + Test.inspect(expected) + ', instead got: ' + Test.inspect(actual), msg));
+        }
+      }
+      else {
+        options = options || {};
+        options.successMsg = options.successMsg || 'Value == ' + Test.inspect(expected);
+        Test.expect(true, null, options);
+      }
+    },
+    assertNotEquals: function (a, b, msg, options) {
+      if (typeof(msg) == 'object') {
+        options = msg;
+        msg = null;
+      }
+
+      if (a === b) {
+        explain = options && options.explain ? options.explain : alwaysExplain;
+
+        if (explain) {
+          Test.expect(false, msg || "Values should not equal each other", _failed(options, function() {
+            Test.display.explain(actual, expected, { mode: explain, className: 'failed' });
+          }));
+        }
+        else {
+          msg = Test.display.message('Values should not be equal: ' + Test.inspect(a), msg);
+          Test.expect(false, msg, options);
+        }
+
+      }
+      else {
+        options = options || {};
+        options.successMsg = options.successMsg || 'Value != ' + Test.inspect(b);
+        Test.expect(true, null, options);
+      }
+    },
+    assertDeepEquals: function (actual, expected, msg, options) {
+      if (deepEquals(actual, expected)) {
+        options = options || {};
+        options.successMsg = options.successMsg || 'Value deep equals ' + Test.inspect(expected);
+        Test.expect(true, null, options);
+      }
+      else {
+        msg = Test.display.message('Expected: ' + Test.inspect(expected) + ', instead got: ' + Test.inspect(actual), msg);
+        Test.expect(false, msg, options);
+      }
+    },
+    assertNotDeepEquals: function (actual, expected, msg, options) {
+      if (!deepEquals(actual, expected)) {
+        options = options || {};
+        options.successMsg = options.successMsg || 'Value not deep equals ' + Test.inspect(expected);
+        Test.expect(true, null, options);
+      }
+      else {
+        msg = Test.display.message('Value should not deep equal ' + Test.inspect(actual), msg);
+        Test.expect(false, msg, options);
+      }
+    },
+    assertContains: function(actual, expected, msg, options) {
+      if (actual.indexOf(expected) >= 0) {
+        options = options || {};
+        options.successMsg = options.successMsg || 'Value ' + Test.inspect(actual) + ' contains ' + Test.inspect(expected);
+        Test.expect(true, null, options);
+      }
+      else {
+        msg = Test.display.message('Value ' + Test.inspect(actual) + ' should contain ' + Test.inspect(expected), msg);
+        Test.expect(false, msg, options);
+      }
+    },
+    assertNotContains: function(actual, expected, msg, options) {
+      if (actual.indexOf(expected) === -1) {
+        options = options || {};
+        options.successMsg = options.successMsg || 'Value ' + Test.inspect(actual) + ' does not contain ' + Test.inspect(expected);
+        Test.expect(true, null, options);
+      }
+      else {
+        msg = Test.display.message('Value ' + Test.inspect(actual) + ' should not contain ' + Test.inspect(expected), msg);
+        Test.expect(false, msg, options);
+      }
+    },
+    expectNoError: function (msg, fn)
+        {
+      if (!fn)
+            {
+        fn = msg;
+        msg = 'Unexpected error was thrown';
+      }
+
+      try
+            {
+        fn();
+        Test.expect(true)
+      }
+      catch (ex)
+            {
+        if (ex.name == 'TestError')
+                {
+          throw ex;
+        }
+        else
+                {
+          msg += ': ' + ex.toString()
+          Test.expect(false, msg)
+        }
+      }
+    },
+    expectError: function (msg, fn, options)
+        {
+      if (!fn)
+            {
+        fn = msg;
+        msg = 'Expected an error to be thrown'
+      }
+
+      var passed = false;
+      try
+            {
+        fn();
+      }
+      catch (ex)
+            {
+        console.log('<b>Expected error was thrown:</b> ' + ex.toString());
+        passed = true
+      }
+
+      Test.expect(passed, msg, options)
+    },
+    randomNumber: function ()
+        {
+      return Math.round(Math.random() * 100)
+    },
+    randomToken: function ()
+        {
+      return Math.random().toString(36).substr(8)
+    },
+    randomize: function (array)
+        {
+      var arr = array.concat(), i = arr.length, j, x;
+      while (i)
+            {
+        j = (Math.random() * i) | 0;
+        x = arr[--i];
+        arr[i] = arr[j];
+        arr[j] = x;
+      }
+      return arr;
+    },
+    sample: function (array)
+        {
+      return array[~~(array.length * Math.random())]
+    },
+    escapeHtml: function (html) {
+      return Test.display.escapeHtml(html);
+    },
+    Error: function (message)
+        {
+      this.name = "TestError";
+      this.message = (message || "");
     }
+  }
 
 //    Test.Error.prototype = require('assert').AssertionError.prototype;
-    Test.Error.prototype = Error.prototype;
+  Test.Error.prototype = Error.prototype;
 
-    Object.freeze(Test.display);
-    Object.freeze(Test);
+  Object.freeze(Test.display);
+  Object.freeze(Test);
 
-    Object.defineProperty(global, 'Test', {
-        writable: false,
-        configurable: false,
-        value: Test
-    })
-    Object.defineProperty(global, 'describe', {
-        writable: false,
-        value: Test.describe
-    })
-    Object.defineProperty(global, 'it', {
-        writable: false,
-        value: Test.it
-    })
-    Object.defineProperty(global, 'before', {
-        writable: false,
-        value: Test.before
-    })
-    Object.defineProperty(global, 'after', {
-        writable: false,
-        value: Test.after
-    })
+  Object.defineProperty(global, 'Test', {
+    writable: false,
+    configurable: false,
+    value: Test
+  })
+  Object.defineProperty(global, 'describe', {
+    writable: false,
+    value: Test.describe
+  })
+  Object.defineProperty(global, 'it', {
+    writable: false,
+    value: Test.it
+  })
+  Object.defineProperty(global, 'before', {
+    writable: false,
+    value: Test.before
+  })
+  Object.defineProperty(global, 'after', {
+    writable: false,
+    value: Test.after
+  })
 
 
 }catch(ex)
 {
-    console.error(ex);
-    throw "Failed to load core API methods";
+  console.error(ex);
+  throw "Failed to load core API methods";
 }

--- a/frameworks/javascript/display.js
+++ b/frameworks/javascript/display.js
@@ -1,26 +1,26 @@
 
 var util = require('util'),
-    isEqual = require('underscore').isEqual,
-    chai = require('chai'),
-    display = module.exports;
+  isEqual = require('underscore').isEqual,
+  chai = require('chai'),
+  display = module.exports;
 
 // prevent anyone from peeking at the code we passed in
 if (global.process) {
-    global.process.execArgv = null;
-    global.process._eval = null;
-    global.process.exit = function () {
-    };
+  global.process.execArgv = null;
+  global.process._eval = null;
+  global.process.exit = function () {
+  };
 
-    Object.defineProperty(global.process, "_eval", {
-        writable: false,
-        configurable: false,
-        value: "Don't cheat :)"
-    });
+  Object.defineProperty(global.process, "_eval", {
+    writable: false,
+    configurable: false,
+    value: "Don't cheat :)"
+  });
 }
 
 function combineMessages(msgs, separator)
 {
-    return msgs.filter(function (m){ return m != null;}).join(separator)
+  return msgs.filter(function (m){ return m != null;}).join(separator)
 }
 
 /**
@@ -31,45 +31,45 @@ function combineMessages(msgs, separator)
  */
 var message = module.exports.message = function message(msg, prefix)
 {
-    if (typeof msg == 'function')
+  if (typeof msg == 'function')
     {
-        msg = msg()
-    }
-    else if (typeof msg == 'array')
+    msg = msg()
+  }
+  else if (typeof msg == 'array')
     {
-        msg = combineMessages(msg, ' - ')
-    }
-    msg = prefix ? (prefix + ' - ' + msg) : msg;
-    return msg || '';
+    msg = combineMessages(msg, ' - ')
+  }
+  msg = prefix ? (prefix + ' - ' + msg) : msg;
+  return msg || '';
 }
 
 /**
  * Base method for writing custom output tokens.
  */  
 module.exports.write = function write(type, msg, opts) {
-    opts = opts || {};
-    var mode = (opts.mode || "").toUpperCase();
-    var label = (opts.label || "");
-    if (opts.mode == 'JSON') {
-        msg = JSON.stringify(msg);
-    }
+  opts = opts || {};
+  var mode = (opts.mode || "").toUpperCase();
+  var label = (opts.label || "");
+  if (opts.mode == 'JSON') {
+    msg = JSON.stringify(msg);
+  }
     
-    msg = display.format(display.message(msg));
-    console.log("<" + type.toUpperCase() + ":" + mode + ":" + label + ">" + msg);
+  msg = display.format(display.message(msg));
+  console.log("<" + type.toUpperCase() + ":" + mode + ":" + label + ">" + msg);
 }
 
 /**
  * Convenience method so that you dont have to write display.write("LOG", msg, opts) but instead display.log(msg, opts)
  */
 module.exports.log = function(msg, opts) {
-    display.write("LOG", msg, opts);
+  display.write("LOG", msg, opts);
 }
 
 /**
  * Convenience method so that you dont have to write display.write("TAB", msg, opts) but instead display.tab(label, msg, mode)
  */
 module.exports.tab = function tab(label, msg, mode) {
-    display.write("TAB", msg, { label: label || "???", mode: mode });
+  display.write("TAB", msg, { label: label || "???", mode: mode });
 }
 
 /**
@@ -78,14 +78,14 @@ module.exports.tab = function tab(label, msg, mode) {
  * @param label
  */
 module.exports.json = function json(obj, label, tab) {
-    display.write(tab ? 'TAB' : 'LOG', obj, {label: label, mode: 'JSON'});
+  display.write(tab ? 'TAB' : 'LOG', obj, {label: label, mode: 'JSON'});
 }
 
 /**
  * Writes a propertly to the last displayed token
  */
 module.exports.prop = function prop(name, value) {
-    display.write("PROP", value, { label: name });
+  display.write("PROP", value, { label: name });
 }
 
 /**
@@ -96,7 +96,7 @@ module.exports.prop = function prop(name, value) {
  * @param {boolean} tab optional if it should be rendered as a tab
  */
 module.exports.inspect = function inspect(obj, label, tab) {
-    display.write(tab ? "TAB" : "LOG", util.inspect(obj), {label: label});
+  display.write(tab ? "TAB" : "LOG", util.inspect(obj), {label: label});
 }
 
 /**
@@ -106,37 +106,37 @@ module.exports.inspect = function inspect(obj, label, tab) {
  *  one group of data.
  */
 var format = module.exports.format = function format(obj, options) {
-    options = options || {};
-    var out = '';
-    if (typeof obj == 'string')
+  options = options || {};
+  var out = '';
+  if (typeof obj == 'string')
     {
-        out = obj;
-    }
-    else if (typeof obj == 'function')
+    out = obj;
+  }
+  else if (typeof obj == 'function')
     {
-        out = obj.toString();
-    }
-    else
+    out = obj.toString();
+  }
+  else
     {
-        if (obj && obj !== true){
+    if (obj && obj !== true){
 
             // for backwards compatibility we will support the indent option
-            if (options.indent || options.json)
+      if (options.indent || options.json)
             {
-                out = Test.stringify(obj, options.indent ? 4 : 0)
-            }
-            else
+        out = Test.stringify(obj, options.indent ? 4 : 0)
+      }
+      else
             {
-                out = util.inspect(obj, options);
-            }
-        }
-        else{
-            out = ('' + obj);
-        }
+        out = util.inspect(obj, options);
+      }
     }
+    else{
+      out = ('' + obj);
+    }
+  }
     // replace linebreaks with LF so that they can be converted back to line breaks later. Otherwise
     // the linebreak will be treated as a new data item.
-    return out.replace(/\n/g, '<:LF:>');
+  return out.replace(/\n/g, '<:LF:>');
 }
 
 
@@ -144,7 +144,7 @@ var format = module.exports.format = function format(obj, options) {
  * Simple HTML escape functionality.
  */
 module.exports.escapeHtml = function escapeHtml(html) {
-    return String(html)
+  return String(html)
         .replace(/&/g, '&amp;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;')
@@ -159,7 +159,7 @@ module.exports.escapeHtml = function escapeHtml(html) {
  * @param collapsed
  */
 module.exports.explainJson = function explainJson(actual, expected, collapsed) {
-    display.explain(actual, expected, {collapsed: collapsed, mode: 'JSON'});
+  display.explain(actual, expected, {collapsed: collapsed, mode: 'JSON'});
 }
 
 /**
@@ -170,30 +170,30 @@ module.exports.explainJson = function explainJson(actual, expected, collapsed) {
  */
 module.exports.explain = function explain(actual, expected, options) {
     // allow true to be passed in as a shortcut to setting collapsed
-    if (options === true || options === false) {
-        options = {collapsed: options };
-    }
+  if (options === true || options === false) {
+    options = {collapsed: options };
+  }
 
-    options = options || {};
-    var collapsed = options.collapsed ? "-" : "",
+  options = options || {};
+  var collapsed = options.collapsed ? "-" : "",
     diff = true;
 
-    if (options.mode) {
-        if (typeof(options.mode) == 'string') {
-            options.mode = options.mode.toUpperCase();
-        }
+  if (options.mode) {
+    if (typeof(options.mode) == 'string') {
+      options.mode = options.mode.toUpperCase();
+    }
         // if mode is not a string, then its expected to be an explain boolean and we can throw it away.
         // doing this allows us to have pass mode strings as explain values within wrapping functions.
         // see cw-2.js Test.assertEquals
-        else {
-            options.mode = null;
-        }
+    else {
+      options.mode = null;
     }
+  }
 
-    options.mode = options.mode;
+  options.mode = options.mode;
 
-    if (options.mode == 'JSON') {
-        diff = actual && expected;
+  if (options.mode == 'JSON') {
+    diff = actual && expected;
         // if (typeof(actual) != 'string') {
         //     actual = JSON.stringify(actual);
         // }
@@ -202,64 +202,64 @@ module.exports.explain = function explain(actual, expected, options) {
         //     expected = JSON.stringify(expected);
         // }
 
-        diff = diff && actual != expected;
-    }
+    diff = diff && actual != expected;
+  }
     // string mode is a special mode for this method which just means inspect as direct strings
-    else if (options.mode == 'STRING') {
-        options.mode = null;
-        actual = actual ? actual.toString() : actual;
-        expected = expected ? expected.toString() : expected;
-        diff = expected != actual && actual && expected;
-    }
-    else {
-        diff = !(actual && expected && isEqual(actual, expected));
-        expected = util.inspect(expected);
-        actual = util.inspect(actual);
-    }
+  else if (options.mode == 'STRING') {
+    options.mode = null;
+    actual = actual ? actual.toString() : actual;
+    expected = expected ? expected.toString() : expected;
+    diff = expected != actual && actual && expected;
+  }
+  else {
+    diff = !(actual && expected && isEqual(actual, expected));
+    expected = util.inspect(expected);
+    actual = util.inspect(actual);
+  }
 
     // if collapsed is not specifically set, then we will only collapse if values are equal by default
-    if (collapsed == null || collapsed == undefined) {
-        collapsed = !diff;
-    }
+  if (collapsed == null || collapsed == undefined) {
+    collapsed = !diff;
+  }
 
-    display.log(expected, { label: collapsed + "Expected", mode: options.mode} );
+  display.log(expected, { label: collapsed + "Expected", mode: options.mode} );
 
     // allows you to setup a special class for a log container
-    if (options.className) {
-        display.prop("className", options.className);
-    }
+  if (options.className) {
+    display.prop("className", options.className);
+  }
 
-    display.tab("Actual", actual, options.mode);
+  display.tab("Actual", actual, options.mode);
 
-    if (diff) {
-        display.tab("Diff", "", "DIFF");
-    }
+  if (diff) {
+    display.tab("Diff", "", "DIFF");
+  }
     
-    if (options.arguments) {
-        var details = "";
-        options.arguments.forEach(function(v, i) {
-            if (i > 0) details += "\n\n";
-            details += "<label>Argument " + i + ":</label>\n";
-            details += util.inspect(v);
-        });
+  if (options.arguments) {
+    var details = "";
+    options.arguments.forEach(function(v, i) {
+      if (i > 0) details += "\n\n";
+      details += "<label>Argument " + i + ":</label>\n";
+      details += util.inspect(v);
+    });
 
-        display.tab("Arguments", details);
-        display.prop("className", "inspection");
-    }
+    display.tab("Arguments", details);
+    display.prop("className", "inspection");
+  }
 
-    if (options.context) {
-        display.tab("Context", util.inspect(options.context));
-    }
+  if (options.context) {
+    display.tab("Context", util.inspect(options.context));
+  }
 
-    if (options.swap) display.write("SWAP");
+  if (options.swap) display.write("SWAP");
 }
 
 module.exports.getPackages = function() {
-    var buffer = require('child_process').execSync('npm ls --json');
-    return JSON.parse(buffer.toString());
+  var buffer = require('child_process').execSync('npm ls --json');
+  return JSON.parse(buffer.toString());
 }
 
 module.exports.availablePackages = function(label) {
-    var packages = display.getPackages(); 
-    display.json(packages, label);
+  var packages = display.getPackages(); 
+  display.json(packages, label);
 }

--- a/frameworks/javascript/karma-coderunner-reporter.js
+++ b/frameworks/javascript/karma-coderunner-reporter.js
@@ -2,77 +2,77 @@
 var util = require('util');
 
 function print(type, text) {
-	var msg = text ? ('' + text).replace(/\n/g, '<:LF:>') : '';
-	console.log('<' + type + '::>' + msg);
+  var msg = text ? ('' + text).replace(/\n/g, '<:LF:>') : '';
+  console.log('<' + type + '::>' + msg);
 }
 
 function CodeRunnerReporter(baseReporterDecorator, formatError, config, helper) {
 	// extend the base reporter
-	baseReporterDecorator(this);
+  baseReporterDecorator(this);
 
-	var suites = [];
+  var suites = [];
 
-	this.onRunStart = function() {
+  this.onRunStart = function() {
 		// nothing to do
-	};
+  };
 
-	this.onBrowserStart = function(browser) {
+  this.onBrowserStart = function(browser) {
 		// We could include the browser as an outer suite, but we're only running on PhantomJS, so there's no real benefit
 		// print('DESCRIBE', browser.toString());
-	};
+  };
 
-	this.onBrowserError = function(browser, error) {
-		print('ERROR', 'Error:\n' + formatError(error));
-	};
+  this.onBrowserError = function(browser, error) {
+    print('ERROR', 'Error:\n' + formatError(error));
+  };
 
-	this.onBrowserLog = function(browser, log, type) {
-		let msg = helper.isString(log) ? log.replace(/^'|'$/g, '') : util.inspect(log);
+  this.onBrowserLog = function(browser, log, type) {
+    let msg = helper.isString(log) ? log.replace(/^'|'$/g, '') : util.inspect(log);
 		// if(typeof console[type] !== 'function') type = 'log';
-		console[type](msg);
-	};
+    console[type](msg);
+  };
 
-	this.onBrowserComplete = function(browser) {
+  this.onBrowserComplete = function(browser) {
 		// We could include the browser as an outer suite, but we're only running on PhantomJS, so there's no real benefit
 		// print('COMPLETEDIN');
-	};
+  };
 
-	this.onSpecComplete = function(browser, result) {
-		if(!result.skipped) {
-			_renderSuites((result.suite || []).slice());
-			print('IT', result.description);
-			if(result.success) {
-				print('PASSED', result.time + 'ms');
-			} else {
-				print('FAILED', result.log);
-			}
-			print('COMPLETEDIN');
-		}
-	};
+  this.onSpecComplete = function(browser, result) {
+    if(!result.skipped) {
+      _renderSuites((result.suite || []).slice());
+      print('IT', result.description);
+      if(result.success) {
+        print('PASSED', result.time + 'ms');
+      } else {
+        print('FAILED', result.log);
+      }
+      print('COMPLETEDIN');
+    }
+  };
 
-	this.onRunComplete = function(browsers, results) {
-		_renderSuites([]);
-	};
+  this.onRunComplete = function(browsers, results) {
+    _renderSuites([]);
+  };
 
-	function _renderSuites(specSuites) {
-		var currentSuites = suites.slice();
-		var finalSuites = [];
-		var i;
-		while(specSuites.length && specSuites[0] === currentSuites[0]) {
-			finalSuites.push(specSuites.shift());
-			currentSuites.shift();
-		}
-		for(i = 0; i < currentSuites.length; i++) {
-			print('COMPLETEDIN');
-		}
-		for(i = 0; i < specSuites.length; i++) {
-			print('DESCRIBE', specSuites[i]);
-		}
-		suites = finalSuites.concat(specSuites);
-	}
+  function _renderSuites(specSuites) {
+    var currentSuites = suites.slice();
+    var finalSuites = [];
+    var i;
+    while(specSuites.length && specSuites[0] === currentSuites[0]) {
+      finalSuites.push(specSuites.shift());
+      currentSuites.shift();
+    }
+    for(i = 0; i < currentSuites.length; i++) {
+      print('COMPLETEDIN');
+    }
+    for(i = 0; i < specSuites.length; i++) {
+      print('DESCRIBE', specSuites[i]);
+    }
+    suites = finalSuites.concat(specSuites);
+  }
 }
 
 CodeRunnerReporter.$inject = ['baseReporterDecorator', 'formatError', 'config', 'helper'];
 
 module.exports = {
-	'reporter:coderunner': ['type', CodeRunnerReporter]
+  'reporter:coderunner': ['type', CodeRunnerReporter]
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,75 +1,75 @@
 module.exports = {
-    version: '1.0.5',
-    testFramework: {
-        defaults: {
-            javascript: 'cw-2',
-            coffeescript: 'cw-2',
-            ruby: 'cw-2',
-            python: 'cw-2',
-            sql: 'rspec',
-            objc: 'cw'
-        }
-    },
-    timeouts: {
-        default: 12000,
-        go: 15000,
-        haskell: 15000,
-        sql: 14000,
-    },
-    moduleRegExs: {
-        haskell: /module\s+([A-Z]([a-z|A-Z|0-9]|\.[A-Z])*)\W/,
-        julia: /module\s+([a-z|A-Z][a-z|A-Z|0-9]*)\W/,
-        erlang: /-module\(([a-z|A-Z][a-z|A-Z|0-9|_]*)\)/,
-        elixir: /defmodule\s+([a-z|A-Z][.a-z|A-Z|0-9|_]*)\s+do/,
-        scala: /(?:object|class)\s+([A-Z][a-z|A-Z|0-9|_]*)/,
-        kotlin: /(?:object|class)\s+([A-Z][a-z|A-Z|0-9|_]*)/,
-        swift: /\n*\/\/\s*([a-z|A-Z|0-9|_|-]+)\.swift\s*\n/,
-        objc: /\n*\/\/\s*([a-z|A-Z|0-9|_|-]+)\.m\s*\n/,
-        objcHeader: /\n*\/\/\s*([a-z|A-Z|0-9|_|-]+)\.h\s*\n/
-    },
-    fileExtensions: {
-        c: 'c',
-        cpp: 'cpp',
-        coffeescript: 'coffee',
-        crystal: 'cr',
-        csharp: 'cs',
-        elixir: 'ex',
-        erlang: 'erl',
-        fsharp: 'fs',
-        go: 'go',
-        groovy: 'groovy',
-        haskell: 'hs',
-        java: 'java',
-        javascript: 'js',
-        julia: 'jl',
-        kotlin: 'kt',
-        objc: 'm',
-        objcHeader: 'h',
-        ruby: 'rb',
-        scala: 'scala',
-        shell: 'sh',
-        sql: 'sql',
-        swift: 'swift',
-    },
-    snippets: {
-        python: {
-            addPythonFramework: [
-                "try: from imp import reload",
-                "except: pass",
-                "reload(__import__('sys')).path.append('./frameworks/python')"
-            ].join('\n'),
+  version: '1.0.5',
+  testFramework: {
+    defaults: {
+      javascript: 'cw-2',
+      coffeescript: 'cw-2',
+      ruby: 'cw-2',
+      python: 'cw-2',
+      sql: 'rspec',
+      objc: 'cw'
+    }
+  },
+  timeouts: {
+    default: 12000,
+    go: 15000,
+    haskell: 15000,
+    sql: 14000,
+  },
+  moduleRegExs: {
+    haskell: /module\s+([A-Z]([a-z|A-Z|0-9]|\.[A-Z])*)\W/,
+    julia: /module\s+([a-z|A-Z][a-z|A-Z|0-9]*)\W/,
+    erlang: /-module\(([a-z|A-Z][a-z|A-Z|0-9|_]*)\)/,
+    elixir: /defmodule\s+([a-z|A-Z][.a-z|A-Z|0-9|_]*)\s+do/,
+    scala: /(?:object|class)\s+([A-Z][a-z|A-Z|0-9|_]*)/,
+    kotlin: /(?:object|class)\s+([A-Z][a-z|A-Z|0-9|_]*)/,
+    swift: /\n*\/\/\s*([a-z|A-Z|0-9|_|-]+)\.swift\s*\n/,
+    objc: /\n*\/\/\s*([a-z|A-Z|0-9|_|-]+)\.m\s*\n/,
+    objcHeader: /\n*\/\/\s*([a-z|A-Z|0-9|_|-]+)\.h\s*\n/
+  },
+  fileExtensions: {
+    c: 'c',
+    cpp: 'cpp',
+    coffeescript: 'coffee',
+    crystal: 'cr',
+    csharp: 'cs',
+    elixir: 'ex',
+    erlang: 'erl',
+    fsharp: 'fs',
+    go: 'go',
+    groovy: 'groovy',
+    haskell: 'hs',
+    java: 'java',
+    javascript: 'js',
+    julia: 'jl',
+    kotlin: 'kt',
+    objc: 'm',
+    objcHeader: 'h',
+    ruby: 'rb',
+    scala: 'scala',
+    shell: 'sh',
+    sql: 'sql',
+    swift: 'swift',
+  },
+  snippets: {
+    python: {
+      addPythonFramework: [
+        "try: from imp import reload",
+        "except: pass",
+        "reload(__import__('sys')).path.append('./frameworks/python')"
+      ].join('\n'),
             // TODO: handle different test class names
-            requireCw2: "test = Test = reload(__import__('cw-2'))",
-            requireUnittest: "unittest = reload(__import__('unittest'))",
+      requireCw2: "test = Test = reload(__import__('cw-2'))",
+      requireUnittest: "unittest = reload(__import__('unittest'))",
             // bit of a hack, hard-coding the DESCRIBE/COMPLETEDIN here
             // however, Python doesn't seem to want to call start/endTestRun, so this will have to do for now
-            runUnittest: `
+      runUnittest: `
 print("<DESCRIBE::>Tests")
 unittest.TestLoader().loadTestsFromTestCase(Test).run(reload(__import__('unittestwrapper')).CwTestResult())
 print("<COMPLETEDIN:>")
 `
-        }
     }
+  }
 };
 
 module.exports.snippets.python3 = module.exports.snippets.python;

--- a/lib/copydir.js
+++ b/lib/copydir.js
@@ -4,232 +4,232 @@ var path = require('path');
 var mkdir = require('mkdir-p');
 
 function FileTools(from, to, filter) {
-    this.from = from;
-    this.to = to;
-    this.filter = filter || function(state, filepath, filename) { return true; };
-    return this;
+  this.from = from;
+  this.to = to;
+  this.filter = filter || function(state, filepath, filename) { return true; };
+  return this;
 }
 
 FileTools.prototype.find = function(callback) {
-    var that = this;
-    var filelist = {
-        dirs: [],
-        files: []
-    };
-    var getfiles = function(from, callback) {
-        fs.readdir(from, function(err, files) {
-            if (err) {
-                callback && callback(err);
-            } else {
-                var index = 0;
-                var filecount = files.length;
-                var loop = function() {
-                    var filename = files[index];
-                    var filepath = path.join(from, filename);
-                    fs.lstat(filepath, function(err, stats) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            if (stats.isDirectory()) {
-                                if (that.filter('directory', filepath, filename)) {
-                                    filelist.dirs.push(filepath);
-                                    getfiles(filepath, function(err) {
-                                        checker(err);
-                                    });
-                                } else {
-                                    checker();
-                                }
-                            } else if (stats.isFile()) {
-                                if (that.filter('file', filepath, filename)) {
-                                    filelist.files.push(filepath);
-                                }
-                                checker();
-                            } else {
-                                checker();
-                            }
-                        }
-                    });
-                };
-                var checker = function(err) {
-                    if (err) {
-                        callback(err);
-                    } else {
-                        index++;
-                        if (index === filecount) {
-                            callback(null, filelist);
-                        } else {
-                            loop();
-                        }
-                    }
-                };
-                if (filecount > 0) {
-                    loop();
-                } else {
-                    callback(null, filelist);
-                }
-            }
-        });
-    };
-    getfiles(this.from, callback);
-};
-
-FileTools.prototype.findSync = function() {
-    var that = this;
-    var filelist = {
-        dirs: [],
-        files: []
-    };
-    var getfiles = function(from) {
-        var files = fs.readdirSync(from);
+  var that = this;
+  var filelist = {
+    dirs: [],
+    files: []
+  };
+  var getfiles = function(from, callback) {
+    fs.readdir(from, function(err, files) {
+      if (err) {
+        callback && callback(err);
+      } else {
         var index = 0;
         var filecount = files.length;
         var loop = function() {
-            var filename = files[index];
-            var filepath = path.join(from, filename);
-            var stats = fs.lstatSync(filepath);
-            if (stats.isDirectory()) {
+          var filename = files[index];
+          var filepath = path.join(from, filename);
+          fs.lstat(filepath, function(err, stats) {
+            if (err) {
+              callback(err);
+            } else {
+              if (stats.isDirectory()) {
                 if (that.filter('directory', filepath, filename)) {
-                    filelist.dirs.push(filepath);
-                    getfiles(filepath);
+                  filelist.dirs.push(filepath);
+                  getfiles(filepath, function(err) {
+                    checker(err);
+                  });
+                } else {
+                  checker();
                 }
-            } else if (stats.isFile()) {
+              } else if (stats.isFile()) {
                 if (that.filter('file', filepath, filename)) {
-                    filelist.files.push(filepath);
+                  filelist.files.push(filepath);
                 }
+                checker();
+              } else {
+                checker();
+              }
             }
-            return checker();
+          });
         };
-        var checker = function() {
+        var checker = function(err) {
+          if (err) {
+            callback(err);
+          } else {
             index++;
             if (index === filecount) {
-                return filelist;
+              callback(null, filelist);
             } else {
-                return loop();
+              loop();
             }
+          }
         };
         if (filecount > 0) {
-            return loop();
+          loop();
         } else {
-            return filelist;
+          callback(null, filelist);
         }
+      }
+    });
+  };
+  getfiles(this.from, callback);
+};
+
+FileTools.prototype.findSync = function() {
+  var that = this;
+  var filelist = {
+    dirs: [],
+    files: []
+  };
+  var getfiles = function(from) {
+    var files = fs.readdirSync(from);
+    var index = 0;
+    var filecount = files.length;
+    var loop = function() {
+      var filename = files[index];
+      var filepath = path.join(from, filename);
+      var stats = fs.lstatSync(filepath);
+      if (stats.isDirectory()) {
+        if (that.filter('directory', filepath, filename)) {
+          filelist.dirs.push(filepath);
+          getfiles(filepath);
+        }
+      } else if (stats.isFile()) {
+        if (that.filter('file', filepath, filename)) {
+          filelist.files.push(filepath);
+        }
+      }
+      return checker();
     };
-    return getfiles(this.from);
+    var checker = function() {
+      index++;
+      if (index === filecount) {
+        return filelist;
+      } else {
+        return loop();
+      }
+    };
+    if (filecount > 0) {
+      return loop();
+    } else {
+      return filelist;
+    }
+  };
+  return getfiles(this.from);
 };
 
 FileTools.prototype.mkdir = function(list, callback) {
-    var index = 0;
-    var filecount = list.length;
-    var loop = function() {
-        mkdir(list[index], function(err) {
-            if (err) {
-                callback(err);
-            } else {
-                index++;
-                if (index === filecount) {
-                    callback(null);
-                } else {
-                    loop();
-                }
-            }
-        });
-    };
-    if (list.length > 0) {
-        loop();
-    } else {
-        callback(null);
-    }
+  var index = 0;
+  var filecount = list.length;
+  var loop = function() {
+    mkdir(list[index], function(err) {
+      if (err) {
+        callback(err);
+      } else {
+        index++;
+        if (index === filecount) {
+          callback(null);
+        } else {
+          loop();
+        }
+      }
+    });
+  };
+  if (list.length > 0) {
+    loop();
+  } else {
+    callback(null);
+  }
 };
 
 FileTools.prototype.mkdirSync = function(list) {
-    var index = 0;
-    var filecount = list.length;
-    var loop = function() {
-        mkdir.sync(list[index]);
-        index++;
-        if (index === filecount) {
-            return true;
-        } else {
-            return loop();
-        }
-    };
-    if (filecount > 0) {
-        return loop();
+  var index = 0;
+  var filecount = list.length;
+  var loop = function() {
+    mkdir.sync(list[index]);
+    index++;
+    if (index === filecount) {
+      return true;
     } else {
-        return true;
+      return loop();
     }
+  };
+  if (filecount > 0) {
+    return loop();
+  } else {
+    return true;
+  }
 };
 
 FileTools.prototype.copyfile = function(list, callback) {
-    var that = this;
-    var index = 0;
-    var filecount = list.length;
-    var loop = function() {
-        var filepath = list[index];
-        var rs = fs.createReadStream(filepath);
-        var ws = fs.createWriteStream(path.join(that.to, path.relative(that.from, filepath)));
-        rs.on('end', function() {
-            index++;
-            if (index === filecount) {
-                if (callback) callback(null);
-            } else {
-                loop();
-            }
-        });
-        rs.pipe(ws);
-    };
-    if (filecount > 0) {
+  var that = this;
+  var index = 0;
+  var filecount = list.length;
+  var loop = function() {
+    var filepath = list[index];
+    var rs = fs.createReadStream(filepath);
+    var ws = fs.createWriteStream(path.join(that.to, path.relative(that.from, filepath)));
+    rs.on('end', function() {
+      index++;
+      if (index === filecount) {
+        if (callback) callback(null);
+      } else {
         loop();
-    } else {
-        callback(null);
-    }
+      }
+    });
+    rs.pipe(ws);
+  };
+  if (filecount > 0) {
+    loop();
+  } else {
+    callback(null);
+  }
 };
 
 FileTools.prototype.copyfileSync = function(list) {
-    var that = this;
-    var index = 0;
-    var filecount = list.length;
-    var loop = function() {
-        var filepath = list[index];
-        var distpath = path.join(that.to, path.relative(that.from, filepath));
-        fs.writeFileSync(distpath, fs.readFileSync(filepath, 'binary'), 'binary');
-        index++;
-        if (index === filecount) {
-            return true;
-        } else {
-            return loop();
-        }
-    };
-    if (filecount > 0) {
-        return loop();
+  var that = this;
+  var index = 0;
+  var filecount = list.length;
+  var loop = function() {
+    var filepath = list[index];
+    var distpath = path.join(that.to, path.relative(that.from, filepath));
+    fs.writeFileSync(distpath, fs.readFileSync(filepath, 'binary'), 'binary');
+    index++;
+    if (index === filecount) {
+      return true;
     } else {
-        return true;
+      return loop();
     }
+  };
+  if (filecount > 0) {
+    return loop();
+  } else {
+    return true;
+  }
 };
 
 function copy(from, to, filter, callback) {
-    if (typeof filter === 'function' && !callback) {
-        callback = filter;
-        filter = null;
-    }
-    var tools = new FileTools(from, to, filter);
-    tools.find(function(err, list) {
-        var dirs = list.dirs.map(function(v) {
-            return path.join(tools.to, path.relative(tools.from, v));
-        }).concat([tools.to]);
-        tools.mkdir(dirs, function(err) {
-            tools.copyfile(list.files, callback);
-        });
+  if (typeof filter === 'function' && !callback) {
+    callback = filter;
+    filter = null;
+  }
+  var tools = new FileTools(from, to, filter);
+  tools.find(function(err, list) {
+    var dirs = list.dirs.map(function(v) {
+      return path.join(tools.to, path.relative(tools.from, v));
+    }).concat([tools.to]);
+    tools.mkdir(dirs, function(err) {
+      tools.copyfile(list.files, callback);
     });
+  });
 }
 
 copy.sync = function(from, to, filter) {
-    var tools = new FileTools(from, to, filter);
-    var list = tools.findSync();
-    var dirs = list.dirs.map(function(v) {
-        return path.join(tools.to, path.relative(tools.from, v));
-    });
-    tools.mkdirSync(dirs);
-    tools.copyfileSync(list.files);
+  var tools = new FileTools(from, to, filter);
+  var list = tools.findSync();
+  var dirs = list.dirs.map(function(v) {
+    return path.join(tools.to, path.relative(tools.from, v));
+  });
+  tools.mkdirSync(dirs);
+  tools.copyfileSync(list.files);
 };
 
 module.exports = copy;

--- a/lib/frontend-frameworks.js
+++ b/lib/frontend-frameworks.js
@@ -2,31 +2,31 @@
 // specific libraries
 // TODO: replace with a smarter way to download and use libraries on the fly
 var frameworks =  {
-	'angular@1.2': [
-		'/runner/frameworks/javascript/angular/1.2.9/angular.js',
-		'/runner/frameworks/javascript/angular/1.2.9/angular-{mocks,resource,route,sanitize}.js',
-	],
-	'angular@1.3': [
-		'/runner/frameworks/javascript/angular/1.3.9/angular.js',
-		'/runner/frameworks/javascript/angular/1.3.9/angular-{mocks,resource,route,sanitize}.js',
-	],
-	'angular@1.4': [
-		'/runner/frameworks/javascript/angular/1.4.9/angular.js',
-		'/runner/frameworks/javascript/angular/1.4.9/angular-{mocks,resource,route,sanitize}.js',
-	],
-	'angular@1.5': [
-		'/runner/frameworks/javascript/angular/1.5.8/angular.js',
-		'/runner/frameworks/javascript/angular/1.5.8/angular-{mocks,resource,route,sanitize}.js',
-	],
+  'angular@1.2': [
+    '/runner/frameworks/javascript/angular/1.2.9/angular.js',
+    '/runner/frameworks/javascript/angular/1.2.9/angular-{mocks,resource,route,sanitize}.js',
+  ],
+  'angular@1.3': [
+    '/runner/frameworks/javascript/angular/1.3.9/angular.js',
+    '/runner/frameworks/javascript/angular/1.3.9/angular-{mocks,resource,route,sanitize}.js',
+  ],
+  'angular@1.4': [
+    '/runner/frameworks/javascript/angular/1.4.9/angular.js',
+    '/runner/frameworks/javascript/angular/1.4.9/angular-{mocks,resource,route,sanitize}.js',
+  ],
+  'angular@1.5': [
+    '/runner/frameworks/javascript/angular/1.5.8/angular.js',
+    '/runner/frameworks/javascript/angular/1.5.8/angular-{mocks,resource,route,sanitize}.js',
+  ],
 };
 
 module.exports.find = function find(name) {
-	var result = [name];
-	if(frameworks[name]) {
-		result = frameworks[name];
-		if(!Array.isArray(result)) {
-			result = [result];
-		}
-	}
-	return result;
+  var result = [name];
+  if(frameworks[name]) {
+    result = frameworks[name];
+    if(!Array.isArray(result)) {
+      result = [result];
+    }
+  }
+  return result;
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,182 +1,182 @@
 const config = require('./config')
 
 module.exports.process = function(opts) {
-    opts = assignConfigJson(opts);
+  opts = assignConfigJson(opts);
 
     // set the default directory to run everything out of
-    opts.dir = opts.dir || '/home/codewarrior'
+  opts.dir = opts.dir || '/home/codewarrior'
 
-    assignProjectMode(opts);
+  assignProjectMode(opts);
 
-    assignEntryFile(opts);
+  assignEntryFile(opts);
 
-    assignPublishing(opts);
+  assignPublishing(opts);
 
-    assignBashFile(opts);
+  assignBashFile(opts);
 
-    assignConfigStatements(opts);
+  assignConfigStatements(opts);
 
-    assignStrategy(opts);
+  assignStrategy(opts);
 
     // in case anything needs to cleanup after itself
-    opts.onCompleted = [];
+  opts.onCompleted = [];
 
-    opts.services = opts.services || [];
+  opts.services = opts.services || [];
 
-    return opts;
+  return opts;
 }
 
 function assignBashFile(opts) {
-    if (!opts.bashFile && opts.files && opts.files['.runner/setup.sh']) {
-        opts.bashFile = '.runner/setup.sh'
-    }
+  if (!opts.bashFile && opts.files && opts.files['.runner/setup.sh']) {
+    opts.bashFile = '.runner/setup.sh'
+  }
 }
 
 // project mode is when multiple files have been provided and not a solution value, which indicates
 // that an entry file is to be specified and that the format is determined by the configuration.
 function assignProjectMode(opts) {
     // if empty files were passed in, make the value null to make it easier to check for emptyness
-    if (opts.files && Object.keys(opts.files).length === 0) {
-        opts.files = null;
-    }
+  if (opts.files && Object.keys(opts.files).length === 0) {
+    opts.files = null;
+  }
 
     // indicate if we should process the
-    if (!opts.solution && opts.files) {
-        opts.projectMode = true
-    }
+  if (!opts.solution && opts.files) {
+    opts.projectMode = true
+  }
 }
 
 // determines the file to be used as the entry file when project mode is enabled
 function assignEntryFile(opts) {
-    if (opts.projectMode) {
-        if (opts.entryFile) {
+  if (opts.projectMode) {
+    if (opts.entryFile) {
           // if there is an entry file lets see if we need to convert it from a wildcard
-            if (opts.entryFile.indexOf('*') >= 0) {
-                opts.entryFile = findWildcardFile(opts, opts.entryFile);
-            }
-        }
+      if (opts.entryFile.indexOf('*') >= 0) {
+        opts.entryFile = findWildcardFile(opts, opts.entryFile);
+      }
+    }
 
         // if no entry file was specified (or was not found using the wildcard above)
-        if (!opts.entryFile) {
+    if (!opts.entryFile) {
           // loop through some common entry points and try to find a match
-            for (var search of ['spec.*', 'test.*', 'fixture.*', 'entry.*']) {
-                opts.entryFile = findWildcardFile(opts, search);
-                if (opts.entryFile) break;
-            }
-        }
+      for (var search of ['spec.*', 'test.*', 'fixture.*', 'entry.*']) {
+        opts.entryFile = findWildcardFile(opts, search);
+        if (opts.entryFile) break;
+      }
+    }
 
-        if (opts.entryFile) {
-            opts.entryPath = `${opts.dir}/${opts.entryFile}`;
-        }
+    if (opts.entryFile) {
+      opts.entryPath = `${opts.dir}/${opts.entryFile}`;
+    }
 
         // setup file paths so its easier to include them
-        opts.filePaths = Object.keys(opts.files).map(name => `${opts.dir}/${name}`);
-        opts.filteredFilePaths = function(ext) {
-            var re = new RegExp(`\.${ext}$`);
-            return opts.filePaths.filter(p => !!p.match(re));
-        }
+    opts.filePaths = Object.keys(opts.files).map(name => `${opts.dir}/${name}`);
+    opts.filteredFilePaths = function(ext) {
+      var re = new RegExp(`\.${ext}$`);
+      return opts.filePaths.filter(p => !!p.match(re));
     }
+  }
 }
 
 function findWildcardFile(opts, search) {
-    for (var fileName in opts.files) {
-        if (wildcardMatch(fileName, search)) {
-          return fileName
-        }
+  for (var fileName in opts.files) {
+    if (wildcardMatch(fileName, search)) {
+      return fileName
     }
+  }
 }
 
 function wildcardMatch (str, search) {
-    if (!str) return str
-    return !!str.match(new RegExp(search.replace(/\./g, "\\.").replace(/\*/g, '.*')))
+  if (!str) return str
+  return !!str.match(new RegExp(search.replace(/\./g, "\\.").replace(/\*/g, '.*')))
 }
 
 // if a specific strategy is not provided then determine based off of the data passed in
 function assignStrategy(opts) {
-    if (!opts.strategy) {
+  if (!opts.strategy) {
         // if a fixture is provided or in project mode
-        if (opts.projectMode || opts.fixture) {
-            opts.strategy = 'testIntegration'
-        }
-        else {
-            opts.strategy = 'solutionOnly'
-        }
+    if (opts.projectMode || opts.fixture) {
+      opts.strategy = 'testIntegration'
     }
+    else {
+      opts.strategy = 'solutionOnly'
+    }
+  }
 }
 
 function assignConfigJson(opts) {
     // if a specific config file was uploaded, then use that as well
-    if (opts.files && opts.files['.runner/config.json']) {
+  if (opts.files && opts.files['.runner/config.json']) {
         // we want to use it as the defaults though, any specific options passed in will override the config file
-        return Object.assign(opts, JSON.parse(opts.files['.runner/config.json']));
-    }
+    return Object.assign(opts, JSON.parse(opts.files['.runner/config.json']));
+  }
 
-    return opts;
+  return opts;
 }
 
 function assignPublishing(opts) {
-    opts.publish = function(){}
+  opts.publish = function(){}
 
-    if (opts.ably && opts.channel) {
-        try {
-            var ably = new require('ably').Rest(opts.ably);
-            var channel = ably.channels.get(opts.channel);
-            opts.publish = function(event, data) {
-            if (event && data) {
-                channel.publish(event, data);
-            }
-            }
+  if (opts.ably && opts.channel) {
+    try {
+      var ably = new require('ably').Rest(opts.ably);
+      var channel = ably.channels.get(opts.channel);
+      opts.publish = function(event, data) {
+        if (event && data) {
+          channel.publish(event, data);
         }
-        catch(e) {}
+      }
     }
+    catch(e) {}
+  }
 }
 
 // we allow configuration to be applied via the setup code block. This is useful for requests in non-project mode.
 // project mode configuration would normally be done instead via adding a .runner/config.json file.
 function assignConfigStatements(opts) {
-    let match;
+  let match;
 
-    if (opts.setup) {
+  if (opts.setup) {
         // bashFile will override any default config settings for a script to run
-        match = opts.setup.match(/^[ #|\/]* ?@config: bash-file (.*$)/m);
-        if (match) opts.bashFile = match[1];
+    match = opts.setup.match(/^[ #|\/]* ?@config: bash-file (.*$)/m);
+    if (match) opts.bashFile = match[1];
 
         // bash will override any default config settings for a script to run
-        match = opts.setup.match(/^[ #|\/]* ?@config: bash (.*$)/m);
-        if (match) opts.bash = match[1];
+    match = opts.setup.match(/^[ #|\/]* ?@config: bash (.*$)/m);
+    if (match) opts.bash = match[1];
 
         // githubRepo
-        match = opts.setup.match(/^[ #|\/]* ?@config: github-repo (.*$)/m);
-        if (match) opts.githubRepo = match[1];
+    match = opts.setup.match(/^[ #|\/]* ?@config: github-repo (.*$)/m);
+    if (match) opts.githubRepo = match[1];
 
         // gist
-        match = opts.setup.match(/^[ #|\/]* ?@config: gist (.*$)/m);
-        if (match) opts.gist = match[1];
+    match = opts.setup.match(/^[ #|\/]* ?@config: gist (.*$)/m);
+    if (match) opts.gist = match[1];
 
         // solutionPath - indcates to some languages what the solution file should be called
-        match = opts.setup.match(/^[ #|\/]* ?@config: solution-path (.*$)/m);
-        if (match) opts.solutionPath = match[1];
+    match = opts.setup.match(/^[ #|\/]* ?@config: solution-path (.*$)/m);
+    if (match) opts.solutionPath = match[1];
 
         // services - indcates which services should be enabled. commas seperated (ie: mongodb,redis)
-        match = opts.setup.match(/^[ #|\/]* ?@config: services (.*$)/m);
-        if (match) opts.services = match[1].split(',');
+    match = opts.setup.match(/^[ #|\/]* ?@config: services (.*$)/m);
+    if (match) opts.services = match[1].split(',');
 
-        match = opts.setup.match(/@(?:config: )?include-external\s+\S+/g);
-        if(match) {
-            opts.externalIncludes = opts.externalIncludes || []
-            match.forEach(match => {
-                let name = match.replace(/@(?:config: )?include-external\s+/, '');
-                opts.externalIncludes.push(name);
-            });
-        }
-
-        match = opts.setup.match(/@(?:config: )?reference\s+\S+/g);
-        if(match) {
-            opts.references = opts.references || []
-            match.forEach(match => {
-                let name = match.replace(/@(?:config: )?reference\s+/, '');
-                opts.references.push(name);
-            });
-        }
+    match = opts.setup.match(/@(?:config: )?include-external\s+\S+/g);
+    if(match) {
+      opts.externalIncludes = opts.externalIncludes || []
+      match.forEach(match => {
+        let name = match.replace(/@(?:config: )?include-external\s+/, '');
+        opts.externalIncludes.push(name);
+      });
     }
+
+    match = opts.setup.match(/@(?:config: )?reference\s+\S+/g);
+    if(match) {
+      opts.references = opts.references || []
+      match.forEach(match => {
+        let name = match.replace(/@(?:config: )?reference\s+/, '');
+        opts.references.push(name);
+      });
+    }
+  }
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,6 +1,6 @@
 // runs the code, supports both callback and Promise formats
 module.exports.run = function (opts, cb) {
     // opts.code is an alias for opts.solution
-    if (opts.code) opts.solution = opts.code;
-    return require("./runners/" + opts.language).run(opts, cb);
+  if (opts.code) opts.solution = opts.code;
+  return require("./runners/" + opts.language).run(opts, cb);
 };

--- a/lib/runners/arm.js
+++ b/lib/runners/arm.js
@@ -1,29 +1,29 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    path = require('path'),
-    temp = require('temp');
+  util = require('../util'),
+  path = require('path'),
+  temp = require('temp');
 
 module.exports.run = function run(opts, cb) {
-    temp.track();
-    var dir = temp.mkdirSync('arm');
+  temp.track();
+  var dir = temp.mkdirSync('arm');
 
-    shovel.start(opts, cb, {
-        solutionOnly: function (run) {
-            var executable = path.join(dir, 'solution'),
-                solutionFile = util.codeWriteSync('arm', opts.solution + '\n', dir, 'solution.s'),
-                objectFile = solutionFile.replace(/\.[^\.]+$/, '.o'),
-                armCommand = ['arm-linux-gnueabi-as', solutionFile, '-o', objectFile].join(' '),
+  shovel.start(opts, cb, {
+    solutionOnly: function (run) {
+      var executable = path.join(dir, 'solution'),
+        solutionFile = util.codeWriteSync('arm', opts.solution + '\n', dir, 'solution.s'),
+        objectFile = solutionFile.replace(/\.[^\.]+$/, '.o'),
+        armCommand = ['arm-linux-gnueabi-as', solutionFile, '-o', objectFile].join(' '),
                 // Check for whether we need to link against libc
-                linker = opts.solution.search(/\.glob[a]?l\W+_start/) == -1 ? "arm-linux-gnueabi-gcc-4.7" : "arm-linux-gnueabi-ld",
-                linkerCommand = [linker, objectFile, '-o', executable].join(' ');
-            util.exec(armCommand, function () {
-                util.exec(linkerCommand, function () {
-                    run({'name': 'qemu-arm', 'args': ['-L', '/usr/arm-linux-gnueabi/', executable]});
-                });
-            });
-        },
-        testIntegration: function (run) {
-            throw new Error('Test framework is not supported');
-        }
-    });
+        linker = opts.solution.search(/\.glob[a]?l\W+_start/) == -1 ? "arm-linux-gnueabi-gcc-4.7" : "arm-linux-gnueabi-ld",
+        linkerCommand = [linker, objectFile, '-o', executable].join(' ');
+      util.exec(armCommand, function () {
+        util.exec(linkerCommand, function () {
+          run({'name': 'qemu-arm', 'args': ['-L', '/usr/arm-linux-gnueabi/', executable]});
+        });
+      });
+    },
+    testIntegration: function (run) {
+      throw new Error('Test framework is not supported');
+    }
+  });
 };

--- a/lib/runners/c.js
+++ b/lib/runners/c.js
@@ -1,50 +1,50 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    exec = require('child_process').exec,
-    path = require('path');
+  util = require('../util'),
+  exec = require('child_process').exec,
+  path = require('path');
 
 module.exports.run = function run(opts, cb) {
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode, fail) {
-            var executable = path.join(opts.dir, 'solution'),
-                solutionFile = util.codeWriteSync('c', opts.solution, opts.dir, 'solution.c'),
-                args = ['clang-3.6', '-std=c11', solutionFile, '-o', executable, '-lm'];
-            if (opts.setup) {
-                var setupFile = util.codeWriteSync('c', opts.setup, opts.dir, 'setup.c');
-                args.push(setupFile);
-            }
-            exec(args.join(' '), function (error, stdout, stderr) {
-                if (error) return fail(error, stdout, stderr);
-                opts.publish('stdout', stdout);
-                runCode({'name': executable, 'args': []});
-            });
-        },
-        testIntegration: function (runCode, fail) {
-            var executable = path.join(opts.dir, 'solution'),
-                solutionFile = util.codeWriteSync('c', opts.solution, opts.dir, 'solution.c'),
-                fixtureFile = util.codeWriteSync('c', opts.fixture, opts.dir, 'fixture.c'),
-                args = ['clang-3.6', '-std=c11', fixtureFile, solutionFile, '-o', executable, './frameworks/c/criterion.c', '-I./frameworks/c', '-lcriterion', '-lm'];
-            if (opts.setup) {
-                var setupFile = util.codeWriteSync('c', opts.setup, opts.dir, 'setup.c');
-                args.push(setupFile);
-            }
-            exec(args.join(' '), function (error, stdout, stderr) {
-                if (error) return fail(error, stdout, stderr);
-                opts.publish('stdout', stdout);
-                runCode({'name': executable, 'args': ['-q','-j1']});
-            });
-        },
-        sanitizeStdErr: function(error)
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode, fail) {
+      var executable = path.join(opts.dir, 'solution'),
+        solutionFile = util.codeWriteSync('c', opts.solution, opts.dir, 'solution.c'),
+        args = ['clang-3.6', '-std=c11', solutionFile, '-o', executable, '-lm'];
+      if (opts.setup) {
+        var setupFile = util.codeWriteSync('c', opts.setup, opts.dir, 'setup.c');
+        args.push(setupFile);
+      }
+      exec(args.join(' '), function (error, stdout, stderr) {
+        if (error) return fail(error, stdout, stderr);
+        opts.publish('stdout', stdout);
+        runCode({'name': executable, 'args': []});
+      });
+    },
+    testIntegration: function (runCode, fail) {
+      var executable = path.join(opts.dir, 'solution'),
+        solutionFile = util.codeWriteSync('c', opts.solution, opts.dir, 'solution.c'),
+        fixtureFile = util.codeWriteSync('c', opts.fixture, opts.dir, 'fixture.c'),
+        args = ['clang-3.6', '-std=c11', fixtureFile, solutionFile, '-o', executable, './frameworks/c/criterion.c', '-I./frameworks/c', '-lcriterion', '-lm'];
+      if (opts.setup) {
+        var setupFile = util.codeWriteSync('c', opts.setup, opts.dir, 'setup.c');
+        args.push(setupFile);
+      }
+      exec(args.join(' '), function (error, stdout, stderr) {
+        if (error) return fail(error, stdout, stderr);
+        opts.publish('stdout', stdout);
+        runCode({'name': executable, 'args': ['-q','-j1']});
+      });
+    },
+    sanitizeStdErr: function(error)
         {
-            error = error || ''
-            return error.replace(/clang.*-std=c[^\s]+/g, '')
+      error = error || ''
+      return error.replace(/clang.*-std=c[^\s]+/g, '')
                         .replace(/Error: Command failed:/g, '')
                         .replace(/\/tmp.*(solution\.c|solution)[:0-9]*/g, '')
                         .replace('\n', '')
                         .replace('  ', ' ')
                         .replace(opts.setup || '', '')
                         .replace(opts.fixture || '', '');
-        }
-    });
+    }
+  });
 };
 

--- a/lib/runners/clojure.js
+++ b/lib/runners/clojure.js
@@ -1,30 +1,30 @@
 var shovel = require('../shovel'),
-    path = require('path');
+  path = require('path');
 
 module.exports.run = function run(opts, cb) {
-    var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.3-standalone.jar');
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            runCode({
-                name: 'java',
-                args: ['-jar', uberJar],
-                stdin: JSON.stringify(opts)
-            });
-        },
-        testIntegration: function (runCode) {
-            return runCode({
-                name: 'java',
-                args: ['-jar', uberJar],
-                stdin: JSON.stringify(opts)
-            });
-        },
+  var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.3-standalone.jar');
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      runCode({
+        name: 'java',
+        args: ['-jar', uberJar],
+        stdin: JSON.stringify(opts)
+      });
+    },
+    testIntegration: function (runCode) {
+      return runCode({
+        name: 'java',
+        args: ['-jar', uberJar],
+        stdin: JSON.stringify(opts)
+      });
+    },
         // HACK: don't know clojure well enough to fix issue within actual runner, but it is escaping line breaks when it shouldn't
-        sanitizeStdOut: function(stdout) {
-            return stdout
+    sanitizeStdOut: function(stdout) {
+      return stdout
                 .replace(/\<:LF:\>\<PASSED::\>/g, '\n<PASSED::>')
                 .replace(/\<:LF:\>\<FAILED::\>/g, '\n<FAILED::>')
                 .replace(/\<:LF:\>\<ERROR::\>/g, '\n<ERROR::>')
 
-        }
-    });
+    }
+  });
 };

--- a/lib/runners/coffeescript.js
+++ b/lib/runners/coffeescript.js
@@ -1,37 +1,37 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    config = require('../config');
+  util = require('../util'),
+  config = require('../config');
 
 module.exports.run = function run(opts, cb) {
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            var code = `
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      var code = `
                 ${opts.setup || ''}
                 ${opts.solution}
             `
 
-            if (opts.setup) {
-                code = opts.setup + ';\n' + code;
-            }
+      if (opts.setup) {
+        code = opts.setup + ';\n' + code;
+      }
 
-            runCode({name: 'coffee', 'args': ['-e', code]});
-        },
-        testIntegration: function (runCode) {
-            switch (opts.testFramework) {
-                case 'cw':
-                case 'cw-2':
-                    return prepareCw2(opts, runCode);
+      runCode({name: 'coffee', 'args': ['-e', code]});
+    },
+    testIntegration: function (runCode) {
+      switch (opts.testFramework) {
+      case 'cw':
+      case 'cw-2':
+        return prepareCw2(opts, runCode);
 
-                default:
-                    throw 'Test framework is not supported'
-            }
-        }
-    });
+      default:
+        throw 'Test framework is not supported'
+      }
+    }
+  });
 };
 
 function prepareCw2(opts, run) {
 
-    var code = `
+  var code = `
         require('./frameworks/javascript/cw-2')
         assert = require('assert')
         Test.handleError ->
@@ -48,11 +48,11 @@ function prepareCw2(opts, run) {
                 ${indentLines(opts.fixture, 17)}
     `;
 
-    run({name: 'coffee', 'args': ['-e', code]});
+  run({name: 'coffee', 'args': ['-e', code]});
 }
 
 function indentLines(lines, spaces) {
-    if (!lines) return '';
-    var padding = new Array(spaces).join(' ');
-    return lines.split("\n").map((line, ndx) => `${ndx == 0 ? '' : padding}${line}`).join("\n");
+  if (!lines) return '';
+  var padding = new Array(spaces).join(' ');
+  return lines.split("\n").map((line, ndx) => `${ndx == 0 ? '' : padding}${line}`).join("\n");
 }

--- a/lib/runners/cpp.js
+++ b/lib/runners/cpp.js
@@ -1,65 +1,65 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    path = require('path'),
-    temp = require('temp'),
-    exec = require('child_process').exec,
-    fs = require('fs'),
-    cppDir = path.resolve(__dirname, '..', '..', 'frameworks', 'cpp'),
-    main = fs.readFileSync(path.resolve(cppDir, 'main.cpp'));
+  util = require('../util'),
+  path = require('path'),
+  temp = require('temp'),
+  exec = require('child_process').exec,
+  fs = require('fs'),
+  cppDir = path.resolve(__dirname, '..', '..', 'frameworks', 'cpp'),
+  main = fs.readFileSync(path.resolve(cppDir, 'main.cpp'));
 
 function compile(args, cb) {
-    args.unshift('clang++-3.6', '-stdlib=libc++ -std=c++1y');
-    exec(args.join(' '), cb);
+  args.unshift('clang++-3.6', '-stdlib=libc++ -std=c++1y');
+  exec(args.join(' '), cb);
 }
 
 module.exports.run = function run(opts, cb) {
-    temp.track();
-    var dir = temp.mkdirSync('cpp');
+  temp.track();
+  var dir = temp.mkdirSync('cpp');
 
-    var args = [];
-    if(opts.setup) {
-        var setupFile = util.codeWriteSync('cpp', opts.setup, dir, 'setup.h');
-        args.push(setupFile);
-        opts.solution = '#include "setup.h"\n' + opts.solution;
-    }
+  var args = [];
+  if(opts.setup) {
+    var setupFile = util.codeWriteSync('cpp', opts.setup, dir, 'setup.h');
+    args.push(setupFile);
+    opts.solution = '#include "setup.h"\n' + opts.solution;
+  }
 
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode, fail) {
-            var executable = path.join(dir, 'solution'),
-                solutionFile = util.codeWriteSync('cpp', opts.solution, dir, 'solution.cpp');
-            args = [solutionFile, '-o', executable];
-            compile(args, function (error, stdout, stderr) {
-                if (error) return fail(error, stdout, stderr);
-                opts.publish('stdout', stdout);
-                runCode({'name': executable, 'args': []});
-            });
-        },
-        testIntegration: function (runCode, fail) {
-            var executable = path.join(dir, 'solution'),
-                solutionFile = util.codeWriteSync('cpp', [
-                    '#include <igloo/igloo_alt.h>',
-                    'using namespace igloo;',
-                    opts.solution,
-                    opts.fixture,
-                    main
-                ].join('\n'), dir, 'solution.cpp');
-            args = ['-isystem', cppDir, solutionFile, '-o', executable];
-            compile(args, function (error, stdout, stderr) {
-                if (error) return fail(error, stdout, stderr);
-                opts.publish('stdout', stdout);
-                runCode({'name': executable, 'args': []});
-            });
-        },
-        sanitizeStdErr: function(error)
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode, fail) {
+      var executable = path.join(dir, 'solution'),
+        solutionFile = util.codeWriteSync('cpp', opts.solution, dir, 'solution.cpp');
+      args = [solutionFile, '-o', executable];
+      compile(args, function (error, stdout, stderr) {
+        if (error) return fail(error, stdout, stderr);
+        opts.publish('stdout', stdout);
+        runCode({'name': executable, 'args': []});
+      });
+    },
+    testIntegration: function (runCode, fail) {
+      var executable = path.join(dir, 'solution'),
+        solutionFile = util.codeWriteSync('cpp', [
+          '#include <igloo/igloo_alt.h>',
+          'using namespace igloo;',
+          opts.solution,
+          opts.fixture,
+          main
+        ].join('\n'), dir, 'solution.cpp');
+      args = ['-isystem', cppDir, solutionFile, '-o', executable];
+      compile(args, function (error, stdout, stderr) {
+        if (error) return fail(error, stdout, stderr);
+        opts.publish('stdout', stdout);
+        runCode({'name': executable, 'args': []});
+      });
+    },
+    sanitizeStdErr: function(error)
         {
-            error = error || ''
-            return error.replace(/clang.*-std=c[^\s]+/g, '')
+      error = error || ''
+      return error.replace(/clang.*-std=c[^\s]+/g, '')
                         .replace(/Error: Command failed:/g, '')
                         .replace(/\/tmp.*(solution\.cpp|solution)[:0-9]*/g, '')
                         .replace('\n', '')
                         .replace('  ', ' ')
                         .replace(opts.setup || '', '')
                         .replace(opts.fixture || '', '');
-        }
-    });
+    }
+  });
 };

--- a/lib/runners/crystal.js
+++ b/lib/runners/crystal.js
@@ -1,48 +1,48 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    config = require('../config'),
-    temp = require('temp'),
-    child_process = require('child_process'),
-    Convert = require('ansi-to-html'),
-    convert = new Convert();
+  util = require('../util'),
+  config = require('../config'),
+  temp = require('temp'),
+  child_process = require('child_process'),
+  Convert = require('ansi-to-html'),
+  convert = new Convert();
 
 module.exports.run = function run(opts, cb) {
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            runCode({name: 'crystal', args: ['eval', opts.solution]})
-        },
-        testIntegration: function (runCode) {
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      runCode({name: 'crystal', args: ['eval', opts.solution]})
+    },
+    testIntegration: function (runCode) {
             // instead of using a tmp directory we use the special crystal directory so that we can
             // use the installed shards without having to copy
-            var dir = '/home/codewarrior/crystal';
+      var dir = '/home/codewarrior/crystal';
 
-            var solution = util.codeWriteSync('crystal', opts.solution, dir, 'solution.cr', true),
-                setup = util.codeWriteSync('crystal', opts.setup || '# no setup provided', dir, 'setup.cr', true),
-                fixture = util.codeWriteSync('crystal', opts.fixture, dir, 'fixture.cr', true),
-                spec = `require "./formatter"`;
+      var solution = util.codeWriteSync('crystal', opts.solution, dir, 'solution.cr', true),
+        setup = util.codeWriteSync('crystal', opts.setup || '# no setup provided', dir, 'setup.cr', true),
+        fixture = util.codeWriteSync('crystal', opts.fixture, dir, 'fixture.cr', true),
+        spec = `require "./formatter"`;
 
-            if (opts.setup) spec += `\nrequire "./setup"`;
-            spec += `\nrequire "./solution"`;
-            spec += `\nrequire "./fixture"`;
+      if (opts.setup) spec += `\nrequire "./setup"`;
+      spec += `\nrequire "./solution"`;
+      spec += `\nrequire "./fixture"`;
 
-            spec = util.codeWriteSync('crystal', spec, dir, 'spec.cr', true);
-            runCode({name: 'crystal', args: ['spec', 'spec.cr'], options: {cwd: dir}});
-        },
-        transformBuffer: function(buffer) {
-            buffer.stdout = convert.toHtml(buffer.stdout);
+      spec = util.codeWriteSync('crystal', spec, dir, 'spec.cr', true);
+      runCode({name: 'crystal', args: ['spec', 'spec.cr'], options: {cwd: dir}});
+    },
+    transformBuffer: function(buffer) {
+      buffer.stdout = convert.toHtml(buffer.stdout);
 
-            var finished = buffer.stdout.search(/(?! )\d* examples?/);
-            if (finished > 0) {
-                var orig = buffer.stdout;
-                buffer.stdout = orig.substr(0, finished).replace("Failures:\n", "Failure Summary:\n");
-            }
+      var finished = buffer.stdout.search(/(?! )\d* examples?/);
+      if (finished > 0) {
+        var orig = buffer.stdout;
+        buffer.stdout = orig.substr(0, finished).replace("Failures:\n", "Failure Summary:\n");
+      }
 
             // crystal likes to write its compile errors to stdout, so lets swap them around
-            if (buffer.stdout.indexOf('Error in ') === 0) {
-                buffer.stderr = buffer.stdout;
-                buffer.stdout = '';
-            }
-        },
-        outputType: 'raw'
-    });
+      if (buffer.stdout.indexOf('Error in ') === 0) {
+        buffer.stderr = buffer.stdout;
+        buffer.stdout = '';
+      }
+    },
+    outputType: 'raw'
+  });
 }

--- a/lib/runners/csharp.js
+++ b/lib/runners/csharp.js
@@ -1,96 +1,96 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    path = require('path'),
-    nunitAssemblies = ['nunit.core.dll', 'nunit.framework.dll', 'nunit.core.interfaces.dll', 'nunit.util', 'Newtonsoft.Json.dll'].join(','),
-    nunitPath = '/runner/frameworks/csharp/nunit/bin'
+  util = require('../util'),
+  path = require('path'),
+  nunitAssemblies = ['nunit.core.dll', 'nunit.framework.dll', 'nunit.core.interfaces.dll', 'nunit.util', 'Newtonsoft.Json.dll'].join(','),
+  nunitPath = '/runner/frameworks/csharp/nunit/bin'
 
 module.exports.run = function run(opts, cb) {
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode, fail) {
-            var codeFile = util.codeWriteSync('csharp', opts.solution, opts.dir, 'code.cs'),
-                exe = path.join(opts.dir, 'solution.exe'),
-                args = ['mcs', '-out:' + exe, codeFile];
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode, fail) {
+      var codeFile = util.codeWriteSync('csharp', opts.solution, opts.dir, 'code.cs'),
+        exe = path.join(opts.dir, 'solution.exe'),
+        args = ['mcs', '-out:' + exe, codeFile];
 
-            if (opts.setup) {
-                args.push(util.codeWriteSync('csharp', opts.setup, opts.dir, 'setup.cs'));
-            }
+      if (opts.setup) {
+        args.push(util.codeWriteSync('csharp', opts.setup, opts.dir, 'setup.cs'));
+      }
 
-            compile(args, function (error, stdout, stderr) {
-                if (error) return fail(error, stdout, stderr);
-                runCode({name: 'mono', args: [exe]});
-            });
-        },
-        testIntegration: function (runCode, fail) {
+      compile(args, function (error, stdout, stderr) {
+        if (error) return fail(error, stdout, stderr);
+        runCode({name: 'mono', args: [exe]});
+      });
+    },
+    testIntegration: function (runCode, fail) {
             // copydir('/runner/frameworks/nunit', opts.dir);
 
-            var dll = path.join(opts.dir, 'test.dll'),
-                args = [
-                    'mcs',
-                    '-out:' + dll,
-                    `-lib:${opts.dir},/runner/frameworks/csharp/mono-4.5,${nunitPath}`,
-                    '-langversion:Default',
-                    '-sdk:4.5',
-                    '-warn:2',
-                    '-target:library',
-                    '-r:' + nunitAssemblies,
-                    '-r:System.Numerics.dll',
-                    '-r:System.Drawing.dll',
-                    '-r:System.Data.dll',
-                    '-r:System.Data.SQLite.dll',
-                    '-r:System.Data.SQLite.Linq.dll',
-                    '-r:System.IO.dll',
-                    '-r:System.Linq.dll',
-                    '-r:System.Linq.Dynamic.dll',
-                    '-r:System.Linq.Expressions.dll',
-                    '-r:System.Messaging.dll',
-                    '-r:System.Threading.Tasks.dll',
-                    '-r:System.Xml.dll',
-                    '-r:Mono.Linq.Expressions.dll',
-                ];
+      var dll = path.join(opts.dir, 'test.dll'),
+        args = [
+          'mcs',
+          '-out:' + dll,
+          `-lib:${opts.dir},/runner/frameworks/csharp/mono-4.5,${nunitPath}`,
+          '-langversion:Default',
+          '-sdk:4.5',
+          '-warn:2',
+          '-target:library',
+          '-r:' + nunitAssemblies,
+          '-r:System.Numerics.dll',
+          '-r:System.Drawing.dll',
+          '-r:System.Data.dll',
+          '-r:System.Data.SQLite.dll',
+          '-r:System.Data.SQLite.Linq.dll',
+          '-r:System.IO.dll',
+          '-r:System.Linq.dll',
+          '-r:System.Linq.Dynamic.dll',
+          '-r:System.Linq.Expressions.dll',
+          '-r:System.Messaging.dll',
+          '-r:System.Threading.Tasks.dll',
+          '-r:System.Xml.dll',
+          '-r:Mono.Linq.Expressions.dll',
+        ];
 
-            if (opts.services.includes("mongodb")) {
-                args.push('-r:MongoDB.Bson.dll');
-                args.push('-r:MongoDB.Driver.Core.dll');
-                args.push('-r:MongoDB.Driver.dll');
-                args.push('-r:MongoDB.Dynamic.dll');
-            }
+      if (opts.services.includes("mongodb")) {
+        args.push('-r:MongoDB.Bson.dll');
+        args.push('-r:MongoDB.Driver.Core.dll');
+        args.push('-r:MongoDB.Driver.dll');
+        args.push('-r:MongoDB.Dynamic.dll');
+      }
 
-            if (opts.services.includes("redis")) {
-                args.push('-r:StackExchange.Redis.dll');
-            }
+      if (opts.services.includes("redis")) {
+        args.push('-r:StackExchange.Redis.dll');
+      }
 
-            if (opts.services.includes("postgres")) {
-                args.push('-r:Npgsql.dll');
-            }
+      if (opts.services.includes("postgres")) {
+        args.push('-r:Npgsql.dll');
+      }
 
             // include any references that have been included
-            if (opts.references) {
-                opts.references.forEach(ref => {
-                    let name = `-r:${ref}`;
-                    if (args.indexOf(name) === -1) {
-                        args.push(name);
-                    }
-                });
-            }
+      if (opts.references) {
+        opts.references.forEach(ref => {
+          let name = `-r:${ref}`;
+          if (args.indexOf(name) === -1) {
+            args.push(name);
+          }
+        });
+      }
 
-            if (opts.files) {
-                args = args.concat(opts.filteredFilePaths('cs'))
-            }
-            if (opts.solution) {
-                args.push(util.codeWriteSync('csharp', opts.solution, opts.dir, 'code.cs'));
-            }
-            if (opts.fixture) {
-                args.push(util.codeWriteSync('csharp', opts.fixture, opts.dir, 'fixture.cs'));
-            }
-            if (opts.setup) {
-                args.push(util.codeWriteSync('csharp', opts.setup, opts.dir, 'setup.cs'));
-            }
+      if (opts.files) {
+        args = args.concat(opts.filteredFilePaths('cs'))
+      }
+      if (opts.solution) {
+        args.push(util.codeWriteSync('csharp', opts.solution, opts.dir, 'code.cs'));
+      }
+      if (opts.fixture) {
+        args.push(util.codeWriteSync('csharp', opts.fixture, opts.dir, 'fixture.cs'));
+      }
+      if (opts.setup) {
+        args.push(util.codeWriteSync('csharp', opts.setup, opts.dir, 'setup.cs'));
+      }
 
             // compile
-            compile(args, function (error, stdout, stderr) {
-                if (error) return fail(error, stdout, stderr);
+      compile(args, function (error, stdout, stderr) {
+        if (error) return fail(error, stdout, stderr);
 
-                const exe = path.join(opts.dir, 'runner.exe')
+        const exe = path.join(opts.dir, 'runner.exe')
 
                 // compile([
                 //     'mcs',
@@ -124,23 +124,23 @@ module.exports.run = function run(opts, cb) {
                 //         options: {env: process.env}
                 //     });
                 // })
-                runCode({
-                    name: "mono",
-                    args: [
-                        path.join(nunitPath, 'nunit-console.exe'),
-                        '-nologo',
-                        '-noresult',
-                        dll
-                    ],
-                    options: {env: process.env}
-                });
-            });
-        }
-    });
-
-    function compile(args, cb) {
-        opts.publish('status', 'Compiling...');
-        util.exec(args.join(' '), {stdout: 'ignore', handleError: true}, cb);
+        runCode({
+          name: "mono",
+          args: [
+            path.join(nunitPath, 'nunit-console.exe'),
+            '-nologo',
+            '-noresult',
+            dll
+          ],
+          options: {env: process.env}
+        });
+      });
     }
+  });
+
+  function compile(args, cb) {
+    opts.publish('status', 'Compiling...');
+    util.exec(args.join(' '), {stdout: 'ignore', handleError: true}, cb);
+  }
 };
 

--- a/lib/runners/elixir.js
+++ b/lib/runners/elixir.js
@@ -1,41 +1,41 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    temp = require('temp');
+  util = require('../util'),
+  temp = require('temp');
 
 module.exports.run = function run(opts, cb) {
-    shovel.start(opts, cb, {
-        solutionOnly: function(runCode) {
-            runCode({
-                name: 'elixir',
-                args: ['-e', solution(opts)]
-            });
-        },
-        testIntegration: function(runCode) {
-            switch (opts.testFramework) {
-                case 'ex_unit':
-                case 'exunit':
-                    return prepareExUnit(opts, runCode);
+  shovel.start(opts, cb, {
+    solutionOnly: function(runCode) {
+      runCode({
+        name: 'elixir',
+        args: ['-e', solution(opts)]
+      });
+    },
+    testIntegration: function(runCode) {
+      switch (opts.testFramework) {
+      case 'ex_unit':
+      case 'exunit':
+        return prepareExUnit(opts, runCode);
 
-                default:
-                    throw 'Test framework is not supported'
-            }
-        },
-    });
+      default:
+        throw 'Test framework is not supported'
+      }
+    },
+  });
 };
 
 function prepareExUnit(opts, run) {
-    var dir = temp.mkdirSync('elixir');
-    var solutionFile = util.codeWriteSync('elixir', solution(opts), dir, 'solution', true);
-    var fixtureFile = util.codeWriteSync('elixir', opts.fixture, dir, 'fixture', true);
+  var dir = temp.mkdirSync('elixir');
+  var solutionFile = util.codeWriteSync('elixir', solution(opts), dir, 'solution', true);
+  var fixtureFile = util.codeWriteSync('elixir', opts.fixture, dir, 'fixture', true);
 
-    var code = `
+  var code = `
         Code.load_file("frameworks/elixir/cw_runner.ex")
         CWRunner.run("${solutionFile}", "${fixtureFile}")
     `
 
-    run({name: 'elixir', 'args': ['-e', code]});
+  run({name: 'elixir', 'args': ['-e', code]});
 }
 
 function solution(opts) {
-    return opts.setup ? `${opts.setup}\n${opts.solution}` : opts.solution;
+  return opts.setup ? `${opts.setup}\n${opts.solution}` : opts.solution;
 }

--- a/lib/runners/erlang.js
+++ b/lib/runners/erlang.js
@@ -1,66 +1,66 @@
 var shovel = require('../shovel'),
-    config = require('../config'),
-    codeWriteSync = require('../util').codeWriteSync,
-    fs = require('fs'),
-    path = require('path'),
-    temp = require('temp');
+  config = require('../config'),
+  codeWriteSync = require('../util').codeWriteSync,
+  fs = require('fs'),
+  path = require('path'),
+  temp = require('temp');
 
 function moduleName(fileName) {
-    return path.basename(fileName).replace(/\.[^/.]+$/, "");
+  return path.basename(fileName).replace(/\.[^/.]+$/, "");
 }
 
 function erlangCompileCommand(fileName, erlangCodeDir) {
-    return [
-        'compile:file("',
-        fileName,
-        '", {outdir,"', erlangCodeDir ,'"}),'
-    ].join('');
+  return [
+    'compile:file("',
+    fileName,
+    '", {outdir,"', erlangCodeDir ,'"}),'
+  ].join('');
 }
 
 function compileFileSync(code,erlangCodeDir) {
-    return erlangCompileCommand( codeWriteSync('erlang', code, erlangCodeDir), erlangCodeDir);
+  return erlangCompileCommand( codeWriteSync('erlang', code, erlangCodeDir), erlangCodeDir);
 }
 
 module.exports.run = function(opts, cb) {
-    temp.track();
-    var erlangCodeDir = temp.mkdirSync('erlang');
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            var setup = opts.setup ? compileFileSync(opts.setup, erlangCodeDir) : '';
-            runCode({
-                name: 'erl',
-                args: ['-pz', erlangCodeDir, '-noshell', '-eval', [setup, opts.solution].join('')],
-                options: { env: {
-                    HOME: process.env['HOME'],
-                    ERL_CRASH_DUMP: "/dev/null"
-                }}
-            });
-        },
-        testIntegration: function (runCode) {
-            var setup = opts.setup ? compileFileSync(opts.setup, erlangCodeDir) : '',
-                solutionFileName = codeWriteSync('erlang', opts.solution, erlangCodeDir),
-                solutionModuleName = moduleName(solutionFileName),
-                testFixture = compileFileSync([
-                    '-module(' + solutionModuleName + '_tests).',
-                    '-compile(export_all).',
-                    '-include_lib("eunit/include/eunit.hrl").',
-                    opts.fixture
-                ].join('\n'), erlangCodeDir);
+  temp.track();
+  var erlangCodeDir = temp.mkdirSync('erlang');
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      var setup = opts.setup ? compileFileSync(opts.setup, erlangCodeDir) : '';
+      runCode({
+        name: 'erl',
+        args: ['-pz', erlangCodeDir, '-noshell', '-eval', [setup, opts.solution].join('')],
+        options: { env: {
+          HOME: process.env['HOME'],
+          ERL_CRASH_DUMP: "/dev/null"
+        }}
+      });
+    },
+    testIntegration: function (runCode) {
+      var setup = opts.setup ? compileFileSync(opts.setup, erlangCodeDir) : '',
+        solutionFileName = codeWriteSync('erlang', opts.solution, erlangCodeDir),
+        solutionModuleName = moduleName(solutionFileName),
+        testFixture = compileFileSync([
+          '-module(' + solutionModuleName + '_tests).',
+          '-compile(export_all).',
+          '-include_lib("eunit/include/eunit.hrl").',
+          opts.fixture
+        ].join('\n'), erlangCodeDir);
 
-            runCode({
-                name: 'erl',
-                args: ['-pz', erlangCodeDir, '-noshell', '-eval',
-                    [
-                        setup,
-                        erlangCompileCommand(solutionFileName, erlangCodeDir),
-                        testFixture,
-                        'eunit:test(', solutionModuleName, '), init:stop().'
-                    ].join('')],
-                options: { env: {
-                    HOME: process.env['HOME'],
-                    ERL_CRASH_DUMP: "/dev/null"
-                }}
-            });
-        }
-    });
+      runCode({
+        name: 'erl',
+        args: ['-pz', erlangCodeDir, '-noshell', '-eval',
+          [
+            setup,
+            erlangCompileCommand(solutionFileName, erlangCodeDir),
+            testFixture,
+            'eunit:test(', solutionModuleName, '), init:stop().'
+          ].join('')],
+        options: { env: {
+          HOME: process.env['HOME'],
+          ERL_CRASH_DUMP: "/dev/null"
+        }}
+      });
+    }
+  });
 };

--- a/lib/runners/fsharp.js
+++ b/lib/runners/fsharp.js
@@ -1,40 +1,40 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    config = require('../config'),
-    temp = require('temp'),
-    path = require("path"),
-    fsharpFrameworksPath = path.resolve(__dirname, '..', '..', 'frameworks', 'fsharp'),
-    fuchuPath = path.resolve(fsharpFrameworksPath, 'Fuchu', 'lib', 'Fuchu'),
+  util = require('../util'),
+  config = require('../config'),
+  temp = require('temp'),
+  path = require("path"),
+  fsharpFrameworksPath = path.resolve(__dirname, '..', '..', 'frameworks', 'fsharp'),
+  fuchuPath = path.resolve(fsharpFrameworksPath, 'Fuchu', 'lib', 'Fuchu'),
 
     // Fuchu references exception classes from these libs
-    nunitAssemblies = ['NUnit.Core.dll', 'NUnit.Core.Interfaces.dll', 'NUnit.Util.dll', 'NUnit.Framework.dll', 'Newtonsoft.Json.dll', 'EntityFramework.dll', 'Qualified.dll'],
-    nunitPath = path.resolve(fsharpFrameworksPath, 'nunit'),
-    gallioPath = path.resolve(fsharpFrameworksPath, 'Gallio', 'lib', 'NET40'),
-    gallioAssembly = path.resolve(gallioPath, 'Gallio.dll'),
-    xUnitPath = path.resolve(fsharpFrameworksPath, 'xunit', 'lib', 'net20');
-    xUnitAssembly = path.resolve(xUnitPath, 'Xunit.dll');
+  nunitAssemblies = ['NUnit.Core.dll', 'NUnit.Core.Interfaces.dll', 'NUnit.Util.dll', 'NUnit.Framework.dll', 'Newtonsoft.Json.dll', 'EntityFramework.dll', 'Qualified.dll'],
+  nunitPath = path.resolve(fsharpFrameworksPath, 'nunit'),
+  gallioPath = path.resolve(fsharpFrameworksPath, 'Gallio', 'lib', 'NET40'),
+  gallioAssembly = path.resolve(gallioPath, 'Gallio.dll'),
+  xUnitPath = path.resolve(fsharpFrameworksPath, 'xunit', 'lib', 'net20');
+xUnitAssembly = path.resolve(xUnitPath, 'Xunit.dll');
 
 
 module.exports.run = function(opts, cb)
 {
-    temp.track();
-    var dir = temp.mkdirSync('fsharp');
+  temp.track();
+  var dir = temp.mkdirSync('fsharp');
 
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode)
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode)
         {
-            var fileContents;
-            if (opts.setup) {
-                fileContents = opts.setup + "\n" + opts.solution;
-            } else {
-                fileContents = opts.solution;
-            }
-            var file = util.codeWriteSync('fsharp', fileContents, dir, 'solution.fsx');
-            runCode({name: 'fsharpi', 'args': [file]});
-        },
-        testIntegration: function (runCode)
+      var fileContents;
+      if (opts.setup) {
+        fileContents = opts.setup + "\n" + opts.solution;
+      } else {
+        fileContents = opts.solution;
+      }
+      var file = util.codeWriteSync('fsharp', fileContents, dir, 'solution.fsx');
+      runCode({name: 'fsharpi', 'args': [file]});
+    },
+    testIntegration: function (runCode)
         {
-            var runFixtureUsingFuchu = 
+      var runFixtureUsingFuchu = 
 `let printCompletedIn (timeSpan: System.TimeSpan) = printfn "<COMPLETEDIN::>%f" timeSpan.TotalMilliseconds in
 let codeWarsTestPrinter: Fuchu.Impl.TestPrinters = {
     BeforeRun = (fun name -> printfn "<IT::>%s" name)
@@ -55,30 +55,30 @@ let codeWarsTestPrinter: Fuchu.Impl.TestPrinters = {
 
 let _ =
     Fuchu.Impl.eval codeWarsTestPrinter Seq.map Tests.suite;;`
-            var stdin = [
-                opts.setup ? opts.setup : "",
-                opts.solution,
-                opts.fixture,
-                runFixtureUsingFuchu
-            ].join("\n");
-            var args = [
-                '--quiet',
-                '--reference:' + fuchuPath,
-                '--lib:' + gallioPath,
-                '--reference:' + gallioAssembly,
-                '--lib:' + xUnitPath,
-                '--reference:' + xUnitAssembly,
-                '--lib:' + nunitPath
-            ].concat(
+      var stdin = [
+        opts.setup ? opts.setup : "",
+        opts.solution,
+        opts.fixture,
+        runFixtureUsingFuchu
+      ].join("\n");
+      var args = [
+        '--quiet',
+        '--reference:' + fuchuPath,
+        '--lib:' + gallioPath,
+        '--reference:' + gallioAssembly,
+        '--lib:' + xUnitPath,
+        '--reference:' + xUnitAssembly,
+        '--lib:' + nunitPath
+      ].concat(
                 nunitAssemblies.map(function(dll){ return "--reference:" + path.resolve(nunitPath,  dll); })
             );
-            runCode({
-                name: 'fsharpi',
-                args: args,                
-                stdin: stdin
-            });
-        }
-    });
+      runCode({
+        name: 'fsharpi',
+        args: args,                
+        stdin: stdin
+      });
+    }
+  });
 };
 
 

--- a/lib/runners/gas.js
+++ b/lib/runners/gas.js
@@ -1,29 +1,29 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    path = require('path'),
-    temp = require('temp');
+  util = require('../util'),
+  path = require('path'),
+  temp = require('temp');
 
 module.exports.run = function(opts, cb) {
-    temp.track();
-    var dir = temp.mkdirSync('gas');
+  temp.track();
+  var dir = temp.mkdirSync('gas');
 
-    shovel.start(opts, cb, {
-        solutionOnly: function(run) {
-            var executable = path.join(dir, 'solution'),
-                solutionFile = util.codeWriteSync('gas', opts.solution + '\n', dir, 'solution.s'),
-                objectFile = solutionFile.replace(/\.[^\.]+$/, '.o'),
-                gasCommand = ['gcc', '-c', solutionFile, '-o', objectFile].join(' '),
+  shovel.start(opts, cb, {
+    solutionOnly: function(run) {
+      var executable = path.join(dir, 'solution'),
+        solutionFile = util.codeWriteSync('gas', opts.solution + '\n', dir, 'solution.s'),
+        objectFile = solutionFile.replace(/\.[^\.]+$/, '.o'),
+        gasCommand = ['gcc', '-c', solutionFile, '-o', objectFile].join(' '),
                 // Check for whether we need to link against libc
-                linker = opts.solution.search(/\.global\W+_start/) == -1 ? "gcc" : "ld";
-                linkerCommand = [linker, objectFile, '-o', executable].join(' ');
-            util.exec(gasCommand, function () {
-                util.exec(linkerCommand, function () {
-                    run({'name': executable, 'args': []});
-                });
-            });
-        },
-        testIntegration: function (run) {
-            throw new Error('Test framework is not supported');
-        }
-    });
+        linker = opts.solution.search(/\.global\W+_start/) == -1 ? "gcc" : "ld";
+      linkerCommand = [linker, objectFile, '-o', executable].join(' ');
+      util.exec(gasCommand, function () {
+        util.exec(linkerCommand, function () {
+          run({'name': executable, 'args': []});
+        });
+      });
+    },
+    testIntegration: function (run) {
+      throw new Error('Test framework is not supported');
+    }
+  });
 };

--- a/lib/runners/groovy.js
+++ b/lib/runners/groovy.js
@@ -1,22 +1,22 @@
 var shovel = require('../shovel'),
-    path = require('path');
+  path = require('path');
 
 module.exports.run = function run(opts, cb) {
-    var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.3-standalone.jar');
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            runCode({
-                name: 'java',
-                args: ['-jar', uberJar],
-                stdin: JSON.stringify(opts)
-            });
-        },
-        testIntegration: function (runCode) {
-            runCode({
-                name: 'java',
-                args: ['-jar', uberJar],
-                stdin: JSON.stringify(opts)
-            });
-        }
-    });
+  var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.3-standalone.jar');
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      runCode({
+        name: 'java',
+        args: ['-jar', uberJar],
+        stdin: JSON.stringify(opts)
+      });
+    },
+    testIntegration: function (runCode) {
+      runCode({
+        name: 'java',
+        args: ['-jar', uberJar],
+        stdin: JSON.stringify(opts)
+      });
+    }
+  });
 };

--- a/lib/runners/haskell.js
+++ b/lib/runners/haskell.js
@@ -1,36 +1,36 @@
 var shovel = require('../shovel'),
-    config = require('../config'),
-    codeWriteSync = require('../util').codeWriteSync,
-    fs = require('fs'),
-    temp = require('temp');
+  config = require('../config'),
+  codeWriteSync = require('../util').codeWriteSync,
+  fs = require('fs'),
+  temp = require('temp');
 
 module.exports.run = function run(opts, cb) {
-    temp.track();
-    var haskellCodeDir = temp.mkdirSync('haskell');
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            if (opts.setup) codeWriteSync('haskell', opts.setup, haskellCodeDir);
-            runCode({
-                name: 'runhaskell',
-                args: [
-                    '-i' + ['frameworks/haskell', haskellCodeDir].join(':'),
-                    codeWriteSync('haskell', opts.solution, haskellCodeDir, "Main.hs")
-                ]
-            });
-        },
-        testIntegration: function (runCode) {
-            if (opts.setup) codeWriteSync('haskell', opts.setup, haskellCodeDir);
-            var solutionFileName = codeWriteSync('haskell', opts.solution, haskellCodeDir, "Main.hs"),
-                fixtureFileName = solutionFileName.split('/').pop() == "Main.hs" ?
+  temp.track();
+  var haskellCodeDir = temp.mkdirSync('haskell');
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      if (opts.setup) codeWriteSync('haskell', opts.setup, haskellCodeDir);
+      runCode({
+        name: 'runhaskell',
+        args: [
+          '-i' + ['frameworks/haskell', haskellCodeDir].join(':'),
+          codeWriteSync('haskell', opts.solution, haskellCodeDir, "Main.hs")
+        ]
+      });
+    },
+    testIntegration: function (runCode) {
+      if (opts.setup) codeWriteSync('haskell', opts.setup, haskellCodeDir);
+      var solutionFileName = codeWriteSync('haskell', opts.solution, haskellCodeDir, "Main.hs"),
+        fixtureFileName = solutionFileName.split('/').pop() == "Main.hs" ?
                     codeWriteSync('haskell', opts.fixture, haskellCodeDir) :
                     codeWriteSync('haskell', opts.fixture, haskellCodeDir, "Main.hs");
-            process.env["solutionFileName"] = solutionFileName;
+      process.env["solutionFileName"] = solutionFileName;
 
-            runCode({
-                name: 'runhaskell',
-                args: ['-i' + ['frameworks/haskell', haskellCodeDir].join(':'), fixtureFileName],
-                options: { env: process.env }
-            });
-        }
-    });
+      runCode({
+        name: 'runhaskell',
+        args: ['-i' + ['frameworks/haskell', haskellCodeDir].join(':'), fixtureFileName],
+        options: { env: process.env }
+      });
+    }
+  });
 };

--- a/lib/runners/java.js
+++ b/lib/runners/java.js
@@ -1,22 +1,22 @@
 var shovel = require('../shovel'),
-    path = require('path');
+  path = require('path');
 
 module.exports.run = function run(opts, cb) {
-    var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.3-standalone.jar');
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            runCode({
-                name: 'java',
-                args: ['-jar', uberJar],
-                stdin: JSON.stringify(opts)
-            });
-        },
-        testIntegration: function (runCode) {
-            runCode({
-                name: 'java',
-                args: ['-jar', uberJar],
-                stdin: JSON.stringify(opts)
-            });
-        }
-    });
+  var uberJar = path.resolve(__dirname, '../../jvm-runner/target/jvm-runner-0.1.3-standalone.jar');
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      runCode({
+        name: 'java',
+        args: ['-jar', uberJar],
+        stdin: JSON.stringify(opts)
+      });
+    },
+    testIntegration: function (runCode) {
+      runCode({
+        name: 'java',
+        args: ['-jar', uberJar],
+        stdin: JSON.stringify(opts)
+      });
+    }
+  });
 };

--- a/lib/runners/javascript.js
+++ b/lib/runners/javascript.js
@@ -3,7 +3,7 @@ var shovel = require('../shovel'),
     config = require('../config'),
     temp = require('temp'),
     exec = require('child_process').exec,
-	frontendFrameworks = require('../frontend-frameworks');
+    frontendFrameworks = require('../frontend-frameworks');
 
 
 module.exports.run = function run(opts, cb)
@@ -99,10 +99,10 @@ function runMocha(opts, interfaceType, runCode, file) {
 }
 
 function prepareKarma(opts, interfaceType, runCode, fail) {
-	var dir = opts.dir;
+    var dir = opts.dir;
 
     // files to load into Karma
-	var files = [];
+    var files = [];
 
     // handle includes
     if (opts.externalIncludes) {
@@ -118,7 +118,7 @@ function prepareKarma(opts, interfaceType, runCode, fail) {
             var code = transform(opts[type] || '', '0.10.x', type + '.js');
             files.push(util.codeWriteSync('javascript', code, dir, type + '.js', true));
         }
-	});
+    });
 
     // include any additional files
     if (opts.files) {
@@ -136,15 +136,15 @@ function prepareKarma(opts, interfaceType, runCode, fail) {
     }
 
     var config = {
-	      files: files,
+        files: files,
         singleRun: true,
-	      autoWatch: false,
-	      retryLimit: 0,
+        autoWatch: false,
+        retryLimit: 0,
         frameworks: ['mocha', 'chai'],
-	      browsers: ['PhantomJS'],
+        browsers: ['PhantomJS'],
         plugins: ['karma-*', '/runner/frameworks/javascript/karma-coderunner-reporter.js'],
         reporters: ['coderunner'],
-	      logLevel: 'warn',
+        logLevel: 'warn',
         client: {
             mocha: {
               timeout: opts.timeout || 8000,

--- a/lib/runners/javascript.js
+++ b/lib/runners/javascript.js
@@ -1,81 +1,81 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    config = require('../config'),
-    temp = require('temp'),
-    exec = require('child_process').exec,
-    frontendFrameworks = require('../frontend-frameworks');
+  util = require('../util'),
+  config = require('../config'),
+  temp = require('temp'),
+  exec = require('child_process').exec,
+  frontendFrameworks = require('../frontend-frameworks');
 
 
 module.exports.run = function run(opts, cb)
 {
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode, fail)
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode, fail)
         {
-            var code = opts.solution;
+      var code = opts.solution;
 
-            if (opts.setup)
-                code = opts.setup + ';\n' + code;
+      if (opts.setup)
+        code = opts.setup + ';\n' + code;
 
-            execNode(opts, code, runCode, fail);
-        },
-        testIntegration: function (runCode, fail)
+      execNode(opts, code, runCode, fail);
+    },
+    testIntegration: function (runCode, fail)
         {
-            switch (opts.testFramework)
+      switch (opts.testFramework)
             {
-                case 'cw': // for backwards compatibility, all legacy CW challenges have been updated to use cw-2
-                case 'cw-2':
-                    return prepareCw2(opts, runCode, fail);
+      case 'cw': // for backwards compatibility, all legacy CW challenges have been updated to use cw-2
+      case 'cw-2':
+        return prepareCw2(opts, runCode, fail);
 
-                case 'mocha':
-                case 'mocha_bdd':
-                    return prepareMocha(opts, 'bdd', runCode, fail);
+      case 'mocha':
+      case 'mocha_bdd':
+        return prepareMocha(opts, 'bdd', runCode, fail);
 
-                case 'mocha_tdd':
-                    return prepareMocha(opts, 'tdd', runCode, fail);
+      case 'mocha_tdd':
+        return prepareMocha(opts, 'tdd', runCode, fail);
 
-                case 'karma':
-                case 'karma_bdd':
-                    return prepareKarma(opts, 'bdd', runCode, fail);
+      case 'karma':
+      case 'karma_bdd':
+        return prepareKarma(opts, 'bdd', runCode, fail);
 
-                case 'karma_tdd':
-                    return prepareKarma(opts, 'tdd', runCode, fail);
+      case 'karma_tdd':
+        return prepareKarma(opts, 'tdd', runCode, fail);
 
-                default:
-                    throw 'Test framework is not supported'
-            }
-        },
-        sanitizeStdErr: function(error)
+      default:
+        throw 'Test framework is not supported'
+      }
+    },
+    sanitizeStdErr: function(error)
         {
-            error = error || ''
-            return error.replace(/(\()?\/codewars\/[(\w\/-\d.js:) ;]*/g, '')
+      error = error || ''
+      return error.replace(/(\()?\/codewars\/[(\w\/-\d.js:) ;]*/g, '')
                         .replace(/( Object. )?[\(]?\[eval\][-:\w\d\)]* at/g, '')
                         .replace(/Module._compile.*/g, '')
                         .replace('Object.Test.handleError ', '')
                         .replace('  ', ' ')
                         .replace(opts.setup || '', '')
                         .replace(opts.fixture || '', '');
-        },
-        sanitizeStdOut: function(stdout)
+    },
+    sanitizeStdOut: function(stdout)
         {
-            return this.sanitizeStdErr(stdout);
-        },
-        files: function() {
+      return this.sanitizeStdErr(stdout);
+    },
+    files: function() {
             // a files object/hash can be passed in as options, which will be transformed (if applicable) and then stored
             // in the provided directory.
             // write files that may have been included to the file system, within the directory that the code executes in
-            util.writeFilesSync(opts.dir, opts.files, true, function(name, content) {
-                return /\.js$/.test(name) ? maybeTransform(content, opts) : content;
-            });
-        }
-    });
+      util.writeFilesSync(opts.dir, opts.files, true, function(name, content) {
+        return /\.js$/.test(name) ? maybeTransform(content, opts) : content;
+      });
+    }
+  });
 };
 
 function prepareMocha(opts, interfaceType, runCode) {
-    if (!opts.solution && opts.files) {
-        runMocha(opts, interfaceType, runCode, opts.entryPath)
-    }
-    else {
-      var code = `
+  if (!opts.solution && opts.files) {
+    runMocha(opts, interfaceType, runCode, opts.entryPath)
+  }
+  else {
+    var code = `
         ${opts.setup};
         ${opts.solution};
         (function() {
@@ -85,75 +85,75 @@ function prepareMocha(opts, interfaceType, runCode) {
 
       // run tests inline to the context but within their own scope. Redefine the key test methods in case they were
       // locally redefined within the solution.
-      var solutionFile = util.codeWriteSync('javascript', maybeTransform(code, opts), opts.dir, 'mocha', true);
-      runMocha(opts, interfaceType, runCode, solutionFile)
-    }
+    var solutionFile = util.codeWriteSync('javascript', maybeTransform(code, opts), opts.dir, 'mocha', true);
+    runMocha(opts, interfaceType, runCode, solutionFile)
+  }
 }
 
 function runMocha(opts, interfaceType, runCode, file) {
     // NOTE: Mocha based testing currently does not support Node versioning
-    runCode({
-        name: 'mocha',
-        args: ['-t', opts.timeout || 8000, '-u', interfaceType, '-R', 'mocha-reporter', file]
-    });
+  runCode({
+    name: 'mocha',
+    args: ['-t', opts.timeout || 8000, '-u', interfaceType, '-R', 'mocha-reporter', file]
+  });
 }
 
 function prepareKarma(opts, interfaceType, runCode, fail) {
-    var dir = opts.dir;
+  var dir = opts.dir;
 
     // files to load into Karma
-    var files = [];
+  var files = [];
 
     // handle includes
-    if (opts.externalIncludes) {
-        opts.externalIncludes.forEach(name => {
-            files.push(...frontendFrameworks.find(name))
-        });
-    }
+  if (opts.externalIncludes) {
+    opts.externalIncludes.forEach(name => {
+      files.push(...frontendFrameworks.find(name))
+    });
+  }
 
     // handle core code (if there is any)
-    ['setup', 'solution', 'fixture'].forEach(function(type) {
-        if(opts[type] && opts[type].length) {
+  ['setup', 'solution', 'fixture'].forEach(function(type) {
+    if(opts[type] && opts[type].length) {
             // always transform this code, it ends up in the browser:
-            var code = transform(opts[type] || '', '0.10.x', type + '.js');
-            files.push(util.codeWriteSync('javascript', code, dir, type + '.js', true));
-        }
-    });
+      var code = transform(opts[type] || '', '0.10.x', type + '.js');
+      files.push(util.codeWriteSync('javascript', code, dir, type + '.js', true));
+    }
+  });
 
     // include any additional files
-    if (opts.files) {
-        Object.keys(opts.files).forEach(file => {
+  if (opts.files) {
+    Object.keys(opts.files).forEach(file => {
             // make sure to include the entry file last
-            if (file !== opts.entryFile && file.match(/\.(js|css|html)$/)) {
-                files.push(`${opts.dir}/${file}`);
-            }
-        });
-    }
+      if (file !== opts.entryFile && file.match(/\.(js|css|html)$/)) {
+        files.push(`${opts.dir}/${file}`);
+      }
+    });
+  }
 
     // now include the entry file
-    if (opts.entryPath) {
-        files.push(opts.entryPath);
-    }
+  if (opts.entryPath) {
+    files.push(opts.entryPath);
+  }
 
-    var config = {
-        files: files,
-        singleRun: true,
-        autoWatch: false,
-        retryLimit: 0,
-        frameworks: ['mocha', 'chai'],
-        browsers: ['PhantomJS'],
-        plugins: ['karma-*', '/runner/frameworks/javascript/karma-coderunner-reporter.js'],
-        reporters: ['coderunner'],
-        logLevel: 'warn',
-        client: {
-            mocha: {
-              timeout: opts.timeout || 8000,
-              ui: interfaceType,
-            },
-        },
-    };
+  var config = {
+    files: files,
+    singleRun: true,
+    autoWatch: false,
+    retryLimit: 0,
+    frameworks: ['mocha', 'chai'],
+    browsers: ['PhantomJS'],
+    plugins: ['karma-*', '/runner/frameworks/javascript/karma-coderunner-reporter.js'],
+    reporters: ['coderunner'],
+    logLevel: 'warn',
+    client: {
+      mocha: {
+        timeout: opts.timeout || 8000,
+        ui: interfaceType,
+      },
+    },
+  };
 
-    var code = `
+  var code = `
         var KarmaServer = require('karma').Server;
         var karma = new KarmaServer(${ JSON.stringify(config, null, 4) }, function(code) {
             process.exit(code);
@@ -161,25 +161,25 @@ function prepareKarma(opts, interfaceType, runCode, fail) {
         karma.start();
     `;
 
-    execNode(opts, code, runCode, fail);
+  execNode(opts, code, runCode, fail);
 }
 
 function prepareCw2(opts, runCode, fail)
 {
-    var code;
+  var code;
 
-    if (opts.projectMode) {
-        code = `
+  if (opts.projectMode) {
+    code = `
             require('/runner/frameworks/javascript/cw-2');
             require('${opts.entryPath}');
         `
-    }
-    else {
+  }
+  else {
         // generate random identifier to avoid name collision
-        const GLOBAL = `GLOBAL_${Math.random().toString(36).substr(2,8)}`;
+    const GLOBAL = `GLOBAL_${Math.random().toString(36).substr(2,8)}`;
         // run tests inline to the context but within their own scope. Redefine the key test methods in case they were
         // locally redefined within the solution.
-        code = `
+    code = `
             require('/runner/frameworks/javascript/cw-2');
             var assert = require('assert');
             Test.handleError(function(){
@@ -193,126 +193,126 @@ function prepareCw2(opts, runCode, fail)
                 })();
             });
         `;
-    }
+  }
 
-    execNode(opts, code, runCode, fail);
+  execNode(opts, code, runCode, fail);
 }
 
 function execNode(opts, code, runCode, fail) {
-    try {
-        var version = versionInfo(opts);
-        code = maybeTransform(code, opts);
+  try {
+    var version = versionInfo(opts);
+    code = maybeTransform(code, opts);
 
-        var args = ['-e', code, '--no-deprecation'];
+    var args = ['-e', code, '--no-deprecation'];
         // if (version.name == '6.x') {
         //     args.push('--trace-warnings');
         // }
 
-        (opts.requires || []).forEach(function (f) {
-            args.push("--require");
-            args.push(f);
-        });
-        runCode({
-            name: `/usr/local/n/versions/node/${version.node}/bin/node`,
-            args: args,
-            options: {
-              cwd: opts.dir
-            }
-        });
-    }
-    catch(ex) {
-        fail(ex);
-    }
+    (opts.requires || []).forEach(function (f) {
+      args.push("--require");
+      args.push(f);
+    });
+    runCode({
+      name: `/usr/local/n/versions/node/${version.node}/bin/node`,
+      args: args,
+      options: {
+        cwd: opts.dir
+      }
+    });
+  }
+  catch(ex) {
+    fail(ex);
+  }
 }
 
 function nodeVersion(version) {
-    switch(version) {
-        case "6.x":
-            return "6.6.0";
-        case "0.10.x":
-            return "0.10.33"
-        default:
-            return version;
-    }
+  switch(version) {
+  case "6.x":
+    return "6.6.0";
+  case "0.10.x":
+    return "0.10.33"
+  default:
+    return version;
+  }
 }
 
 // returns information about the version passed in, such as its node version and if babel is enabled
 function versionInfo(opts) {
-    var info = {
-        name: (opts.languageVersion || '6.x').split('/')[0],
-        babel: opts.languageVersion && opts.languageVersion.split('/')[1] == 'babel'
-    }
+  var info = {
+    name: (opts.languageVersion || '6.x').split('/')[0],
+    babel: opts.languageVersion && opts.languageVersion.split('/')[1] == 'babel'
+  }
 
-    info.node = nodeVersion(info.name);
-    return info;
+  info.node = nodeVersion(info.name);
+  return info;
 }
 
 // will babel transform the code if babel is configured, otherwise will just return the code unaltered.
 function maybeTransform(code, opts, filename) {
-    var version = versionInfo(opts);
+  var version = versionInfo(opts);
 
-    if (version.babel) {
-        return transform(code, version.name, filename);
-    }
-    else {
-        return code;
-    }
+  if (version.babel) {
+    return transform(code, version.name, filename);
+  }
+  else {
+    return code;
+  }
 }
 
 function transform(code, version, filename) {
-    try {
-        switch (version) {
-            case '0.10.x':
-                return require('babel-core').transform(code, {
-                    presets: ["stage-1", "react"],
-                    plugins: [
-                        "check-es2015-constants",
-                        "angular2-annotations",
-                        "transform-decorators-legacy",
-                        "transform-class-properties",
-                        "transform-flow-strip-types",
-                        "transform-es2015-arrow-functions",
-                        "transform-es2015-block-scoped-functions",
-                        "transform-es2015-block-scoping",
-                        "transform-es2015-classes",
-                        "transform-es2015-computed-properties",
-                        "transform-es2015-destructuring",
-                        "transform-es2015-duplicate-keys",
-                        "transform-es2015-for-of",
-                        "transform-es2015-function-name",
-                        "transform-es2015-literals",
-                        "transform-es2015-object-super",
-                        "transform-es2015-parameters",
-                        "transform-es2015-shorthand-properties",
-                        "transform-es2015-spread",
-                        "transform-es2015-sticky-regex",
-                        "transform-es2015-template-literals",
-                        "transform-es2015-typeof-symbol",
-                        "transform-es2015-unicode-regex",
-                        "transform-regenerator",
-                    ],
-                    ast: false,
-                    filename: filename || 'kata.js'
-                }).code;
+  try {
+    switch (version) {
+    case '0.10.x':
+      return require('babel-core').transform(code, {
+        presets: ["stage-1", "react"],
+        plugins: [
+          "check-es2015-constants",
+          "angular2-annotations",
+          "transform-decorators-legacy",
+          "transform-class-properties",
+          "transform-flow-strip-types",
+          "transform-es2015-arrow-functions",
+          "transform-es2015-block-scoped-functions",
+          "transform-es2015-block-scoping",
+          "transform-es2015-classes",
+          "transform-es2015-computed-properties",
+          "transform-es2015-destructuring",
+          "transform-es2015-duplicate-keys",
+          "transform-es2015-for-of",
+          "transform-es2015-function-name",
+          "transform-es2015-literals",
+          "transform-es2015-object-super",
+          "transform-es2015-parameters",
+          "transform-es2015-shorthand-properties",
+          "transform-es2015-spread",
+          "transform-es2015-sticky-regex",
+          "transform-es2015-template-literals",
+          "transform-es2015-typeof-symbol",
+          "transform-es2015-unicode-regex",
+          "transform-regenerator",
+        ],
+        ast: false,
+        filename: filename || 'kata.js'
+      }).code;
 
-            default:
-                return require('babel-core').transform(code, {
-                    presets: ["stage-1", "node5", "react"],
-                    plugins: [
-                        "angular2-annotations",
-                        "transform-decorators-legacy",
-                        "transform-class-properties",
-                        "transform-flow-strip-types",
-                    ],
-                    ast: false,
-                    filename: filename || 'kata.js'
-                }).code;
+    default:
+      return require('babel-core').transform(code, {
+        presets: ["stage-1", "node5", "react"],
+        plugins: [
+          "angular2-annotations",
+          "transform-decorators-legacy",
+          "transform-class-properties",
+          "transform-flow-strip-types",
+        ],
+        ast: false,
+        filename: filename || 'kata.js'
+      }).code;
 
 
-        }
     }
-    catch(ex) {
-        var msg = ex.message;
+  }
+  catch(ex) {
+    var msg = ex.message;
         // if (ex.loc) {
         //     // replace the line number since it is not what the user sees
         //     msg = msg.replace(/ \(\d*:\d*\)/, ":" + ex.loc.column)
@@ -324,6 +324,6 @@ function transform(code, version, filename) {
         //     }
         //     msg += '^';
         // }
-        throw new shovel.CompileError(msg);
-    }
+    throw new shovel.CompileError(msg);
+  }
 }

--- a/lib/runners/julia.js
+++ b/lib/runners/julia.js
@@ -1,39 +1,39 @@
 'use strict'
 
 var shovel = require('../shovel'),
-    config = require('../config'),
-    codeWriteSync = require('../util').codeWriteSync,
-    fs = require('fs'),
-    temp = require('temp');
+  config = require('../config'),
+  codeWriteSync = require('../util').codeWriteSync,
+  fs = require('fs'),
+  temp = require('temp');
 
 module.exports.run = function run(opts, cb) {
-    temp.track();
-    var juliaCodeDir = temp.mkdirSync('julia');
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            if (opts.setup) codeWriteSync('julia', opts.setup, juliaCodeDir);
-            runCode({
-                name: 'julia',
-                args: ['-P', ['push!(LOAD_PATH, "', juliaCodeDir, '", "frameworks/julia")'].join(""),
-                    '-e', opts.solution]
-            });
-        },
-        testIntegration: function (runCode) {
-            codeWriteSync('julia', opts.code, juliaCodeDir, 'solution.jl', true);
+  temp.track();
+  var juliaCodeDir = temp.mkdirSync('julia');
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      if (opts.setup) codeWriteSync('julia', opts.setup, juliaCodeDir);
+      runCode({
+        name: 'julia',
+        args: ['-P', ['push!(LOAD_PATH, "', juliaCodeDir, '", "frameworks/julia")'].join(""),
+          '-e', opts.solution]
+      });
+    },
+    testIntegration: function (runCode) {
+      codeWriteSync('julia', opts.code, juliaCodeDir, 'solution.jl', true);
 
-            if (opts.setup) codeWriteSync('julia', opts.setup, juliaCodeDir);
+      if (opts.setup) codeWriteSync('julia', opts.setup, juliaCodeDir);
 
-            let runCmd = `
+      let runCmd = `
               include("frameworks/julia/Test.jl")
               include("${juliaCodeDir}/solution.jl")
               using Test
               ${opts.fixture}
             `
 
-            runCode({
-                name: 'julia',
-                args: ['-ie', runCmd]
-            });
-        }
-    });
+      runCode({
+        name: 'julia',
+        args: ['-ie', runCmd]
+      });
+    }
+  });
 };

--- a/lib/runners/kotlin.js
+++ b/lib/runners/kotlin.js
@@ -1,7 +1,7 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    path = require('path'),
-    temp = require('temp');
+  util = require('../util'),
+  path = require('path'),
+  temp = require('temp');
 
 var KOTLIN_BASE_DIR = '/usr/local/lib/kotlin/kotlinc/bin/';
 var KOTLIN_DEFAULT_SOLUTION = 'Solution';
@@ -9,32 +9,32 @@ var KOTLIN_DEFAULT_SETUP = 'Setup';
 var KOTLIN_DEFAULT_TEST = 'Test';
 
 module.exports.run = function run(opts, cb) {
-    temp.track();
-    var dir = temp.mkdirSync('kotlin');
+  temp.track();
+  var dir = temp.mkdirSync('kotlin');
 
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode, fail) {
-            var classDirectory = path.join(dir, 'classes'),
-                solutionFile = util.codeWriteSync('kotlin', opts.solution, dir, KOTLIN_DEFAULT_SOLUTION),
-                solutionClassName = path.basename(solutionFile, '.kt'),
-                args = [KOTLIN_BASE_DIR + 'kotlinc', '-d', classDirectory, solutionFile],
-                runArgs = ['-classpath', classDirectory, solutionClassName + 'Kt'];
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode, fail) {
+      var classDirectory = path.join(dir, 'classes'),
+        solutionFile = util.codeWriteSync('kotlin', opts.solution, dir, KOTLIN_DEFAULT_SOLUTION),
+        solutionClassName = path.basename(solutionFile, '.kt'),
+        args = [KOTLIN_BASE_DIR + 'kotlinc', '-d', classDirectory, solutionFile],
+        runArgs = ['-classpath', classDirectory, solutionClassName + 'Kt'];
 
-            if (opts.setup) {
-                var setupFile = util.codeWriteSync('kotlin', opts.setup, dir, KOTLIN_DEFAULT_SETUP);
-                args.push(setupFile);
-            }
-            util.mkdirParentSync(classDirectory);
-            util.exec(args.join(' '), function (error) {
-                if (error) return fail(error);
-                runCode({
-                    'name': KOTLIN_BASE_DIR + 'kotlin',
-                    'args': runArgs
-                });
-            });
-        },
-        testIntegration: function (run) {
-            throw new Error('Test framework is not supported');
-        }
-    });
+      if (opts.setup) {
+        var setupFile = util.codeWriteSync('kotlin', opts.setup, dir, KOTLIN_DEFAULT_SETUP);
+        args.push(setupFile);
+      }
+      util.mkdirParentSync(classDirectory);
+      util.exec(args.join(' '), function (error) {
+        if (error) return fail(error);
+        runCode({
+          'name': KOTLIN_BASE_DIR + 'kotlin',
+          'args': runArgs
+        });
+      });
+    },
+    testIntegration: function (run) {
+      throw new Error('Test framework is not supported');
+    }
+  });
 };

--- a/lib/runners/lisp.js
+++ b/lib/runners/lisp.js
@@ -1,27 +1,27 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    temp = require('temp');
+  util = require('../util'),
+  temp = require('temp');
 
 module.exports.run = function run(opts, cb) {
-    temp.track();
-    var lispCodeDir = temp.mkdirSync('lisp'),
-        args = [
-            '--noinform', // Disable banner
-            '--disable-ldb',  // Disable the low-level debugger
-            '--lose-on-corruption', // Don't try to recover
-            '--non-interactive' // No REPL
-        ];
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            if (opts.setup) {
-                var setupFile = util.codeWriteSync('lisp', opts.setup, lispCodeDir, 'setup.lisp');
-                args.push('--load', setupFile);
-            }
-            args.push('--eval', opts.solution);
-            runCode({name: 'sbcl', args: args});
-        },
-        testIntegration: function (runCode) {
-            throw 'Test framework is not supported';
-        }
-    });
+  temp.track();
+  var lispCodeDir = temp.mkdirSync('lisp'),
+    args = [
+      '--noinform', // Disable banner
+      '--disable-ldb',  // Disable the low-level debugger
+      '--lose-on-corruption', // Don't try to recover
+      '--non-interactive' // No REPL
+    ];
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      if (opts.setup) {
+        var setupFile = util.codeWriteSync('lisp', opts.setup, lispCodeDir, 'setup.lisp');
+        args.push('--load', setupFile);
+      }
+      args.push('--eval', opts.solution);
+      runCode({name: 'sbcl', args: args});
+    },
+    testIntegration: function (runCode) {
+      throw 'Test framework is not supported';
+    }
+  });
 };

--- a/lib/runners/lua.js
+++ b/lib/runners/lua.js
@@ -1,5 +1,5 @@
 var shovel = require('../shovel'),
-    writeFileSync = require('../util').writeFileSync;
+  writeFileSync = require('../util').writeFileSync;
 
 module.exports.run = function run(opts, cb) {
   const dir = '/home/codewarrior/lua';

--- a/lib/runners/nasm.js
+++ b/lib/runners/nasm.js
@@ -1,30 +1,30 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    path = require('path'),
-    temp = require('temp');
+  util = require('../util'),
+  path = require('path'),
+  temp = require('temp');
 
 module.exports.run = function run(opts, cb) {
-    temp.track();
-    var dir = temp.mkdirSync('nasm');
+  temp.track();
+  var dir = temp.mkdirSync('nasm');
 
-    shovel.start(opts, cb, {
-        solutionOnly: function (run) {
+  shovel.start(opts, cb, {
+    solutionOnly: function (run) {
             // TODO: Support setup code; setup code should either be NASM or C, and we should automatically detect it
-            var executable = path.join(dir, 'solution'),
-                solutionFile = util.codeWriteSync('nasm', opts.solution + '\n', dir, 'solution.asm'),
-                nasmCommand = ['nasm', '-felf64', solutionFile].join(' '),
-                objectFile = solutionFile.replace(/\.[^\.]+$/, '.o'),
+      var executable = path.join(dir, 'solution'),
+        solutionFile = util.codeWriteSync('nasm', opts.solution + '\n', dir, 'solution.asm'),
+        nasmCommand = ['nasm', '-felf64', solutionFile].join(' '),
+        objectFile = solutionFile.replace(/\.[^\.]+$/, '.o'),
                 // Check for whether we need to link against libc
-                linker = opts.solution.search(/global\W+_start/) == -1 ? "gcc" : "ld";
-                linkerCommand = [linker, objectFile, '-o', executable].join(' ');
-            util.exec(nasmCommand, function () {
-                util.exec(linkerCommand, function () {
-                    run({'name': executable, 'args': []});
-                });
-            });
-        },
-        testIntegration: function (run) {
-            throw new Error('Test framework is not supported');
-        }
-    });
+        linker = opts.solution.search(/global\W+_start/) == -1 ? "gcc" : "ld";
+      linkerCommand = [linker, objectFile, '-o', executable].join(' ');
+      util.exec(nasmCommand, function () {
+        util.exec(linkerCommand, function () {
+          run({'name': executable, 'args': []});
+        });
+      });
+    },
+    testIntegration: function (run) {
+      throw new Error('Test framework is not supported');
+    }
+  });
 };

--- a/lib/runners/objc.js
+++ b/lib/runners/objc.js
@@ -148,14 +148,14 @@ module.exports.run = function run (opts, cb) {
       args = ['-o', executable];
 
       switch (opts.testFramework) {
-        case 'cw':
-          args = args.concat(prepareCW(opts, runCode));
-          break;
-        case 'unitkit':
-          args = args.concat(prepareUnitKit(opts, runCode));
-          break;
-        default:
-          throw `Test framework: ${opts.testFramework} not supported`
+      case 'cw':
+        args = args.concat(prepareCW(opts, runCode));
+        break;
+      case 'unitkit':
+        args = args.concat(prepareUnitKit(opts, runCode));
+        break;
+      default:
+        throw `Test framework: ${opts.testFramework} not supported`
       }
 
       compile(args, function (error, stdout, stderr) {

--- a/lib/runners/ocaml.js
+++ b/lib/runners/ocaml.js
@@ -1,60 +1,60 @@
 var shovel = require('../shovel');
 
 module.exports.run = function run(opts, cb) {
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            var stdin;
-            if (opts.setup) {
-                stdin = opts.setup + "\n" + opts.solution
-            } else {
-                stdin = opts.solution
-            }
-            runCode({
-                name: 'bash',
-                args: ['/home/codewarrior/run_ocaml.sh', 'utop', '-require', 'core', '-require', 'batteries', '-require', 'oUnit', '-stdin'],
-                stdin: stdin
-            });
-        },
-        testIntegration: function(runCode) {
-            var runFixtureUsingOUnit = [
-				'#load "str.cma";;',
-				'module TestRunner = struct',
-                '	open OUnit',
-                '	let cw_print_endline s = s |> Str.global_replace (Str.regexp_string "\n") "<:LF:>" |> print_endline;;',
-                '	let cw_print_test_event = function',
-                '	    | EStart (name::rest) -> print_endline ("<IT::>" ^ OUnit.string_of_node name)',
-                '	    | EResult result -> ',
-                '	        begin match result with ',
-                '	        | RSuccess _ -> print_endline ("<PASSED::>Test passed")',
-                '	        | RFailure (_, err) -> print_endline ("<FAILED::>" ^ err)',
-                '	        | RError (_, err) -> print_endline ("<ERROR::>" ^ err)',
-                '	        | _ -> ()',
-                '	        end',
-                '	    | _ -> ()',
-                '	',
-                '	let run_test = function',
-                '	    | TestLabel (name, suite) -> begin',
-                '	        print_endline ("<DESCRIBE::>" ^ name);',
-                '	        perform_test cw_print_test_event suite',
-                '	    end',
-                '	    | suite -> perform_test cw_print_test_event suite',
-                '	',
-                'end',
-                'let _ = ',
-                '    List.map TestRunner.run_test Tests.suite |> ignore',
-            ].join("\n");
-            var stdin = [
-                opts.setup ? opts.setup : "",
-                opts.solution,
-                opts.fixture,
-                runFixtureUsingOUnit
-            ].join("\n");
-            var test = opts.fixture
-            runCode({
-                name: 'bash',
-                args: ['/home/codewarrior/run_ocaml.sh', 'utop', '-require', 'core', '-require', 'batteries', '-require', 'oUnit', '-stdin'],
-                stdin: stdin
-            });
-        }
-    });
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      var stdin;
+      if (opts.setup) {
+        stdin = opts.setup + "\n" + opts.solution
+      } else {
+        stdin = opts.solution
+      }
+      runCode({
+        name: 'bash',
+        args: ['/home/codewarrior/run_ocaml.sh', 'utop', '-require', 'core', '-require', 'batteries', '-require', 'oUnit', '-stdin'],
+        stdin: stdin
+      });
+    },
+    testIntegration: function(runCode) {
+      var runFixtureUsingOUnit = [
+        '#load "str.cma";;',
+        'module TestRunner = struct',
+        '	open OUnit',
+        '	let cw_print_endline s = s |> Str.global_replace (Str.regexp_string "\n") "<:LF:>" |> print_endline;;',
+        '	let cw_print_test_event = function',
+        '	    | EStart (name::rest) -> print_endline ("<IT::>" ^ OUnit.string_of_node name)',
+        '	    | EResult result -> ',
+        '	        begin match result with ',
+        '	        | RSuccess _ -> print_endline ("<PASSED::>Test passed")',
+        '	        | RFailure (_, err) -> print_endline ("<FAILED::>" ^ err)',
+        '	        | RError (_, err) -> print_endline ("<ERROR::>" ^ err)',
+        '	        | _ -> ()',
+        '	        end',
+        '	    | _ -> ()',
+        '	',
+        '	let run_test = function',
+        '	    | TestLabel (name, suite) -> begin',
+        '	        print_endline ("<DESCRIBE::>" ^ name);',
+        '	        perform_test cw_print_test_event suite',
+        '	    end',
+        '	    | suite -> perform_test cw_print_test_event suite',
+        '	',
+        'end',
+        'let _ = ',
+        '    List.map TestRunner.run_test Tests.suite |> ignore',
+      ].join("\n");
+      var stdin = [
+        opts.setup ? opts.setup : "",
+        opts.solution,
+        opts.fixture,
+        runFixtureUsingOUnit
+      ].join("\n");
+      var test = opts.fixture
+      runCode({
+        name: 'bash',
+        args: ['/home/codewarrior/run_ocaml.sh', 'utop', '-require', 'core', '-require', 'batteries', '-require', 'oUnit', '-stdin'],
+        stdin: stdin
+      });
+    }
+  });
 };

--- a/lib/runners/perl.js
+++ b/lib/runners/perl.js
@@ -1,22 +1,22 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    config = require('../config'),
-    temp = require('temp');
+  util = require('../util'),
+  config = require('../config'),
+  temp = require('temp');
 
 module.exports.run = function run(opts, cb)
 {
-    temp.track();
-    var dir = temp.mkdirSync('perl');
+  temp.track();
+  var dir = temp.mkdirSync('perl');
 
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode)
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode)
         {
-            var file = util.codeWriteSync('perl', opts.solution, dir, 'solution.pl')
-            runCode({name: 'perl', 'args': [file]});
-        },
-        testIntegration: function (runCode)
+      var file = util.codeWriteSync('perl', opts.solution, dir, 'solution.pl')
+      runCode({name: 'perl', 'args': [file]});
+    },
+    testIntegration: function (runCode)
         {
-            throw 'Test framework is not supported'
-        }
-    });
+      throw 'Test framework is not supported'
+    }
+  });
 };

--- a/lib/runners/php.js
+++ b/lib/runners/php.js
@@ -16,12 +16,12 @@ module.exports.run = function run (opts, cb) {
     },
     testIntegration: function (runCode) {
       switch (opts.testFramework) {
-        case 'cw-2':
-          return prepareCw2(opts, runCode);
-        case 'phpunit':
-          return preparePHPUnit(opts, runCode);
-        default:
-          throw 'Test framework is not supported'
+      case 'cw-2':
+        return prepareCw2(opts, runCode);
+      case 'phpunit':
+        return preparePHPUnit(opts, runCode);
+      default:
+        throw 'Test framework is not supported'
       }
     },
     sanitizeStdOut: function (output) {

--- a/lib/runners/python.js
+++ b/lib/runners/python.js
@@ -1,110 +1,110 @@
 var shovel = require('../shovel'),
-    config = require('../config');
+  config = require('../config');
 
 module.exports.run = function run(opts, cb) {
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            var code = [opts.setup, opts.solution].join("\n");
-            runVersion(opts, code, runCode);
-        },
-        testIntegration: function (runCode) {
-            var code;
-            var snippets = config.snippets.python;
-            switch (opts.testFramework) {
-                case 'cw':
-                case 'cw-2':
-                    code = opts.projectMode ? cw2Project(opts) : cw2Code(opts)
-                    break;
-                case 'unittest':
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      var code = [opts.setup, opts.solution].join("\n");
+      runVersion(opts, code, runCode);
+    },
+    testIntegration: function (runCode) {
+      var code;
+      var snippets = config.snippets.python;
+      switch (opts.testFramework) {
+      case 'cw':
+      case 'cw-2':
+        code = opts.projectMode ? cw2Project(opts) : cw2Code(opts)
+        break;
+      case 'unittest':
                     // TODO: support projectMode for unittest, which should require
                     // improving unittest support so that a specific test case called Test doesn't need
                     // to be used
-                    code = [
-                        opts.setup,
-                        opts.solution,
-                        snippets.addPythonFramework,
-                        snippets.requireUnittest,
-                        opts.fixture,
-                        snippets.runUnittest
-                    ].join('\n');
-                    break;
-                default:
-                    throw new Error('test framework is not supported');
-            }
-            runVersion(opts, code, runCode);
-        },
-        sanitizeStdErr: function (err) {
+        code = [
+          opts.setup,
+          opts.solution,
+          snippets.addPythonFramework,
+          snippets.requireUnittest,
+          opts.fixture,
+          snippets.runUnittest
+        ].join('\n');
+        break;
+      default:
+        throw new Error('test framework is not supported');
+      }
+      runVersion(opts, code, runCode);
+    },
+    sanitizeStdErr: function (err) {
             // get rid of some of the noisy content. We remove line numbers since
             // they don't match up to what the user sees and will only confuse them.
-            return err
+      return err
                 .replace(/>\n\n+</g, '>\n<')
                 .replace(/File "(<string>)?", line \d*,/g, '')
                 .replace(' (most recent call last)', '')
                 .replace(' in in ', ' in ');
-        }
-    });
+    }
+  });
 };
 
 function runVersion(opts, code, run) {
-    run({name: pythonCmd(opts), 'args': ['-c', code]});
+  run({name: pythonCmd(opts), 'args': ['-c', code]});
 }
 
 function pythonCmd(opts) {
-    switch (opts.languageVersion) {
-        case '3.6':
-        case '3.6.x':
-            return 'python3.6'
+  switch (opts.languageVersion) {
+  case '3.6':
+  case '3.6.x':
+    return 'python3.6'
 
-        case '3.4.x':
-        case '3.4':
-        case '3.x':
-        case '3':
-            return 'python3'
+  case '3.4.x':
+  case '3.4':
+  case '3.x':
+  case '3':
+    return 'python3'
 
-        case '2.x':
-        case '2.7':
-        case '2':
-        case '':
-        case null:
-        case undefined:
-            return 'python'
+  case '2.x':
+  case '2.7':
+  case '2':
+  case '':
+  case null:
+  case undefined:
+    return 'python'
 
-        default:
-            throw `python version ${opts.languageVersion} not supported`
-    }
+  default:
+    throw `python version ${opts.languageVersion} not supported`
+  }
 }
 
 function isPython3(opts) {
-    return opts.languageVersion && opts.languageVersion[0] == '3'
+  return opts.languageVersion && opts.languageVersion[0] == '3'
 }
 
 function cw2Code(opts) {
-    return [
-        defaultImports(opts),
-        CW2_IMPORT,
-        opts.setup,
-        opts.solution,
-        opts.fixture
-    ].join('\n')
+  return [
+    defaultImports(opts),
+    CW2_IMPORT,
+    opts.setup,
+    opts.solution,
+    opts.fixture
+  ].join('\n')
 }
 
 function cw2Project(opts) {
-    return [
-        defaultImports(opts),
-        CW2_IMPORT,
-        pythonExec(opts)
-    ].join('\n')
+  return [
+    defaultImports(opts),
+    CW2_IMPORT,
+    pythonExec(opts)
+  ].join('\n')
 }
 
 function pythonExec (opts, file) {
-    file = file || opts.entryPath;
-    return isPython3(opts) ?
+  file = file || opts.entryPath;
+  return isPython3(opts) ?
         `exec(compile(open("${file}", "rb").read(), "${file}", 'exec'))` :
         `execfile('${file}')`;
 }
 
 function defaultImports (opts) {
-    return `try: from imp import reload
+  return `try: from imp import reload
 except: pass
 reload(__import__('sys')).path.append('./frameworks/python') 
 reload(__import__('sys')).path.append('${opts.dir}') 

--- a/lib/runners/python3.js
+++ b/lib/runners/python3.js
@@ -2,8 +2,8 @@
 var python = require('./python');
 
 module.exports.run = function run(opts, cb) {
-    opts.languageVersion = '3.x'; // we only care about the major version
-    python.run(opts, cb);
+  opts.languageVersion = '3.x'; // we only care about the major version
+  python.run(opts, cb);
 }
 
 

--- a/lib/runners/r.js
+++ b/lib/runners/r.js
@@ -1,18 +1,18 @@
 var shovel = require('../shovel');
 
 module.exports.run = function run(opts, cb) {
-    shovel.start(opts, cb, {
-        solutionOnly: function (run) {
-            if (opts.setup) {
-                opts.solution = opts.setup + opts.solution;
-            }
-            run({
-                name: 'R',
-                args: ['--vanilla', '--slave', '-e', opts.solution]
-            });
-        },
-        testIntegration: function (run) {
-            throw new Error('Test framework is not supported');
-        }
-    });
+  shovel.start(opts, cb, {
+    solutionOnly: function (run) {
+      if (opts.setup) {
+        opts.solution = opts.setup + opts.solution;
+      }
+      run({
+        name: 'R',
+        args: ['--vanilla', '--slave', '-e', opts.solution]
+      });
+    },
+    testIntegration: function (run) {
+      throw new Error('Test framework is not supported');
+    }
+  });
 };

--- a/lib/runners/racket.js
+++ b/lib/runners/racket.js
@@ -1,25 +1,25 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    temp = require('temp');
+  util = require('../util'),
+  temp = require('temp');
 
 module.exports.run = function run(opts, cb) {
-    temp.track();
-    var racketCodeDir = temp.mkdirSync('racket'),
-        args = ['-l', 'racket/base'];
-    shovel.start(opts, cb, {
-        solutionOnly: function (run) {
-            if (opts.setup) {
-                var setupFile = util.codeWriteSync('racket', opts.setup, racketCodeDir, 'setup.rkt');
-                args.push('-t', setupFile);
-            }
-            args.push('-e', opts.solution);
-            run({
-                name: 'racket',
-                args: args
-            });
-        },
-        testIntegration: function (run) {
-            throw 'Test framework is not supported';
-        }
-    });
+  temp.track();
+  var racketCodeDir = temp.mkdirSync('racket'),
+    args = ['-l', 'racket/base'];
+  shovel.start(opts, cb, {
+    solutionOnly: function (run) {
+      if (opts.setup) {
+        var setupFile = util.codeWriteSync('racket', opts.setup, racketCodeDir, 'setup.rkt');
+        args.push('-t', setupFile);
+      }
+      args.push('-e', opts.solution);
+      run({
+        name: 'racket',
+        args: args
+      });
+    },
+    testIntegration: function (run) {
+      throw 'Test framework is not supported';
+    }
+  });
 };

--- a/lib/runners/ruby.js
+++ b/lib/runners/ruby.js
@@ -21,14 +21,14 @@ module.exports.run = function run (opts, cb) {
     },
     testIntegration: function (runCode) {
       switch (opts.testFramework) {
-        case 'cw':
-        case 'cw-2':
-          return prepareCw2(opts, runCode);
-        case 'rspec':
-          return prepareRSpec(opts, runCode);
+      case 'cw':
+      case 'cw-2':
+        return prepareCw2(opts, runCode);
+      case 'rspec':
+        return prepareRSpec(opts, runCode);
 
-        default:
-          throw 'Test framework is not supported'
+      default:
+        throw 'Test framework is not supported'
       }
     },
     sanitizeStdErr: function (error) {

--- a/lib/runners/rust.js
+++ b/lib/runners/rust.js
@@ -70,42 +70,42 @@ module.exports.run = function run(opts, cb) {
   // Create the solution file
   const  _createSolution = function() {
       // Set the code
-      let code = opts.setup ? `${opts.setup}\n${opts.code}` : opts.code;
+    let code = opts.setup ? `${opts.setup}\n${opts.code}` : opts.code;
 
-      return util.codeWriteSync('rust', code, opts.dir, 'main.rs', true);
+    return util.codeWriteSync('rust', code, opts.dir, 'main.rs', true);
   }
 
   // Create the spec
   const  _createSpec = function() {
-      let code = opts.setup ? `${opts.setup}\n${opts.code}` : opts.code;
-      code += `\n${opts.fixture}`
+    let code = opts.setup ? `${opts.setup}\n${opts.code}` : opts.code;
+    code += `\n${opts.fixture}`
 
-      return util.codeWriteSync('rust', code, opts.dir, 'main.rs', true);
+    return util.codeWriteSync('rust', code, opts.dir, 'main.rs', true);
   }
 
   // Initalizes the Rust dir via cargo
   const _compile = function(cb) {
-      exec(`rustc main.rs ${usingTests ? '--test' : ''}`,{cwd: opts.dir}, cb);
+    exec(`rustc main.rs ${usingTests ? '--test' : ''}`,{cwd: opts.dir}, cb);
   }
 
   const _formatOut = function(stdout) {
-      let output = '';
-      let tests = stdout.split(/\n/gm).filter(v => !v.search(/^test.*(?:ok|FAILED)$/));
+    let output = '';
+    let tests = stdout.split(/\n/gm).filter(v => !v.search(/^test.*(?:ok|FAILED)$/));
 
-      for(let test of tests) output += _parseTest(test);
+    for(let test of tests) output += _parseTest(test);
 
-      return output;
+    return output;
   }
 
   const _formatErr = function(stderr) {
-      return stderr.split('\n').reduce((prev,curr) => prev += curr.substr(8) + '\n','<ERROR::>');
+    return stderr.split('\n').reduce((prev,curr) => prev += curr.substr(8) + '\n','<ERROR::>');
   }
 
   const _parseTest = function(test) {
-      let result = test.split(' ');
-      let out = `<DESCRIBE::>${result[1]}\n`;
-      out += result[3] != 'FAILED' ? `<PASSED::>Test Passed\n` : `<FAILED::>Test Failed\n`;
-      return out;
+    let result = test.split(' ');
+    let out = `<DESCRIBE::>${result[1]}\n`;
+    out += result[3] != 'FAILED' ? `<PASSED::>Test Passed\n` : `<FAILED::>Test Failed\n`;
+    return out;
   }
 };
 

--- a/lib/runners/scala.js
+++ b/lib/runners/scala.js
@@ -1,35 +1,35 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    path = require('path'),
-    exec = require('child_process').exec,
-    temp = require('temp');
+  util = require('../util'),
+  path = require('path'),
+  exec = require('child_process').exec,
+  temp = require('temp');
 
 module.exports.run = function run(opts, cb) {
-    temp.track();
-    var dir = temp.mkdirSync('scala');
+  temp.track();
+  var dir = temp.mkdirSync('scala');
 
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode, fail) {
-            var classDirectory = path.join(dir, 'classes'),
-                solutionFile = util.codeWriteSync('scala', opts.solution, dir),
-                solutionClassName = path.basename(solutionFile, '.scala'),
-                args = ['scalac', '-d', classDirectory, solutionFile];
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode, fail) {
+      var classDirectory = path.join(dir, 'classes'),
+        solutionFile = util.codeWriteSync('scala', opts.solution, dir),
+        solutionClassName = path.basename(solutionFile, '.scala'),
+        args = ['scalac', '-d', classDirectory, solutionFile];
 
-            if (opts.setup) {
-                var setupFile = util.codeWriteSync('scala', opts.setup, dir);
-                args.push(setupFile);
-            }
-            util.mkdirParentSync(classDirectory);
-            exec(args.join(' '), function (error) {
-                if (error) return fail(error);
-                runCode({
-                    'name': 'scala',
-                    'args': ['-classpath', classDirectory, solutionClassName]
-                });
-            });
-        },
-        testIntegration: function (runCode, fail) {
-            throw new Error('Test framework is not supported');
-        }
-    });
+      if (opts.setup) {
+        var setupFile = util.codeWriteSync('scala', opts.setup, dir);
+        args.push(setupFile);
+      }
+      util.mkdirParentSync(classDirectory);
+      exec(args.join(' '), function (error) {
+        if (error) return fail(error);
+        runCode({
+          'name': 'scala',
+          'args': ['-classpath', classDirectory, solutionClassName]
+        });
+      });
+    },
+    testIntegration: function (runCode, fail) {
+      throw new Error('Test framework is not supported');
+    }
+  });
 };

--- a/lib/runners/shell.js
+++ b/lib/runners/shell.js
@@ -1,37 +1,37 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    config = require('../config'),
-    temp = require('temp'),
-    ruby = require('./ruby');
+  util = require('../util'),
+  config = require('../config'),
+  temp = require('temp'),
+  ruby = require('./ruby');
 
 module.exports.run = function run(opts, cb)
 {
-    temp.track();
-    var dir = temp.mkdirSync('bash');
+  temp.track();
+  var dir = temp.mkdirSync('bash');
 
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode)
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode)
         {
-            var file = util.codeWriteSync('bash', opts.solution, dir, 'solution.sh')
-            runCode({name: opts.languageVersion || 'bash', 'args': [file]});
-        },
-        testIntegration: function (runCode)
+      var file = util.codeWriteSync('bash', opts.solution, dir, 'solution.sh')
+      runCode({name: opts.languageVersion || 'bash', 'args': [file]});
+    },
+    testIntegration: function (runCode)
         {
-            process.env.SHELL = opts.languageVersion || 'bash';
+      process.env.SHELL = opts.languageVersion || 'bash';
 
-            if (!opts.projectMode) {
-              prepareSetup(opts);
-              opts.solution = "#"
-              opts.fixture = `\`rm -rf /workspace/fixture.rb\` ; ${opts.fixture}`
-            }
+      if (!opts.projectMode) {
+        prepareSetup(opts);
+        opts.solution = "#"
+        opts.fixture = `\`rm -rf /workspace/fixture.rb\` ; ${opts.fixture}`
+      }
 
-            ruby.prepareRSpec(opts, runCode);
-        }
-    });
+      ruby.prepareRSpec(opts, runCode);
+    }
+  });
 };
 
 function prepareSetup(opts) {
-    opts.setup = `
+  opts.setup = `
         require '/runner/frameworks/ruby/shell'
         ${opts.setup || ''}
     `;

--- a/lib/runners/sql.js
+++ b/lib/runners/sql.js
@@ -1,75 +1,75 @@
 var shovel = require('../shovel'),
-    config = require('../config'),
-    ruby = require('./ruby');
+  config = require('../config'),
+  ruby = require('./ruby');
 
 module.exports.run = function run(opts, cb) {
 
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            prepareSetup(opts);
-            var code = `${opts.setup}\nputs run_sql`;
-            runCode({name: 'ruby', 'args': ['-e', code]});
-        },
-        testIntegration: function (runCode) {
-            prepareSetup(opts);
-            opts.solution = "#"
-            if (opts.testFramework === 'cw-2') {
-                ruby.prepareCw2(opts, runCode);
-            }
-            else {
-                ruby.prepareRSpec(opts, runCode);
-            }
-        },
-        modifyOpts: function(opts) {
-            switch (opts.languageVersion) {
-                case 'postgres':
-                    addService(opts, 'postgres');
-                    break;
-            }
-        },
-        sanitizeStdErr: function(err) {
-            return err.split("\n").filter(l => l.indexOf("from /usr/local") == -1).join("\n")
-        }
-    });
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      prepareSetup(opts);
+      var code = `${opts.setup}\nputs run_sql`;
+      runCode({name: 'ruby', 'args': ['-e', code]});
+    },
+    testIntegration: function (runCode) {
+      prepareSetup(opts);
+      opts.solution = "#"
+      if (opts.testFramework === 'cw-2') {
+        ruby.prepareCw2(opts, runCode);
+      }
+      else {
+        ruby.prepareRSpec(opts, runCode);
+      }
+    },
+    modifyOpts: function(opts) {
+      switch (opts.languageVersion) {
+      case 'postgres':
+        addService(opts, 'postgres');
+        break;
+      }
+    },
+    sanitizeStdErr: function(err) {
+      return err.split("\n").filter(l => l.indexOf("from /usr/local") == -1).join("\n")
+    }
+  });
 };
 
 function prepareSetup(opts) {
     // this will set environment variables
-    connectDb(opts)
+  connectDb(opts)
 
-    if (!opts.projectMode) {
-        opts.setup = [
-            "require '/runner/frameworks/ruby/sql'",
-            opts.setup || ''
-        ].join("\n");
-    }
+  if (!opts.projectMode) {
+    opts.setup = [
+      "require '/runner/frameworks/ruby/sql'",
+      opts.setup || ''
+    ].join("\n");
+  }
 }
 
 function connectDb(opts) {
-    opts.env = opts.env || {}
-    var type = opts.languageVersion || 'sqlite',
-        database = ":memory:"
+  opts.env = opts.env || {}
+  var type = opts.languageVersion || 'sqlite',
+    database = ":memory:"
 
-    if (type == 'postgres') {
-        database = dbName(opts) || 'postgres';
-    }
+  if (type == 'postgres') {
+    database = dbName(opts) || 'postgres';
+  }
 
     // these variables will be passed on to the ruby process
-    process.env.DATABASE_TYPE = type
-    process.env.DATABASE_NAME = database
+  process.env.DATABASE_TYPE = type
+  process.env.DATABASE_NAME = database
 }
 
 // checks the first two lines of the setup code to see if a database name was specified. This is done
 // because the first line can be used as a comment explaining why its there
 function dbName(opts) {
     // both @use-database and @config: use-database are supported for backwards compatibility
-    var match = (opts.setup || opts.fixture || '').match(/^# ?@(?:config: )?use-database (\w*)/m);
-    return match ? match[1] : opts.useDatabase || null;
+  var match = (opts.setup || opts.fixture || '').match(/^# ?@(?:config: )?use-database (\w*)/m);
+  return match ? match[1] : opts.useDatabase || null;
 }
 
 function addService(opts, name) {
-    opts.services = opts.services || [];
-    if (opts.services.indexOf(name) === -1) {
-        opts.services.push(name)
-    }
+  opts.services = opts.services || [];
+  if (opts.services.indexOf(name) === -1) {
+    opts.services.push(name)
+  }
 }

--- a/lib/runners/swift.js
+++ b/lib/runners/swift.js
@@ -1,5 +1,5 @@
 var shovel = require('../shovel'),
-    util = require('../util')
+  util = require('../util')
 
 
 var cw2 = `
@@ -60,82 +60,82 @@ var test = Test
 var xctest = 'import XCTest';
 
 module.exports.run = function run(opts, cb) {
-    var dir = '/home/codewarrior',
-        fixtureOffset = 0; // tracks any code we add to the fixture, used later for line number offsets
+  var dir = '/home/codewarrior',
+    fixtureOffset = 0; // tracks any code we add to the fixture, used later for line number offsets
 
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode) {
-            var code = [opts.setup, opts.solution].join("\n");
-            var file = util.codeWriteSync('swift', code, dir, 'solution.swift')
-            runCode({name: 'swift', 'args': [file]});
-        },
-        testIntegration: function (runCode) {
-            var code;
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode) {
+      var code = [opts.setup, opts.solution].join("\n");
+      var file = util.codeWriteSync('swift', code, dir, 'solution.swift')
+      runCode({name: 'swift', 'args': [file]});
+    },
+    testIntegration: function (runCode) {
+      var code;
 
-            if (opts.setup) {
-                opts.setup = opts.setup.trim();
-            }
+      if (opts.setup) {
+        opts.setup = opts.setup.trim();
+      }
 
-            switch (opts.testFramework) {
-                case 'cw-2':
-                    code = [
-                        opts.setup,
-                        opts.solution,
-                        cw2,
-                        opts.fixture
-                    ].join('\n');
-                    break;
-                case 'xctest':
-                    code = [opts.solution];
-                    if (opts.setup) {
-                        code.unshift(opts.setup);
-                    }
+      switch (opts.testFramework) {
+      case 'cw-2':
+        code = [
+          opts.setup,
+          opts.solution,
+          cw2,
+          opts.fixture
+        ].join('\n');
+        break;
+      case 'xctest':
+        code = [opts.solution];
+        if (opts.setup) {
+          code.unshift(opts.setup);
+        }
 
-                    if (opts.fixture) {
+        if (opts.fixture) {
                         // if the xctest import statement was provided, then auto include it
-                        if (opts.fixture.indexOf(xctest) === -1) {
-                            code.push(xctest);
-                            fixtureOffset = 1;
-                        }
+          if (opts.fixture.indexOf(xctest) === -1) {
+            code.push(xctest);
+            fixtureOffset = 1;
+          }
 
-                        code.push(opts.fixture);
-                    }
+          code.push(opts.fixture);
+        }
 
-                    code = code.join('\n');
-                    break;
+        code = code.join('\n');
+        break;
                 
-                default:
-                    throw new Error('test framework is not supported');
-            }
-            var file = util.codeWriteSync('swift', code, dir, 'solution.swift')
-            runCode({name: 'swift', 'args': [file]});
-        },
-        sanitizeStdErr: function (err) {
-            var setup = opts.setup ? (opts.setup || '').split('\n').length : 0,
-                code = opts.solution.split('\n').length
+      default:
+        throw new Error('test framework is not supported');
+      }
+      var file = util.codeWriteSync('swift', code, dir, 'solution.swift')
+      runCode({name: 'swift', 'args': [file]});
+    },
+    sanitizeStdErr: function (err) {
+      var setup = opts.setup ? (opts.setup || '').split('\n').length : 0,
+        code = opts.solution.split('\n').length
 
             // We need to change some of the line reporting to make it more useful
-            return err.replace(/solution.swift:(\d*):(\d*):/g, function(text, line, ch) {
-                try {
+      return err.replace(/solution.swift:(\d*):(\d*):/g, function(text, line, ch) {
+        try {
                     // convert line to an integer and make it zero based
-                    line = parseInt(line);
+          line = parseInt(line);
 
-                    if (setup > 0 && line <= setup)
-                        return `${text}(setup)`;
+          if (setup > 0 && line <= setup)
+            return `${text}(setup)`;
                         
-                    else if (setup > 0 && line <= setup + code)
-                        return `${text}(solution:${line - setup}:${ch})`;
+          else if (setup > 0 && line <= setup + code)
+            return `${text}(solution:${line - setup}:${ch})`;
                     
-                    else if (line > setup + code)
-                        return `${text}(fixture:${line - setup - code - fixtureOffset}:${ch})`;
+          else if (line > setup + code)
+            return `${text}(fixture:${line - setup - code - fixtureOffset}:${ch})`;
                     
-                    else
+          else
                         return text;
-                }
-                catch(ex) {
-                    return text;
-                }
-            })
         }
-    });
+        catch(ex) {
+          return text;
+        }
+      })
+    }
+  });
 };

--- a/lib/runners/typescript.js
+++ b/lib/runners/typescript.js
@@ -1,62 +1,62 @@
 var shovel = require('../shovel'),
-    util = require('../util'),
-    exec = require('child_process').exec,
-    temp = require('temp');
+  util = require('../util'),
+  exec = require('child_process').exec,
+  temp = require('temp');
 
 module.exports.run = function run(opts, cb) {
-    var dir = opts.dir;
-    shovel.start(opts, cb, {
-        solutionOnly: function (runCode, fail) {
+  var dir = opts.dir;
+  shovel.start(opts, cb, {
+    solutionOnly: function (runCode, fail) {
             // TODO: Support Setup Code
 
-            var solutionFile = util.codeWriteSync('typescript', opts.solution, dir, 'solution.ts', true);
-            exec('tsc ' + solutionFile + ' --module commonjs', function (error, stdout, stderr) {
-                if (error) return fail(error, stdout, stderr);
-                runCode({name: 'node', args: [solutionFile.replace('.ts', '.js')]});
-            });
-        },
-        testIntegration: function (runCode, fail) {
-            switch (opts.testFramework) {
-                case 'mocha':
-                case 'mocha_bdd':
-                    return prepareMocha(opts, 'bdd', runCode, fail);
-                case 'mocha_tdd':
-                    return prepareMocha(opts, 'tdd', runCode, fail);
-                default:
-                    throw 'Test framework is not supported'
-            }
-        },
-        sanitizeStdErr: function(error)
+      var solutionFile = util.codeWriteSync('typescript', opts.solution, dir, 'solution.ts', true);
+      exec('tsc ' + solutionFile + ' --module commonjs', function (error, stdout, stderr) {
+        if (error) return fail(error, stdout, stderr);
+        runCode({name: 'node', args: [solutionFile.replace('.ts', '.js')]});
+      });
+    },
+    testIntegration: function (runCode, fail) {
+      switch (opts.testFramework) {
+      case 'mocha':
+      case 'mocha_bdd':
+        return prepareMocha(opts, 'bdd', runCode, fail);
+      case 'mocha_tdd':
+        return prepareMocha(opts, 'tdd', runCode, fail);
+      default:
+        throw 'Test framework is not supported'
+      }
+    },
+    sanitizeStdErr: function(error)
         {
-            error = error || ''
-            return error.replace(/(\()?\/codewars\/[(\w\/-\d.js:) ;]*/g, '')
+      error = error || ''
+      return error.replace(/(\()?\/codewars\/[(\w\/-\d.js:) ;]*/g, '')
                 .replace(/( Object. )?[\(]?\[eval\][-:\w\d\)]* at/g, '')
                 .replace(/Module._compile.*/g, '')
                 .replace('Object.Test.handleError ', '')
                 .replace('  ', ' ');
-        },
-        sanitizeStdOut: function(stdout)
+    },
+    sanitizeStdOut: function(stdout)
         {
-            return this.sanitizeStdErr(stdout);
-        }
-    });
-
-    function prepareMocha(opts, interfaceType, runCode, fail) {
-        var code = opts.setup ? `${opts.setup}\n${opts.solution}` : opts.solution;
-
-        var codeFile = util.codeWriteSync('typescript', code, null, 'solution.ts', true);
-
-        exec('tsc --module commonjs ' + codeFile, function (error, stdout, stderr) {
-            if (error) return fail(error, stdout, stderr);
-
-            var specFile = util.codeWriteSync('typescript', opts.fixture, null, 'spec.ts', true);
-
-            exec('tsc --module commonjs ' + specFile, function (error, stdout, stderr) {
-                if (error) return fail(error, stdout, stderr);
-                specFile = specFile.replace('.ts', '.js')
-                runCode({name: 'mocha', 'args': ['-t', opts.timeout || 7000, '-u', interfaceType, '-R', 'mocha-reporter', specFile]});
-            });
-        });
+      return this.sanitizeStdErr(stdout);
     }
+  });
+
+  function prepareMocha(opts, interfaceType, runCode, fail) {
+    var code = opts.setup ? `${opts.setup}\n${opts.solution}` : opts.solution;
+
+    var codeFile = util.codeWriteSync('typescript', code, null, 'solution.ts', true);
+
+    exec('tsc --module commonjs ' + codeFile, function (error, stdout, stderr) {
+      if (error) return fail(error, stdout, stderr);
+
+      var specFile = util.codeWriteSync('typescript', opts.fixture, null, 'spec.ts', true);
+
+      exec('tsc --module commonjs ' + specFile, function (error, stdout, stderr) {
+        if (error) return fail(error, stdout, stderr);
+        specFile = specFile.replace('.ts', '.js')
+        runCode({name: 'mocha', 'args': ['-t', opts.timeout || 7000, '-u', interfaceType, '-R', 'mocha-reporter', specFile]});
+      });
+    });
+  }
 
 };

--- a/lib/runners/xcode.js
+++ b/lib/runners/xcode.js
@@ -1,21 +1,21 @@
 var shovel = require("../shovel"),
-codeWriteSync = require('../util').codeWriteSync,
-_ = require("lodash"),
-path = require("path"),
-temp = require("temp");
+  codeWriteSync = require('../util').codeWriteSync,
+  _ = require("lodash"),
+  path = require("path"),
+  temp = require("temp");
 
 module.exports.testIntegration = function testIntegration(opts,run) {
-    temp.track();
-    var tempCodeDir = temp.mkdirSync("xcode"),
-        script = path.resolve(__dirname, "../../frameworks/osx/run_template.sh"),
-        files = {"CODE": codeWriteSync(opts.language, opts.code, tempCodeDir, "code"),
-                 "FIXTURE": codeWriteSync(opts.language, opts.fixture, tempCodeDir, "test")};
+  temp.track();
+  var tempCodeDir = temp.mkdirSync("xcode"),
+    script = path.resolve(__dirname, "../../frameworks/osx/run_template.sh"),
+    files = {"CODE": codeWriteSync(opts.language, opts.code, tempCodeDir, "code"),
+      "FIXTURE": codeWriteSync(opts.language, opts.fixture, tempCodeDir, "test")};
+  if (opts.language == "objc")
+    files.CODE_HEADER = codeWriteSync("objcHeader", opts.codeHeader, tempCodeDir, "code.h");
+  if ("setup" in opts) {
+    files.SETUP = codeWriteSync(opts.language, opts.setup, tempCodeDir, "setup");
     if (opts.language == "objc")
-        files.CODE_HEADER = codeWriteSync("objcHeader", opts.codeHeader, tempCodeDir, "code.h");
-    if ("setup" in opts) {
-        files.SETUP = codeWriteSync(opts.language, opts.setup, tempCodeDir, "setup");
-        if (opts.language == "objc")
-            files.SETUP_HEADER = codeWriteSync("objcHeader", opts.setupHeader, tempCodeDir, "setup.h");
-    }
-    run({ name: script,
-          options: {"env": _.merge({}, process.env, opts, files)}});};
+      files.SETUP_HEADER = codeWriteSync("objcHeader", opts.setupHeader, tempCodeDir, "setup.h");
+  }
+  run({ name: script,
+    options: {"env": _.merge({}, process.env, opts, files)}});};

--- a/lib/services.js
+++ b/lib/services.js
@@ -1,64 +1,64 @@
 var spawn = require('child_process').spawn,
-    Promise = require('bluebird'),
-    temp = require('temp');
+  Promise = require('bluebird'),
+  temp = require('temp');
 
 const startService = {
-    redis: function(opts) {
-        return spawnAndWait(opts, 'redis-server', [], 'Running')
-    },
-    mongodb: function(opts) {
-        var dir = temp.mkdirSync('mongodb')
-        return spawnAndWait(opts, 'mongod', ['--smallfiles', '--noprealloc', '--nojournal', '--dbpath',  dir], 'waiting for connections on port');
-    },
-    postgres: function(opts) {
+  redis: function(opts) {
+    return spawnAndWait(opts, 'redis-server', [], 'Running')
+  },
+  mongodb: function(opts) {
+    var dir = temp.mkdirSync('mongodb')
+    return spawnAndWait(opts, 'mongod', ['--smallfiles', '--noprealloc', '--nojournal', '--dbpath',  dir], 'waiting for connections on port');
+  },
+  postgres: function(opts) {
         // stop the service. This is mostly needed just for specs since under normal circumstances the entire
         // container would be destroyed and no cleanup would be necessary
-        opts.onCompleted.push(function() {
-            spawn("/usr/lib/postgresql/9.6/bin/pg_ctl", ['-D', '/pgdata/pg', '-w', 'stop'])
-        });
+    opts.onCompleted.push(function() {
+      spawn("/usr/lib/postgresql/9.6/bin/pg_ctl", ['-D', '/pgdata/pg', '-w', 'stop'])
+    });
 
-        return spawnAndWait(opts, '/usr/lib/postgresql/9.6/bin/pg_ctl', ['-D', '/pgdata/pg', '-w', 'restart'])
-    },
-    mariadb: function(opts) {
+    return spawnAndWait(opts, '/usr/lib/postgresql/9.6/bin/pg_ctl', ['-D', '/pgdata/pg', '-w', 'restart'])
+  },
+  mariadb: function(opts) {
         // TODO
-    },
-    couchdb: function(opts) {
+  },
+  couchdb: function(opts) {
         // TODO
-    },
-    rabbitmq: function(opts) {
+  },
+  rabbitmq: function(opts) {
         // TODO
-    }
+  }
 }
 
 function spawnAndWait(opts, cmd, args, text, delay) {
 
-    return new Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
 
-        function handleData(data) {
-            var str = data && data.toString();
+    function handleData(data) {
+      var str = data && data.toString();
 
-            opts.publish('stdout', str);
+      opts.publish('stdout', str);
             // console.log(str);  // for debugging only
 
-            if (str && str.indexOf(text) > 0){
-                setTimeout(resolve, delay || 0);
-            }
-        }
+      if (str && str.indexOf(text) > 0){
+        setTimeout(resolve, delay || 0);
+      }
+    }
 
-        var s = spawn(cmd, args);
-        s.stderr.on('data', handleData);
-        s.stdout.on('data', handleData);
+    var s = spawn(cmd, args);
+    s.stderr.on('data', handleData);
+    s.stdout.on('data', handleData);
 
-        s.on('exit', resolve);
+    s.on('exit', resolve);
 
-        setTimeout(resolve, 2000);
-    });
+    setTimeout(resolve, 2000);
+  });
 }
 
 // loops through each requested service and returns once all services have started
 module.exports.start = function(opts, resolve) {
-    return Promise.map(opts.services || [], function(service){
+  return Promise.map(opts.services || [], function(service){
         // console.log("Starting " + service); // debug only
-        return startService[service](opts);
-    }).finally(resolve);
+    return startService[service](opts);
+  }).finally(resolve);
 }

--- a/lib/shovel.js
+++ b/lib/shovel.js
@@ -1,185 +1,185 @@
 var util = require('./util'),
-    child_process = require('child_process'),
-    spawn = child_process.spawn,
-    spawnSync = child_process.spawnSync,
-    config = require('./config'),
-    temp = require('temp'),
-    services = require('./services'),
-    options = require('./options');
+  child_process = require('child_process'),
+  spawn = child_process.spawn,
+  spawnSync = child_process.spawnSync,
+  config = require('./config'),
+  temp = require('temp'),
+  services = require('./services'),
+  options = require('./options');
 
 // used for indicating an error which is related to user code and not an application error.
 // useful for when we run code compilation inside of this host process.
 var CompileError = module.exports.CompileError = function(message) {
-    this.name = "CompileError";
-    this.message = message;
+  this.name = "CompileError";
+  this.message = message;
 }
 CompileError.prototype = Error.prototype;
 
 //runs the strategy specified in opts and reports the results of the run, then runs the callback
 module.exports.start = function start(opts, cb, strategies) {
     // if in test environment then cleanup any previous files before we get going
-    if (process.env.NODE_ENV === 'test') cleanup();
+  if (process.env.NODE_ENV === 'test') cleanup();
 
-    opts = options.process(opts);
+  opts = options.process(opts);
 
-    cb = cb || function (){};
-    run(opts, strategies, function (buffer) {
-        reportBuffer(opts, buffer, strategies);
-        cb(buffer);
+  cb = cb || function (){};
+  run(opts, strategies, function (buffer) {
+    reportBuffer(opts, buffer, strategies);
+    cb(buffer);
 
-        opts.onCompleted.forEach(f => f(buffer));
-    });
+    opts.onCompleted.forEach(f => f(buffer));
+  });
 };
 
 // given the options provided and a list of strategies on how to handle them, run will pick the
 // appropriate strategy and execute it.
 function run(opts, strategies, cb) {
     // this is the "run/exec" method that is passed in to the shovel methods as the callback.
-    function runCode (params) {
-        exec(opts, params.name, params.args, params.options, params.stdin, cb);
-    }
+  function runCode (params) {
+    exec(opts, params.name, params.args, params.options, params.stdin, cb);
+  }
 
     // called if the compile process fails
-    function fail (error, stdout, stderr) {
+  function fail (error, stdout, stderr) {
         // if params is an object with stdout/err values, then assume its already been processed within the language specific runner
-        if (error.stdout || error.stderr) {
-            error.compilationFailure = true;
-            cb(error);
-        }
-        else {
-            // if an error is passed in, then this is an execution error probably happening due to a compilation issue
-            var err = error.toString();
-            // don't add stderr if its just a repeat of the error message
-            if (stderr && err.indexOf(stderr) == -1) err += stderr;
-
-            cb({
-                stdout: stdout || '',
-                stderr: err,
-                wallTime: 0,
-                exitCode: error.code,
-                exitSignal: error.signal,
-                compilationFailure: true
-            });
-        }
+    if (error.stdout || error.stderr) {
+      error.compilationFailure = true;
+      cb(error);
     }
+    else {
+            // if an error is passed in, then this is an execution error probably happening due to a compilation issue
+      var err = error.toString();
+            // don't add stderr if its just a repeat of the error message
+      if (stderr && err.indexOf(stderr) == -1) err += stderr;
+
+      cb({
+        stdout: stdout || '',
+        stderr: err,
+        wallTime: 0,
+        exitCode: error.code,
+        exitSignal: error.signal,
+        compilationFailure: true
+      });
+    }
+  }
 
     // this won't be present in multi-file support cases
-    if (opts.code || opts.solution) {
+  if (opts.code || opts.solution) {
         // write the solution to a text file so that it can be inspected if need be
-        util.codeWriteSync(null, opts.code || opts.solution, opts.dir, 'solution.txt', true);
-    }
+    util.codeWriteSync(null, opts.code || opts.solution, opts.dir, 'solution.txt', true);
+  }
 
-    var hasServices = !!opts.services.length;
-    if (hasServices) opts.publish('status', 'Starting services...');
+  var hasServices = !!opts.services.length;
+  if (hasServices) opts.publish('status', 'Starting services...');
 
     // allow for language level modification of opts, such as services and shell
-    if (strategies.modifyOpts) {
-        strategies.modifyOpts(opts);
-    }
+  if (strategies.modifyOpts) {
+    strategies.modifyOpts(opts);
+  }
 
-    services.start(opts, function () {
-        downloadFromGithub(opts, function () {
-            setupFiles(opts, strategies);
-            runShell(opts, function () {
-                try {
-                    if (strategies.before) strategies.before();
+  services.start(opts, function () {
+    downloadFromGithub(opts, function () {
+      setupFiles(opts, strategies);
+      runShell(opts, function () {
+        try {
+          if (strategies.before) strategies.before();
 
-                    if (opts.files && opts.files['.runner/run.js'] && opts.customRunner) {
-                        const customStrategy = require(opts.dir + '/.runner/run.js');
-                        Object.assign(strategies, customStrategy(opts));
-                        strategies.custom(runCode, fail);
-                    }
-                    else {
+          if (opts.files && opts.files['.runner/run.js'] && opts.customRunner) {
+            const customStrategy = require(opts.dir + '/.runner/run.js');
+            Object.assign(strategies, customStrategy(opts));
+            strategies.custom(runCode, fail);
+          }
+          else {
                         // if a fixture was provided (or no solution was) then use testIntegration mode
-                        var strategy = strategies[opts.strategy];
-                        strategy(runCode, fail);
-                    }
-                }
-                catch (ex) {
-                    fail(ex);
-                }
-            });
-        });
+            var strategy = strategies[opts.strategy];
+            strategy(runCode, fail);
+          }
+        }
+        catch (ex) {
+          fail(ex);
+        }
+      });
     });
+  });
 }
 
 // if files are included, by default it will just write them to the working directory. If
 // a files strategy is defined however, it will call that method instead.
 function setupFiles(opts, strategies) {
-    if (opts.files) {
-        if (strategies.files) {
-            strategies.files();
-        } else {
+  if (opts.files) {
+    if (strategies.files) {
+      strategies.files();
+    } else {
             // write any optional files to the same directory
-            util.writeFilesSync(opts.dir, opts.files, true);
-        }
+      util.writeFilesSync(opts.dir, opts.files, true);
     }
+  }
 }
 
 // handles running an optional shell value, which allows users to configure a shell script to be ran
 // before the code executes
 function runShell(opts, resolve, status) {
     // if a shellFile was specified, then run that first before any manual shell code
-    if (opts.bashFile) {
-        opts.bash = `cd ${opts.dir} ; sh ${opts.bashFile}\n${opts.bash || ''}`;
-    }
+  if (opts.bashFile) {
+    opts.bash = `cd ${opts.dir} ; sh ${opts.bashFile}\n${opts.bash || ''}`;
+  }
 
     // if a shell script is provided then run it now
-    if (opts.bash) {
-        opts.publish('status', status || 'Running setup scripts...');
-        temp.track();
-        var file = util.codeWriteSync('bash', `#!/bin/bash\n${opts.bash}`, opts.dir, '.runner.sh'),
-            shellOpts = {
-                timeout: 10000, // allow the shell script its own 10 sec timeout
-                compiling: true // set to true so that the script doesn't exit
-            };
+  if (opts.bash) {
+    opts.publish('status', status || 'Running setup scripts...');
+    temp.track();
+    var file = util.codeWriteSync('bash', `#!/bin/bash\n${opts.bash}`, opts.dir, '.runner.sh'),
+      shellOpts = {
+        timeout: 10000, // allow the shell script its own 10 sec timeout
+        compiling: true // set to true so that the script doesn't exit
+      };
 
-        exec(shellOpts, 'bash', [file], {}, null, function (result) {
-            opts.shell = result;
-            resolve();
-        });
-    }
-    else {
-        resolve();
-    }
+    exec(shellOpts, 'bash', [file], {}, null, function (result) {
+      opts.shell = result;
+      resolve();
+    });
+  }
+  else {
+    resolve();
+  }
 }
 
 function downloadFromGithub(opts, resolve) {
-    if (opts.githubRepo) {
-        var repo = opts.githubRepo;
-        if (repo.indexOf('/tarball') == -1) {
-            repo += "/tarball";
-        }
-        if (repo.indexOf('api.github.com') == -1) {
-            repo = 'https://api.github.com/repos/' + repo;
-        }
+  if (opts.githubRepo) {
+    var repo = opts.githubRepo;
+    if (repo.indexOf('/tarball') == -1) {
+      repo += "/tarball";
+    }
+    if (repo.indexOf('api.github.com') == -1) {
+      repo = 'https://api.github.com/repos/' + repo;
+    }
 
-        var dl = {
-            publish: opts.publish,
-            bash: `
+    var dl = {
+      publish: opts.publish,
+      bash: `
                 cd ${opts.dir}
                 wget -qO- ${repo} | tar xvz --strip-components=1
             `
-        };
-        runShell(dl, resolve, 'Downloading files from Github...');
-    }
-    else if (opts.gist) {
-        require("request")({
-            url: "https://api.github.com/gists/" + opts.gist,
-            headers: {'User-Agent': 'Node-API'},
-            json: true
-        }, (err, response, body) => {
-            if (response && response.statusCode === 200 && body && body.files) {
-                Object.keys(body.files).forEach(name => {
-                    util.writeFileSync(opts.dir, name, body.files[name].content, true);
-                });
-            }
-            resolve();
+    };
+    runShell(dl, resolve, 'Downloading files from Github...');
+  }
+  else if (opts.gist) {
+    require("request")({
+      url: "https://api.github.com/gists/" + opts.gist,
+      headers: {'User-Agent': 'Node-API'},
+      json: true
+    }, (err, response, body) => {
+      if (response && response.statusCode === 200 && body && body.files) {
+        Object.keys(body.files).forEach(name => {
+          util.writeFileSync(opts.dir, name, body.files[name].content, true);
         });
-    }
-    else {
-        resolve();
-    }
+      }
+      resolve();
+    });
+  }
+  else {
+    resolve();
+  }
 }
 
 function cleanup() {
@@ -187,158 +187,158 @@ function cleanup() {
 }
 
 function exec(opts, name, args, processOptions, processStdin, cb) {
-    opts.publish = opts.publish || function(){};
+  opts.publish = opts.publish || function(){};
 
-    opts.publish("status", "Running...");
+  opts.publish("status", "Running...");
 
-    var child = spawn(name, args || [], processOptions),
-        buffer = {stdout: '', stderr: ''},
-        start = new Date(),
-        finished = false,
-        stdoutLength = 0,
-        maxTime = opts.timeout || config.timeouts[opts.language] || config.timeouts.default;
+  var child = spawn(name, args || [], processOptions),
+    buffer = {stdout: '', stderr: ''},
+    start = new Date(),
+    finished = false,
+    stdoutLength = 0,
+    maxTime = opts.timeout || config.timeouts[opts.language] || config.timeouts.default;
 
-    function exit(reason) {
-        if (!finished) {
-            child.kill('SIGKILL');
-            buffer.exitSignal = 'SIGKILL';
-            if (reason) buffer.stderr += reason + '\n';
-            finished = true;
-        }
-        cb(buffer);
+  function exit(reason) {
+    if (!finished) {
+      child.kill('SIGKILL');
+      buffer.exitSignal = 'SIGKILL';
+      if (reason) buffer.stderr += reason + '\n';
+      finished = true;
     }
+    cb(buffer);
+  }
 
-    if (processStdin) child.stdin.write(processStdin);
+  if (processStdin) child.stdin.write(processStdin);
 
     // Listen
-    const KB = 1024;
-    const MAX_BUFFER = KB * 1500; // 1.5mb
-    const MAX_DATA_BUFFER = KB * 50; //50kb is the max that can be written at once.
-    child.stdout.on('data', function (data) {
-        if (!!data) {
-            var text = data.toString();
-            opts.publish('stdout', text);
-            stdoutLength += text.length;
-            if (text.length > MAX_DATA_BUFFER) {
-                text = text.substr(0, MAX_DATA_BUFFER);
-                text += `\nContent truncated due to max data buffer of ${MAX_DATA_BUFFER / KB}kb being reached. Try flushing buffer with less content.\n`;
-            }
-            buffer.stdout += text;
-        }
-
-        if (stdoutLength > MAX_BUFFER) {
-            var msg = 'Max Buffer reached: Too much information has been written to stdout.';
-            opts.publish(msg);
-            buffer.status = 'max_buffer_reached';
-            exit(msg);
-        }
-    });
-
-    child.stderr.on('data', function (data) {
-        if (!!data) {
-            var text = data.toString();
-            opts.publish('stderr', text);
-            buffer.stderr += text;
-        }
-    });
-
-    child.on('close', code => buffer.code = code);
-    child.on('error', exit);
-
-    // prevent the process from running for too long
-    var timeout = setTimeout(function () {
-        if (!finished) {
-            buffer.status = 'max_time_reached';
-            exit('Process was terminated. It took longer than ' + maxTime + 'ms to complete');
-        }
-        process.exit(1);
-    }, maxTime);
-
-    var complete = function(code, signal) {
-        if (finished) return;
-
-        finished = true;
-        buffer.exitCode = code;
-        buffer.exitSignal = signal;
-        buffer.wallTime = new Date() - start;
-        cb(buffer);
-
-        // if we are within the run script
-        if (!opts.compiling && (process.argv[1] || '').indexOf('/run') >= 0) {
-            //ensure that node exits now, even if processes have forked off
-            process.exit(0);
-        }
+  const KB = 1024;
+  const MAX_BUFFER = KB * 1500; // 1.5mb
+  const MAX_DATA_BUFFER = KB * 50; //50kb is the max that can be written at once.
+  child.stdout.on('data', function (data) {
+    if (!!data) {
+      var text = data.toString();
+      opts.publish('stdout', text);
+      stdoutLength += text.length;
+      if (text.length > MAX_DATA_BUFFER) {
+        text = text.substr(0, MAX_DATA_BUFFER);
+        text += `\nContent truncated due to max data buffer of ${MAX_DATA_BUFFER / KB}kb being reached. Try flushing buffer with less content.\n`;
+      }
+      buffer.stdout += text;
     }
 
-    child.on('exit', function (code, signal) {
+    if (stdoutLength > MAX_BUFFER) {
+      var msg = 'Max Buffer reached: Too much information has been written to stdout.';
+      opts.publish(msg);
+      buffer.status = 'max_buffer_reached';
+      exit(msg);
+    }
+  });
+
+  child.stderr.on('data', function (data) {
+    if (!!data) {
+      var text = data.toString();
+      opts.publish('stderr', text);
+      buffer.stderr += text;
+    }
+  });
+
+  child.on('close', code => buffer.code = code);
+  child.on('error', exit);
+
+    // prevent the process from running for too long
+  var timeout = setTimeout(function () {
+    if (!finished) {
+      buffer.status = 'max_time_reached';
+      exit('Process was terminated. It took longer than ' + maxTime + 'ms to complete');
+    }
+    process.exit(1);
+  }, maxTime);
+
+  var complete = function(code, signal) {
+    if (finished) return;
+
+    finished = true;
+    buffer.exitCode = code;
+    buffer.exitSignal = signal;
+    buffer.wallTime = new Date() - start;
+    cb(buffer);
+
+        // if we are within the run script
+    if (!opts.compiling && (process.argv[1] || '').indexOf('/run') >= 0) {
+            //ensure that node exits now, even if processes have forked off
+      process.exit(0);
+    }
+  }
+
+  child.on('exit', function (code, signal) {
         // wait the remaining time left to see if all stdio processes close
         // preferably we cleanup after 'exit' is called
         // only wait up to 1 second though
-        setTimeout(function() {
-            complete(code, signal);
-        }, Math.min(getTimeLeft(timeout), 1000));
-    });
+    setTimeout(function() {
+      complete(code, signal);
+    }, Math.min(getTimeLeft(timeout), 1000));
+  });
 
-    child.on('close', function (code, signal) {
-        clearTimeout(timeout);
-        complete(code, signal);
-    });
+  child.on('close', function (code, signal) {
+    clearTimeout(timeout);
+    complete(code, signal);
+  });
 
-    child.stdin.end();
+  child.stdin.end();
 }
 
 // Get the time left in a set timeout
 // http://stackoverflow.com/questions/3144711/find-the-time-left-in-a-settimeout
 function getTimeLeft(timeout) {
-    return Math.ceil((timeout._idleStart + timeout._idleTimeout - Date.now()) / 1000);
+  return Math.ceil((timeout._idleStart + timeout._idleTimeout - Date.now()) / 1000);
 }
 
 function reportBuffer(opts, buffer, strategies) {
-    if (strategies) {
+  if (strategies) {
         // added as a way to transform the buffer before any additional stdout/err specific processing is made.
         // useful for things like when you may want to split stdout into both stdout and stderr
-        if (strategies.transformBuffer) {
-            strategies.transformBuffer(buffer);
-        }
+    if (strategies.transformBuffer) {
+      strategies.transformBuffer(buffer);
+    }
 
         // if there is an error, provide the ability to sanitize it. This is useful for when
         // output can be noisy.
-        if (buffer.stderr && strategies.sanitizeStdErr) {
-            buffer.stderr = strategies.sanitizeStdErr(buffer.stderr);
-        }
-
-        if (buffer.stdout && strategies.sanitizeStdOut) {
-            buffer.stdout = strategies.sanitizeStdOut(buffer.stdout);
-        }
+    if (buffer.stderr && strategies.sanitizeStdErr) {
+      buffer.stderr = strategies.sanitizeStdErr(buffer.stderr);
     }
+
+    if (buffer.stdout && strategies.sanitizeStdOut) {
+      buffer.stdout = strategies.sanitizeStdOut(buffer.stdout);
+    }
+  }
 
     // return the output of the shell call
-    if (opts.shell) {
-        buffer.shell = opts.shell;
-    }
+  if (opts.shell) {
+    buffer.shell = opts.shell;
+  }
 
     // escape the stderr output after strategies have been run
     // and before the it is written to the process stream
 
-    buffer.outputType = strategies.outputType || 'pre';
+  buffer.outputType = strategies.outputType || 'pre';
 
-    if (opts.format == 'json') {
-        writeToStream(process.stdout, JSON.stringify(buffer), "\\n");
-    } else {
-        if (buffer.stdout) writeToStream(process.stdout, buffer.stdout, "\n");
-        if (buffer.stderr) writeToStream(process.stderr, buffer.stderr, "\n");
-        if (buffer.wallTime && opts.debug) {
-            console.info(buffer.wallTime + 'ms');
-        }
+  if (opts.format == 'json') {
+    writeToStream(process.stdout, JSON.stringify(buffer), "\\n");
+  } else {
+    if (buffer.stdout) writeToStream(process.stdout, buffer.stdout, "\n");
+    if (buffer.stderr) writeToStream(process.stderr, buffer.stderr, "\n");
+    if (buffer.wallTime && opts.debug) {
+      console.info(buffer.wallTime + 'ms');
     }
+  }
 }
 
 // we need to chunk the data back out to handle strange inconsistency issues with large data.
 // Ideally we could chunk based off of character count but for some reason chunking by line breaks
 // is the only thing that is consistent.
 function writeToStream(stream, data, linebreak) {
-    data.split(linebreak).forEach((line, i, arr) => {
+  data.split(linebreak).forEach((line, i, arr) => {
         // don't write a line break on the last line
-        return stream.write(line.normalize() + (i != arr.length - 1 ? linebreak : ''));
-    });
+    return stream.write(line.normalize() + (i != arr.length - 1 ? linebreak : ''));
+  });
 }

--- a/lib/test_utils.js
+++ b/lib/test_utils.js
@@ -1,5 +1,5 @@
 var fs = require('fs'),
-    expect = require('chai').expect,
-    yaml = require('js-yaml'),
-    runner = require('./runner');
+  expect = require('chai').expect,
+  yaml = require('js-yaml'),
+  runner = require('./runner');
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,118 +1,118 @@
 var fs = require('fs'),
-    path = require('path'),
-    config = require('./config'),
-    child_process = require('child_process'),
-    util = module.exports;
+  path = require('path'),
+  config = require('./config'),
+  child_process = require('child_process'),
+  util = module.exports;
 
 module.exports.exec = function (command, opts, cb) {
-    if (!cb) {
-        cb = opts;
-        opts = {};
-    }
+  if (!cb) {
+    cb = opts;
+    opts = {};
+  }
 
-    opts = opts || {};
+  opts = opts || {};
 
-    function handleOutput (error, stdout, stderr) {
+  function handleOutput (error, stdout, stderr) {
         // wraps up any errors into a nice package and returns the json value.
-        if (opts.handleError && (error || stderr)) {
-            cb({
-                stdout: stdout,
-                stderr: [stderr, error].filter(v => !!v).join(''),
-                exitCode: error && error.code,
-                exitSignal: error && error.signal
-            });
-        }
-        else {
-            // if (stdout) console.log(stdout);
-            if (stderr) {
-                if (cb.length == 1) cb(stderr);
-                else throw new Error(stderr);
-            }
-            else if (error !== null) {
-                if (cb.length == 1) cb(error, stdout, stderr);
-                else throw error;
-            }
-            else {
-                cb();
-            }
-        }
+    if (opts.handleError && (error || stderr)) {
+      cb({
+        stdout: stdout,
+        stderr: [stderr, error].filter(v => !!v).join(''),
+        exitCode: error && error.code,
+        exitSignal: error && error.signal
+      });
     }
+    else {
+            // if (stdout) console.log(stdout);
+      if (stderr) {
+        if (cb.length == 1) cb(stderr);
+        else throw new Error(stderr);
+      }
+      else if (error !== null) {
+        if (cb.length == 1) cb(error, stdout, stderr);
+        else throw error;
+      }
+      else {
+        cb();
+      }
+    }
+  }
 
-    child_process.exec(command, opts, handleOutput);
+  child_process.exec(command, opts, handleOutput);
 };
 
 // mkdir -p
 function mkdirParentSync(dirPath, mode) {
-    var dirs = dirPath.split("/"), partialPath;
-    for (var idx = (dirPath[0] == '/' ? 1 : 0); idx < dirs.length; idx++) {
-        partialPath = dirs.slice(0, idx + 1).join("/");
-        if (!fs.existsSync(partialPath)) {
-            fs.mkdirSync(partialPath, mode);
-        }
+  var dirs = dirPath.split("/"), partialPath;
+  for (var idx = (dirPath[0] == '/' ? 1 : 0); idx < dirs.length; idx++) {
+    partialPath = dirs.slice(0, idx + 1).join("/");
+    if (!fs.existsSync(partialPath)) {
+      fs.mkdirSync(partialPath, mode);
     }
+  }
 }
 
 module.exports.mkdirParentSync = mkdirParentSync;
 
 // Infer the name of a file from a module or namespace declaration in the code
 function codeFileName(language, code, defaultFileName) {
-    if (config.moduleRegExs[language]) {
-        var fileExtensionMatch = (new RegExp('\\.' + config.fileExtensions[language] + '$')).exec(defaultFileName),
-            moduleMatch = config.moduleRegExs[language].exec(code);
+  if (config.moduleRegExs[language]) {
+    var fileExtensionMatch = (new RegExp('\\.' + config.fileExtensions[language] + '$')).exec(defaultFileName),
+      moduleMatch = config.moduleRegExs[language].exec(code);
 
-        if (moduleMatch !== null) {
-            return moduleMatch[1].replace(/\./g, '/').replace(/-/g, '_') + '.' + config.fileExtensions[language];
-        }
-        if (fileExtensionMatch !== null) {
-            return defaultFileName;
-        }
-        return defaultFileName + '.' + config.fileExtensions[language];
+    if (moduleMatch !== null) {
+      return moduleMatch[1].replace(/\./g, '/').replace(/-/g, '_') + '.' + config.fileExtensions[language];
     }
-    else {
-        return defaultFileName || language;
+    if (fileExtensionMatch !== null) {
+      return defaultFileName;
     }
+    return defaultFileName + '.' + config.fileExtensions[language];
+  }
+  else {
+    return defaultFileName || language;
+  }
 }
 
 module.exports.codeWriteSync = function (language, code, codeDir, defaultFileName, overwrite) {
-    var fileName = codeFileName(language, code, defaultFileName);
-    if (!(typeof fileName == 'string' || fileName instanceof String)) {
-        throw new Error("Could not determine valid name from code:\n\n" + code);
-    }
+  var fileName = codeFileName(language, code, defaultFileName);
+  if (!(typeof fileName == 'string' || fileName instanceof String)) {
+    throw new Error("Could not determine valid name from code:\n\n" + code);
+  }
 
-    if (!code) {
-        throw new Error("Code cannot be empty!");
-    }
+  if (!code) {
+    throw new Error("Code cannot be empty!");
+  }
 
-    return util.writeFileSync(codeDir, fileName, code, overwrite);
+  return util.writeFileSync(codeDir, fileName, code, overwrite);
 };
 
 module.exports.writeFileSync = function(dir, fileName, content, overwrite) {
-    overwrite = overwrite !== false;
-    fileName = path.join(dir || '/home/codewarrior', fileName);
+  overwrite = overwrite !== false;
+  fileName = path.join(dir || '/home/codewarrior', fileName);
 
-    if (fs.existsSync(fileName)) {
-        if (!overwrite) {
-            throw new Error(["Could not write code to file ", fileName,
-                " because file already exists:\n\n", content].join(""));
-        }
+  if (fs.existsSync(fileName)) {
+    if (!overwrite) {
+      throw new Error(["Could not write code to file ", fileName,
+        " because file already exists:\n\n", content].join(""));
     }
+  }
 
-    mkdirParentSync(path.dirname(fileName));
-    fs.writeFileSync(fileName, content);
-    return fileName;
+  mkdirParentSync(path.dirname(fileName));
+  fs.writeFileSync(fileName, content);
+  return fileName;
 }
 
 // writes multiple files. Also allows you to transform the content before it gets written. Files should be an object
 // with keys mapping to file names and values mapping to file content.
 module.exports.writeFilesSync = function(dir, files, overwrite, transform) {
-    if (files) {
-        Object.keys(files).forEach(function (fileName) {
-            var content = files[fileName];
-            if (transform) {
-                content = transform(fileName, content);
-            }
+  if (files) {
+    Object.keys(files).forEach(function (fileName) {
+      var content = files[fileName];
+      if (transform) {
+        content = transform(fileName, content);
+      }
 
-            util.writeFileSync(dir, fileName, content, overwrite);
-        });
-    }
+      util.writeFileSync(dir, fileName, content, overwrite);
+    });
+  }
 }

--- a/listen.js
+++ b/listen.js
@@ -1,13 +1,13 @@
 // this file is used to keep a image alive so that it can be pre-warmed and communicated with.
 var net = require('net'),
-    fs = require('fs');
+  fs = require('fs');
 
 // Creates a new TCP server. The handler argument is automatically set as a listener for the 'connection' event
 var server = net.createServer(function (socket) {
 
     // Every time someone connects, tell them hello and then close the connection.
-    console.log("Connection from " + socket.remoteAddress);
-    socket.end("Hello World\n");
+  console.log("Connection from " + socket.remoteAddress);
+  socket.end("Hello World\n");
 
 });
 

--- a/run.js
+++ b/run.js
@@ -1,63 +1,63 @@
 var run = require('./lib/runner').run,
-    opts = require("nomnom")
+  opts = require("nomnom")
         .options({
-            code: {
-              abbr: 'c',
-              help: 'code to run'
-            },
-            fixture: {
-                abbr: 'f',
-                help: 'Test fixture code to test with'
-            },
-            setup: {
-                abbr: 's',
-                help: 'Setup code to be used for executing the code'
-            },
-            language: {
-                abbr: 'l',
-                help: 'The language to execute the code in'
-            },
-            languageVersion: {
-                abbr: 'lv',
-                help: 'The language version that should be used'
-            },
-            testFramework: {
-                abbr: 't',
-                full: 'test-framework',
-                help: 'The language specific framework to run in'
-            },
-            shell: {
-                abbr: 'sh',
-                help: 'An optional shell script which will be ran within the sandbox environment before the code is executed'
-            },
-            timeout: {
-                help: 'The timeout to be used for running the code. If not specified a language specific default will be used'
-            },
-            format: {
-                help: 'The output format that will be returned. Options are "default" and "json"',
-                default: 'default',
-                choices: ['default', 'json'],
-                abbr: 'fmt'
-            },
-            services: {
-                abbr: 'srv',
-                help: 'Enable a set of services, such as redis or mongodb. Multiple options can be specified',
-                list: true,
-                choices: ['mongodb', 'redis']
-            },
-            debug: {
-                abbr: 'd',
-                help: 'Print debugging info',
-                flag: true
-            },
-            version: {
-                abbr: 'v',
-                flag: true,
-                help: 'Print version and exit',
-                callback: function () {
-                    return require('./lib/config').version;
-                }
+          code: {
+            abbr: 'c',
+            help: 'code to run'
+          },
+          fixture: {
+            abbr: 'f',
+            help: 'Test fixture code to test with'
+          },
+          setup: {
+            abbr: 's',
+            help: 'Setup code to be used for executing the code'
+          },
+          language: {
+            abbr: 'l',
+            help: 'The language to execute the code in'
+          },
+          languageVersion: {
+            abbr: 'lv',
+            help: 'The language version that should be used'
+          },
+          testFramework: {
+            abbr: 't',
+            full: 'test-framework',
+            help: 'The language specific framework to run in'
+          },
+          shell: {
+            abbr: 'sh',
+            help: 'An optional shell script which will be ran within the sandbox environment before the code is executed'
+          },
+          timeout: {
+            help: 'The timeout to be used for running the code. If not specified a language specific default will be used'
+          },
+          format: {
+            help: 'The output format that will be returned. Options are "default" and "json"',
+            default: 'default',
+            choices: ['default', 'json'],
+            abbr: 'fmt'
+          },
+          services: {
+            abbr: 'srv',
+            help: 'Enable a set of services, such as redis or mongodb. Multiple options can be specified',
+            list: true,
+            choices: ['mongodb', 'redis']
+          },
+          debug: {
+            abbr: 'd',
+            help: 'Print debugging info',
+            flag: true
+          },
+          version: {
+            abbr: 'v',
+            flag: true,
+            help: 'Print version and exit',
+            callback: function () {
+              return require('./lib/config').version;
             }
+          }
         })
         .help('This utility will run code in a specified language, using the specified testing suite.')
         .parse();

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,44 +1,44 @@
 var fs = require('fs'),
-    expect = require('chai').expect,
-    yaml = require('js-yaml'),
-    runner = require('../lib/runner');
+  expect = require('chai').expect,
+  yaml = require('js-yaml'),
+  runner = require('../lib/runner');
 
 module.exports.run = runner.run;
 
 // loops through the language specific examples within the examples.yml file and calls the cb function with each individual example
 function iterateCodeExamples(language, cb)  {
-    var examples = yaml.safeLoad(fs.readFileSync('./examples/' + language + '.yml', 'utf8'));
-    if (examples) {
-        for (var framework in examples) {
-            for (var example in examples[framework]) {
-                cb(framework, example, examples[framework][example]);
-            }
-        }
+  var examples = yaml.safeLoad(fs.readFileSync('./examples/' + language + '.yml', 'utf8'));
+  if (examples) {
+    for (var framework in examples) {
+      for (var example in examples[framework]) {
+        cb(framework, example, examples[framework][example]);
+      }
     }
+  }
 }
 
 module.exports.assertCodeExamples = function(language, version) {
-    describe('example challenges', function() {
-        iterateCodeExamples(language, function (framework, name, example) {
-            it ('should define an initial code block', function() {
-                expect(example.initial).to.be.a('string');
-            });
+  describe('example challenges', function() {
+    iterateCodeExamples(language, function (framework, name, example) {
+      it ('should define an initial code block', function() {
+        expect(example.initial).to.be.a('string');
+      });
 
-            it ('should have a passing ' + name + ' example', function(done) {
-                runner.run({
-                    language: language,
-                    languageVersion: version,
-                    setup: example.setup,
-                    code: example.answer,
-                    fixture: example.fixture,
-                    testFramework: framework
-                }, function(buffer) {
-                    expect(buffer.stdout).to.not.contain('<FAILED::>');
-                    expect(buffer.stdout).to.not.contain('<ERROR::>');
-                    if (buffer.stderr) console.log(buffer.stderr);
-                    done();
-                });
-            });
+      it ('should have a passing ' + name + ' example', function(done) {
+        runner.run({
+          language: language,
+          languageVersion: version,
+          setup: example.setup,
+          code: example.answer,
+          fixture: example.fixture,
+          testFramework: framework
+        }, function(buffer) {
+          expect(buffer.stdout).to.not.contain('<FAILED::>');
+          expect(buffer.stdout).to.not.contain('<ERROR::>');
+          if (buffer.stderr) console.log(buffer.stderr);
+          done();
         });
+      });
     });
+  });
 };

--- a/test/runners/c_spec.js
+++ b/test/runners/c_spec.js
@@ -2,45 +2,45 @@ var expect = require('chai').expect;
 var runner = require('../runner');
 
 describe('c runner', function() {
-describe('.run', function() {
+  describe('.run', function() {
     runner.assertCodeExamples('c');
 
     it('should handle basic code evaluation', function(done) {
-        var solution = `
+      var solution = `
                 #include <stdio.h>
 
                 int main() {
                   printf("Hello world");
                 }
                 `;
-        runner.run({
-            language: 'c',
-            code: solution
-        }, function(buffer) {
-            expect(buffer.stdout).to.equal("Hello world");
-            expect(buffer.exitCode).to.equal(0);
-            done();
-        });
+      runner.run({
+        language: 'c',
+        code: solution
+      }, function(buffer) {
+        expect(buffer.stdout).to.equal("Hello world");
+        expect(buffer.exitCode).to.equal(0);
+        done();
+      });
     });
     it('should get the return code', function(done) {
-        var solution = `
+      var solution = `
                 #include <stdlib.h>
 
                 int main() {
                   return 10;
                 }
                 `;
-        runner.run({
-            language: 'c',
-            code: solution
-        }, function(buffer) {
-            expect(buffer.exitCode).to.equal(10);
-            expect(buffer.exitSignal).to.equal(null);
-            done();
-        });
+      runner.run({
+        language: 'c',
+        code: solution
+      }, function(buffer) {
+        expect(buffer.exitCode).to.equal(10);
+        expect(buffer.exitSignal).to.equal(null);
+        done();
+      });
     });
     it('should catch return codes', function(done) {
-        var solution = `
+      var solution = `
                 #include <stdlib.h>
 
                 int main() {
@@ -49,101 +49,101 @@ describe('.run', function() {
                   return 0;
                 }
                 `;
-        runner.run({
-            language: 'c',
-            code: solution
-        }, function(buffer) {
-            expect(buffer.exitCode).to.equal(null);
-            expect(buffer.exitSignal).to.equal('SIGSEGV');
-            done();
-        });
+      runner.run({
+        language: 'c',
+        code: solution
+      }, function(buffer) {
+        expect(buffer.exitCode).to.equal(null);
+        expect(buffer.exitSignal).to.equal('SIGSEGV');
+        done();
+      });
     });
     it('should handle setup code and imports', function(done) {
-        runner.run({
-            language: 'c',
-            setup: `int square(int a) { return a * a ; }`,
-            code: `
+      runner.run({
+        language: 'c',
+        setup: `int square(int a) { return a * a ; }`,
+        code: `
                     #include <stdio.h>
                     int square(int);
 
                     int main() {
                       printf("%i",square(5));
                     }`
-        }, function(buffer) {
-            expect(buffer.stdout).to.equal('25');
-            done();
-        });
+      }, function(buffer) {
+        expect(buffer.stdout).to.equal('25');
+        done();
+      });
     });
     it('should handle compile errors', function(done) {
-        runner.run({
-            language: 'c',
-            code: `
+      runner.run({
+        language: 'c',
+        code: `
                 int main() {
                     fudge();
                     doubleFudge();
                 }
             `
-        }, function(buffer) {
-            expect(buffer.stderr).to.contain("undefined reference to `fudge\'");
-            expect(buffer.stderr).to.contain("undefined reference to `doubleFudge\'");
-            expect(buffer.stderr).to.contain("error: linker command failed with exit code 1");
-            done();
-        });
+      }, function(buffer) {
+        expect(buffer.stderr).to.contain("undefined reference to `fudge\'");
+        expect(buffer.stderr).to.contain("undefined reference to `doubleFudge\'");
+        expect(buffer.stderr).to.contain("error: linker command failed with exit code 1");
+        done();
+      });
     });
     describe('criterion test framework', function() {
-        it('should be able to run a basic test', function(done) {
-            runner.run({
-                language: 'c',
-                code: `int square(int a) { return a * a ; }`,
-                fixture: `#include <criterion/criterion.h>
+      it('should be able to run a basic test', function(done) {
+        runner.run({
+          language: 'c',
+          code: `int square(int a) { return a * a ; }`,
+          fixture: `#include <criterion/criterion.h>
                         int square(int);
 
                         Test(basic_test, should_square_a_number) {
                             cr_assert_eq(25,square(5));
                         }`
-            }, function(buffer) {
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                done();
-            });
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+          done();
         });
-        it('should handle setup code for a basic test', function(done) {
-            runner.run({
-                language: 'c',
-                setup: `int square(int a) { return a * a ; }`,
-                code: ' ',
-                fixture: `#include <criterion/criterion.h>
+      });
+      it('should handle setup code for a basic test', function(done) {
+        runner.run({
+          language: 'c',
+          setup: `int square(int a) { return a * a ; }`,
+          code: ' ',
+          fixture: `#include <criterion/criterion.h>
                         int square(int);
 
                         Test(test, square) {
                             cr_assert_eq(25,square(5));
                         }`
-            }, function(buffer) {
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                done();
-            });
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+          done();
         });
-        it('should handle basic failures', function(done) {
-            runner.run({
-                language: 'c',
-                code: `int square(int a) { return a * a ; }`,
-                fixture: `#include <criterion/criterion.h>
+      });
+      it('should handle basic failures', function(done) {
+        runner.run({
+          language: 'c',
+          code: `int square(int a) { return a * a ; }`,
+          fixture: `#include <criterion/criterion.h>
                         int square(int);
 
                         Test(basic_failure, should_raise_a_failure) {
                             cr_assert_eq(25,square(6));
                         }`
-            }, function(buffer) {
-                expect(buffer.stdout).to.contain('<FAILED::>');
-                expect(buffer.stdout).to.contain('The expression (25) == (square(6)) is false');
-                done();
-            });
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          expect(buffer.stdout).to.contain('The expression (25) == (square(6)) is false');
+          done();
         });
+      });
 
-        it('should support multiple asserts', function(done) {
-            runner.run({
-                language: 'c',
-                code: `int square(int a) { return a * a ; }`,
-                fixture: `#include <criterion/criterion.h>
+      it('should support multiple asserts', function(done) {
+        runner.run({
+          language: 'c',
+          code: `int square(int a) { return a * a ; }`,
+          fixture: `#include <criterion/criterion.h>
                         int square(int);
 
                         Test(multiple_assert_test, should_support_multiple_asserts) {
@@ -151,17 +151,17 @@ describe('.run', function() {
                             cr_assert_neq(36,square(5));
                             cr_assert_eq(36,square(5));
                         }`
-            }, function(buffer) {
-                expect(buffer.stdout.match(/<PASSED::>/g).length).to.equal(2);
-                expect(buffer.stdout.match(/<FAILED::>/g).length).to.equal(1);
-                done();
-            });
+        }, function(buffer) {
+          expect(buffer.stdout.match(/<PASSED::>/g).length).to.equal(2);
+          expect(buffer.stdout.match(/<FAILED::>/g).length).to.equal(1);
+          done();
         });
-        it('should support multiple tests on one suite', function(done) {
-            runner.run({
-                language: 'c',
-                code: `int square(int a) { return a * a ; }`,
-                fixture: `#include <criterion/criterion.h>
+      });
+      it('should support multiple tests on one suite', function(done) {
+        runner.run({
+          language: 'c',
+          code: `int square(int a) { return a * a ; }`,
+          fixture: `#include <criterion/criterion.h>
                         int square(int);
 
                         Test(square_test, should_square_a_number) {
@@ -173,18 +173,18 @@ describe('.run', function() {
                             cr_assert_eq(25,square(5));
                         }
                         `
-            }, function(buffer) {
-                expect(buffer.stdout.match(/<DESCRIBE::>/g).length).to.equal(1);
-                expect(buffer.stdout.match(/<IT::>/g).length).to.equal(2);
-                expect(buffer.stdout.match(/<PASSED::>/g).length).to.equal(3);
-                done();
-            });
+        }, function(buffer) {
+          expect(buffer.stdout.match(/<DESCRIBE::>/g).length).to.equal(1);
+          expect(buffer.stdout.match(/<IT::>/g).length).to.equal(2);
+          expect(buffer.stdout.match(/<PASSED::>/g).length).to.equal(3);
+          done();
         });
-        it('should support multiple test suites', function(done) {
-            runner.run({
-                language: 'c',
-                code: `int square(int a) { return a * a ; }`,
-                fixture: `#include <criterion/criterion.h>
+      });
+      it('should support multiple test suites', function(done) {
+        runner.run({
+          language: 'c',
+          code: `int square(int a) { return a * a ; }`,
+          fixture: `#include <criterion/criterion.h>
                         int square(int);
 
                         Test(basic_test, should_multiply) {
@@ -197,18 +197,18 @@ describe('.run', function() {
                             cr_assert_eq(36,square(5));
                         }
                         `
-            }, function(buffer) {
-                expect(buffer.stdout.match(/<DESCRIBE::>/g).length).to.equal(2);
-                expect(buffer.stdout.match(/<PASSED::>/g).length).to.equal(3);
-                expect(buffer.stdout.match(/<FAILED::>/g).length).to.equal(1);
-                done();
-            });
+        }, function(buffer) {
+          expect(buffer.stdout.match(/<DESCRIBE::>/g).length).to.equal(2);
+          expect(buffer.stdout.match(/<PASSED::>/g).length).to.equal(3);
+          expect(buffer.stdout.match(/<FAILED::>/g).length).to.equal(1);
+          done();
         });
-        it('should handle a crash', function(done) {
-            runner.run({
-                language: 'c',
-                code: ' ',
-                fixture: `
+      });
+      it('should handle a crash', function(done) {
+        runner.run({
+          language: 'c',
+          code: ' ',
+          fixture: `
                     #include <criterion/criterion.h>
 
                     Test(misc, crash_dereference) {
@@ -216,17 +216,17 @@ describe('.run', function() {
                         *i = 42; // CRASH: dereference i on writing
                     }
                     `
-            }, function(buffer) {
-                expect(buffer.stdout).to.contain('<FAILED::>Test Crashed');
-                expect(buffer.stdout).to.contain('<:LF:>Signal code: 11');
-                done();
-            });
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<FAILED::>Test Crashed');
+          expect(buffer.stdout).to.contain('<:LF:>Signal code: 11');
+          done();
         });
-        it('should handle a timeout', function(done) {
-            runner.run({
-                language: 'c',
-                code: ' ',
-                fixture: `
+      });
+      it('should handle a timeout', function(done) {
+        runner.run({
+          language: 'c',
+          code: ' ',
+          fixture: `
                     # include <unistd.h>
                     #include <criterion/criterion.h>
 
@@ -234,27 +234,27 @@ describe('.run', function() {
                         sleep(10);
                     }
                     `
-            }, function(buffer) {
-                expect(buffer.stdout).to.contain('<FAILED::>Test Timed Out');
-                done();
-            });
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<FAILED::>Test Timed Out');
+          done();
         });
-        it('should replace message line feeds', function(done) {
-            runner.run({
-                language: 'c',
-                code: ' ',
-                fixture: `
+      });
+      it('should replace message line feeds', function(done) {
+        runner.run({
+          language: 'c',
+          code: ' ',
+          fixture: `
                     #include <criterion/criterion.h>
 
                     Test(timeout, simple) {
                         cr_assert(0, "This message contains \\n 2 \\n line feeds");
                     }
                     `
-            }, function(buffer) {
-                expect(buffer.stdout.match(/<:LF:>/g).length).to.equal(2);
-                done();
-            });
+        }, function(buffer) {
+          expect(buffer.stdout.match(/<:LF:>/g).length).to.equal(2);
+          done();
         });
+      });
     });
-});
+  });
 });

--- a/test/runners/clojure_spec.js
+++ b/test/runners/clojure_spec.js
@@ -2,193 +2,193 @@ var expect = require('chai').expect;
 var runner = require('../runner');
 
 describe('clojure runner', function () {
-    describe('.run', function () {
-        it('should handle basic code evaluation', function (done) {
-            runner.run({
-                language: 'clojure',
-                code: '(println "42")'
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
-        it('should handle running a namespace with imports', function (done) {
-            runner.run({
-                language: 'clojure',
-                code: [
-                    '(ns foo (:require [clojure.edn :as edn]))',
-                    '(print (get (edn/read-string "{:code \\"wars\\"}") :code))'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.equal('wars');
-                done();
-            });
-        });
-        it('should handle setup code', function (done) {
-            runner.run({
-                language: 'clojure',
-                code: [
-                    '(ns foo.code-code (:require [foo.fighters]))',
-                    '(foo.fighters/everlong)'
-                ].join('\n'),
-                setup: [
-                    '(ns foo.fighters)',
-                    '(defn everlong [] (print "Hello, I\'ve waited here for you"))'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.equal('Hello, I\'ve waited here for you');
-                done();
-            });
-        });
+  describe('.run', function () {
+    it('should handle basic code evaluation', function (done) {
+      runner.run({
+        language: 'clojure',
+        code: '(println "42")'
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
     });
-    describe('codewars test framework (clojure.test)', function () {
-        it('should be able to run a basic test', function (done) {
-            runner.run({
-                language: 'clojure',
-                code: '(ns empty.namespace)',
-                fixture: [
-                    '(ns clojure.test.example (:use clojure.test))',
-                    '(deftest add-1-to-1 (testing "arithmetic works" (is (= 2 (+ 1 1)))))'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>add-1-to-1');
-                expect(buffer.stdout).to.contain('<IT::>arithmetic works');
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-                done();
-            });
-        });
-        it('should be able to fail', function (done) {
-            runner.run({
-                language: 'clojure',
-                code: '(ns empty.namespace)',
-                fixture: [
-                    '(ns clojure.test.example (:use clojure.test))',
-                    '(deftest sad-path (testing "won\'t work" (is (= 2 1) "bad math")))'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>sad-path');
-                expect(buffer.stdout).to.contain('<IT::>won\'t work');
-                expect(buffer.stdout).to.contain('<FAILED::>bad math');
-                expect(buffer.stdout).to.contain('expected: (= 2 1)');
-                expect(buffer.stdout).to.contain('actual: (not (= 2 1))');
-                done();
-            });
-        });
-        it('should print', function (done) {
-            runner.run({
-                language: 'clojure',
-                code: '(ns foo) (defn bar [] (print "yolo") 1)',
-                fixture: [
-                    '(ns clojure.test.example (:use clojure.test) (:require [foo]))',
-                    '(deftest printing (testing "foo/bar" (is (= 1 (foo/bar)))))'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>printing');
-                expect(buffer.stdout).to.contain('yolo<IT::>foo/bar');
-                expect(buffer.stdout).to.contain('\n<PASSED::>Test Passed');
-                expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-                done();
-            });
-        });
-        it('should have an error when there\'s an exception', function (done) {
-            runner.run({
-                language: 'clojure',
-                code: '(ns foo)',
-                fixture: [
-                    '(ns clojure.test.example (:use clojure.test))',
-                    '(deftest exception (testing "1 / 0" (is (= 1 (/ 1 0)))))'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>exception');
-                expect(buffer.stdout).to.contain('<IT::>1 / 0');
-                expect(buffer.stdout).to.contain('<ERROR::>');
-                expect(buffer.stdout).to.contain('expected: (= 1 (/ 1 0))');
-                expect(buffer.stdout).to.contain('actual: java.lang.ArithmeticException');
-                done();
-            });
-        });
-        it('should handle a typical kata', function (done) {
-            runner.run({
-                language: 'clojure',
-                code: [
-                    '(ns last (:refer-clojure :exclude [last]))',
-                    '(defn last [lst] (reduce #(do %2) lst))'
-                ].join('\n'),
-                fixture: [
-                    '(ns last-test',
-                    '  (:require [clojure.test :refer :all]',
-                    '            [last :as last])',
-                    '  (:refer-clojure :exclude [last]))',
-                    '(defn- last [lst] (reduce #(do %2) lst))',
-                    '(with-redefs',
-                    '  [clojure.core/last',
-                    '   (fn [& _] ',
-                    '     (throw (Exception. "Sorry! The last built-in is disabled for this kata!")))',
-                    '   clojure.core/take-last',
-                    '   (fn [& _] ',
-                    '     (throw (Exception. "Sorry! The take-last built-in is disabled for this kata!")))]',
-                    '  (deftest test-last-function',
-                    '    (let [input1 [1 9 13 1 99 9 9 13]',
-                    '          input2 (repeatedly (+ 5 (rand-int 10)) #(rand-int 100))',
-                    '          input3 "foop"]',
-                    '      (testing (prn-str input1)',
-                    '        (is (= (last/last input1) 13)))',
-                    '      (testing (prn-str input2)',
-                    '        (is (= (last/last input2) (last input2))))',
-                    '      (testing (str "String: " (prn-str input3))',
-                    '        (is (= (last/last input3) (last input3)))))))'
+    it('should handle running a namespace with imports', function (done) {
+      runner.run({
+        language: 'clojure',
+        code: [
+          '(ns foo (:require [clojure.edn :as edn]))',
+          '(print (get (edn/read-string "{:code \\"wars\\"}") :code))'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.equal('wars');
+        done();
+      });
+    });
+    it('should handle setup code', function (done) {
+      runner.run({
+        language: 'clojure',
+        code: [
+          '(ns foo.code-code (:require [foo.fighters]))',
+          '(foo.fighters/everlong)'
+        ].join('\n'),
+        setup: [
+          '(ns foo.fighters)',
+          '(defn everlong [] (print "Hello, I\'ve waited here for you"))'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.equal('Hello, I\'ve waited here for you');
+        done();
+      });
+    });
+  });
+  describe('codewars test framework (clojure.test)', function () {
+    it('should be able to run a basic test', function (done) {
+      runner.run({
+        language: 'clojure',
+        code: '(ns empty.namespace)',
+        fixture: [
+          '(ns clojure.test.example (:use clojure.test))',
+          '(deftest add-1-to-1 (testing "arithmetic works" (is (= 2 (+ 1 1)))))'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>add-1-to-1');
+        expect(buffer.stdout).to.contain('<IT::>arithmetic works');
+        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+        expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+        done();
+      });
+    });
+    it('should be able to fail', function (done) {
+      runner.run({
+        language: 'clojure',
+        code: '(ns empty.namespace)',
+        fixture: [
+          '(ns clojure.test.example (:use clojure.test))',
+          '(deftest sad-path (testing "won\'t work" (is (= 2 1) "bad math")))'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>sad-path');
+        expect(buffer.stdout).to.contain('<IT::>won\'t work');
+        expect(buffer.stdout).to.contain('<FAILED::>bad math');
+        expect(buffer.stdout).to.contain('expected: (= 2 1)');
+        expect(buffer.stdout).to.contain('actual: (not (= 2 1))');
+        done();
+      });
+    });
+    it('should print', function (done) {
+      runner.run({
+        language: 'clojure',
+        code: '(ns foo) (defn bar [] (print "yolo") 1)',
+        fixture: [
+          '(ns clojure.test.example (:use clojure.test) (:require [foo]))',
+          '(deftest printing (testing "foo/bar" (is (= 1 (foo/bar)))))'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>printing');
+        expect(buffer.stdout).to.contain('yolo<IT::>foo/bar');
+        expect(buffer.stdout).to.contain('\n<PASSED::>Test Passed');
+        expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+        done();
+      });
+    });
+    it('should have an error when there\'s an exception', function (done) {
+      runner.run({
+        language: 'clojure',
+        code: '(ns foo)',
+        fixture: [
+          '(ns clojure.test.example (:use clojure.test))',
+          '(deftest exception (testing "1 / 0" (is (= 1 (/ 1 0)))))'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>exception');
+        expect(buffer.stdout).to.contain('<IT::>1 / 0');
+        expect(buffer.stdout).to.contain('<ERROR::>');
+        expect(buffer.stdout).to.contain('expected: (= 1 (/ 1 0))');
+        expect(buffer.stdout).to.contain('actual: java.lang.ArithmeticException');
+        done();
+      });
+    });
+    it('should handle a typical kata', function (done) {
+      runner.run({
+        language: 'clojure',
+        code: [
+          '(ns last (:refer-clojure :exclude [last]))',
+          '(defn last [lst] (reduce #(do %2) lst))'
+        ].join('\n'),
+        fixture: [
+          '(ns last-test',
+          '  (:require [clojure.test :refer :all]',
+          '            [last :as last])',
+          '  (:refer-clojure :exclude [last]))',
+          '(defn- last [lst] (reduce #(do %2) lst))',
+          '(with-redefs',
+          '  [clojure.core/last',
+          '   (fn [& _] ',
+          '     (throw (Exception. "Sorry! The last built-in is disabled for this kata!")))',
+          '   clojure.core/take-last',
+          '   (fn [& _] ',
+          '     (throw (Exception. "Sorry! The take-last built-in is disabled for this kata!")))]',
+          '  (deftest test-last-function',
+          '    (let [input1 [1 9 13 1 99 9 9 13]',
+          '          input2 (repeatedly (+ 5 (rand-int 10)) #(rand-int 100))',
+          '          input3 "foop"]',
+          '      (testing (prn-str input1)',
+          '        (is (= (last/last input1) 13)))',
+          '      (testing (prn-str input2)',
+          '        (is (= (last/last input2) (last input2))))',
+          '      (testing (str "String: " (prn-str input3))',
+          '        (is (= (last/last input3) (last input3)))))))'
 
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>test-last-function');
-                expect(buffer.stdout).to.contain('<IT::>[1 9 13 1 99 9 9 13]');
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                done();
-            });
-        });
-        it('should fail fast', function (done) {
-            runner.run({
-                language: 'clojure',
-                code: '(ns empty.namespace)',
-                fixture: [
-                    '(ns clojure.test.example (:use clojure.test))',
-                    '(deftest fast-fail',
-                    '  (testing "quit early" (is (= 2 1) "not true"))',
-                    '  (testing "shouldn\'t happen" (is (= 3 1) "can\'t get here"))',
-                    ')'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>fast-fail');
-                expect(buffer.stdout).to.contain('<IT::>quit early');
-                expect(buffer.stdout).to.contain('<FAILED::>not true');
-                expect(buffer.stdout).to.contain('expected: (= 2 1)');
-                expect(buffer.stdout).to.contain('actual: (not (= 2 1))');
-                expect(buffer.stdout).to.not.contain("shouldn't happen");
-                expect(buffer.stdout).to.not.contain("can't get here");
-                done();
-            });
-        });
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>test-last-function');
+        expect(buffer.stdout).to.contain('<IT::>[1 9 13 1 99 9 9 13]');
+        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+        done();
+      });
     });
-    describe('potpourri', function () {
-        it('test framework should not think HOME is /root', function (done) {
-            runner.run({
-                language: 'clojure',
-                code: '(print (System/getenv "HOME"))'
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.not.equal('/root');
-                done();
-            });
-        });
+    it('should fail fast', function (done) {
+      runner.run({
+        language: 'clojure',
+        code: '(ns empty.namespace)',
+        fixture: [
+          '(ns clojure.test.example (:use clojure.test))',
+          '(deftest fast-fail',
+          '  (testing "quit early" (is (= 2 1) "not true"))',
+          '  (testing "shouldn\'t happen" (is (= 3 1) "can\'t get here"))',
+          ')'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>fast-fail');
+        expect(buffer.stdout).to.contain('<IT::>quit early');
+        expect(buffer.stdout).to.contain('<FAILED::>not true');
+        expect(buffer.stdout).to.contain('expected: (= 2 1)');
+        expect(buffer.stdout).to.contain('actual: (not (= 2 1))');
+        expect(buffer.stdout).to.not.contain("shouldn't happen");
+        expect(buffer.stdout).to.not.contain("can't get here");
+        done();
+      });
     });
+  });
+  describe('potpourri', function () {
+    it('test framework should not think HOME is /root', function (done) {
+      runner.run({
+        language: 'clojure',
+        code: '(print (System/getenv "HOME"))'
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.not.equal('/root');
+        done();
+      });
+    });
+  });
 });

--- a/test/runners/coffeescript_spec.js
+++ b/test/runners/coffeescript_spec.js
@@ -3,44 +3,44 @@ var runner = require('../runner');
 
 
 describe( 'coffeescript runner', function(){
-    describe( '.run', function(){
-        runner.assertCodeExamples('coffeescript');
+  describe( '.run', function(){
+    runner.assertCodeExamples('coffeescript');
 
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'coffeescript', code: 'console.log 42'}, function(buffer) {
-                expect(buffer.stdout ).to.equal('42\n');
-                done();
-            });
-        });
-
-        describe('cw-2', function() {
-            it( 'should handle a basic assertion', function(done){
-                runner.run({language: 'coffeescript', code: 'a = 1', fixture: 'Test.expect a == 1', testFramework: 'cw-2'}, function(buffer) {
-                    expect(buffer.stdout ).to.equal('<PASSED::>Test Passed\n');
-                    done();
-                });
-            });
-        });
-
-        it( 'should handle comments as fixture', function(done){
-            runner.run({language: 'coffeescript', code: 'console.log(42)', fixture: '#', testFramework: 'cw-2'}, function(buffer) {
-                expect(buffer.stdout ).to.equal('42\n');
-                done();
-            });
-        });
-
-        it( 'should handle a basic failed test', function(done){
-            runner.run({language: 'coffeescript', code: 'a = 1', fixture: 'Test.expect(a == 2)', testFramework: 'cw-2'}, function(buffer) {
-                expect(buffer.stdout ).to.equal('<FAILED::>Value is not what was expected\n');
-                done();
-            });
-        });
-
-        it( 'should handle logging objects', function(done){
-            runner.run({language: 'coffeescript', code:'console.log {a: 1}', testFramework: 'cw-2'}, function(buffer) {
-                expect(buffer.stdout ).to.equal('{ a: 1 }\n');
-                done();
-            });
-        });
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'coffeescript', code: 'console.log 42'}, function(buffer) {
+        expect(buffer.stdout ).to.equal('42\n');
+        done();
+      });
     });
+
+    describe('cw-2', function() {
+      it( 'should handle a basic assertion', function(done){
+        runner.run({language: 'coffeescript', code: 'a = 1', fixture: 'Test.expect a == 1', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout ).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
+    });
+
+    it( 'should handle comments as fixture', function(done){
+      runner.run({language: 'coffeescript', code: 'console.log(42)', fixture: '#', testFramework: 'cw-2'}, function(buffer) {
+        expect(buffer.stdout ).to.equal('42\n');
+        done();
+      });
+    });
+
+    it( 'should handle a basic failed test', function(done){
+      runner.run({language: 'coffeescript', code: 'a = 1', fixture: 'Test.expect(a == 2)', testFramework: 'cw-2'}, function(buffer) {
+        expect(buffer.stdout ).to.equal('<FAILED::>Value is not what was expected\n');
+        done();
+      });
+    });
+
+    it( 'should handle logging objects', function(done){
+      runner.run({language: 'coffeescript', code:'console.log {a: 1}', testFramework: 'cw-2'}, function(buffer) {
+        expect(buffer.stdout ).to.equal('{ a: 1 }\n');
+        done();
+      });
+    });
+  });
 });

--- a/test/runners/cpp_spec.js
+++ b/test/runners/cpp_spec.js
@@ -2,25 +2,25 @@ var expect = require('chai').expect;
 var runner = require('../runner');
 
 describe('cpp runner', function () {
-    describe('.run', function () {
-        runner.assertCodeExamples('cpp');
+  describe('.run', function () {
+    runner.assertCodeExamples('cpp');
 
-        it('should handle basic code evaluation', function (done) {
-            var code = `
+    it('should handle basic code evaluation', function (done) {
+      var code = `
                 #include <iostream>
                 int main() { 
                     printf("Hello World");
                 }
            `;
 
-            runner.run({language: 'cpp', code: code}, function (buffer) {
-                expect(buffer.stdout).to.equal("Hello World");
-                done();
-            });
-        });
+      runner.run({language: 'cpp', code: code}, function (buffer) {
+        expect(buffer.stdout).to.equal("Hello World");
+        done();
+      });
+    });
 
-        it('should handle C++11 nonsense', function (done) {
-            var code = `
+    it('should handle C++11 nonsense', function (done) {
+      var code = `
                 #include "stdio.h"
                 int main() {
                     auto f = []{ printf("Finally, lambdas in C++.  Now if we had typeclasses, purity and laziness we might have a reasonable functional programming language."); };
@@ -28,14 +28,14 @@ describe('cpp runner', function () {
                 }
             `;
 
-            runner.run({language: 'cpp', code: code}, function (buffer) {
-                expect(buffer.stdout).to.equal("Finally, lambdas in C++.  Now if we had typeclasses, purity and laziness we might have a reasonable functional programming language.");
-                done();
-            });
-        });
+      runner.run({language: 'cpp', code: code}, function (buffer) {
+        expect(buffer.stdout).to.equal("Finally, lambdas in C++.  Now if we had typeclasses, purity and laziness we might have a reasonable functional programming language.");
+        done();
+      });
+    });
 
-        it('should handle C++14 digit seperators', function (done) {
-            var code = `
+    it('should handle C++14 digit seperators', function (done) {
+      var code = `
                 #include <iostream>
                 int main() {
                     int x = 10'000'000;
@@ -43,50 +43,50 @@ describe('cpp runner', function () {
                 }
             `;
 
-            runner.run({language: 'cpp', code: code}, function (buffer) {
-                expect(buffer.stdout).to.equal("10000000\n");
-                done();
-            });
-        });
+      runner.run({language: 'cpp', code: code}, function (buffer) {
+        expect(buffer.stdout).to.equal("10000000\n");
+        done();
+      });
+    });
 
-        it('should handle compile errors', function (done) {
-            var code = `
+    it('should handle compile errors', function (done) {
+      var code = `
                 int main() {
                     fudge();
                     doubleFudge();
                 }
             `;
 
-            runner.run({language: 'cpp', code: code}, function (buffer) {
-                expect(buffer.stderr).to.contain("use of undeclared identifier \'fudge\'");
-                expect(buffer.stderr).to.contain("use of undeclared identifier \'doubleFudge\'");
-                expect(buffer.stderr).to.contain("2 errors generated.");
-                done();
-            });
-        });
+      runner.run({language: 'cpp', code: code}, function (buffer) {
+        expect(buffer.stderr).to.contain("use of undeclared identifier \'fudge\'");
+        expect(buffer.stderr).to.contain("use of undeclared identifier \'doubleFudge\'");
+        expect(buffer.stderr).to.contain("2 errors generated.");
+        done();
+      });
+    });
 
-        it('should handle setup code and imports', function (done) {
-            runner.run({
-                language: 'cpp',
-                setup: `
+    it('should handle setup code and imports', function (done) {
+      runner.run({
+        language: 'cpp',
+        setup: `
                     int square(int a) { return a * a ; }
                 `,
-                code: `
+        code: `
                     #include <iostream>
                     int main() {
                         std::cout << square(6);
                     }
                 `
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('36');
-                done();
-            });
-        });
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('36');
+        done();
+      });
+    });
 
-        it('should handle importing classes and member functions', function (done) {
-            runner.run({
-                language: 'cpp',
-                setup: `
+    it('should handle importing classes and member functions', function (done) {
+      runner.run({
+        language: 'cpp',
+        setup: `
                     #include <iostream>
                     class pizza {
                     public:
@@ -95,29 +95,29 @@ describe('cpp runner', function () {
                         }
                     };
                 `,
-                code: `
+        code: `
                     #include <iostream>
                     int main() {
                         pizza p;
                         std::cout << p.tastes();
                     }
                 `
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('good');
-                done();
-            });
-        });
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('good');
+        done();
+      });
+    });
 
-        describe('igloo bdd', function() {
-            it( 'should handle basic assertions', function(done){
-                runner.run({
-                    language: 'cpp',
-                    code: `
+    describe('igloo bdd', function() {
+      it( 'should handle basic assertions', function(done){
+        runner.run({
+          language: 'cpp',
+          code: `
                         unsigned int NumberOne() {
                             return 1;
                         }
                     `,
-                    fixture: `
+          fixture: `
                         Describe(basic_tests)
                         {
                           It(should_test_well)
@@ -126,21 +126,21 @@ describe('cpp runner', function () {
                           }
                         };
                     `
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
-                });
-            });
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          done();
+        });
+      });
 
-            it( 'should handle basic failures', function(done){
-                runner.run({
-                    language: 'cpp',
-                    code: `
+      it( 'should handle basic failures', function(done){
+        runner.run({
+          language: 'cpp',
+          code: `
                         unsigned int NumberOne() {
                             return 1;
                         }
                     `,
-                    fixture: `
+          fixture: `
                         Describe(basic_tests)
                         {
                           It(should_test_well)
@@ -149,17 +149,17 @@ describe('cpp runner', function () {
                           }
                         };
                     `
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    expect(buffer.stdout).to.contain('Expected: equal to 2<:LF:>Actual: 1');
-                    done();
-                });
-            });
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          expect(buffer.stdout).to.contain('Expected: equal to 2<:LF:>Actual: 1');
+          done();
+        });
+      });
 
-            it('should run test iterations in the order written (not alphabetical)', function(done) {
-                runner.run({
-                    language: 'cpp',
-                    code: `
+      it('should run test iterations in the order written (not alphabetical)', function(done) {
+        runner.run({
+          language: 'cpp',
+          code: `
                         char LetterA() {
                             return 'a';
                         }
@@ -170,7 +170,7 @@ describe('cpp runner', function () {
                             return 'c';
                         }
                     `,
-                    fixture: `
+          fixture: `
                         Describe(alphabetical_tests)
                         {
                           It(b_test)
@@ -187,26 +187,26 @@ describe('cpp runner', function () {
                           }
                         };
                     `
-                }, function(buffer) {
-                    var aIndex = buffer.stdout.indexOf("a_test");
-                    var bIndex = buffer.stdout.indexOf("b_test");
-                    var cIndex = buffer.stdout.indexOf("c_test");
-                    expect(bIndex).to.be.below(cIndex);
-                    expect(cIndex).to.be.below(aIndex);
-                    done();
-                });
-            })
+        }, function(buffer) {
+          var aIndex = buffer.stdout.indexOf("a_test");
+          var bIndex = buffer.stdout.indexOf("b_test");
+          var cIndex = buffer.stdout.indexOf("c_test");
+          expect(bIndex).to.be.below(cIndex);
+          expect(cIndex).to.be.below(aIndex);
+          done();
+        });
+      })
 
-            it( 'should record std output', function(done){
-                runner.run({
-                    language: 'cpp',
-                    code: `
+      it( 'should record std output', function(done){
+        runner.run({
+          language: 'cpp',
+          code: `
                         unsigned int NumberOne() {
                             std::cout << "Hello Codewars!" << std::endl;
                             return 1;
                         }
                     `,
-                    fixture: `
+          fixture: `
                         Describe(basic_tests)
                         {
                           It(should_test_well)
@@ -215,16 +215,16 @@ describe('cpp runner', function () {
                           }
                         };
                     `
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('Hello Codewars!');
-                    done();
-                });
-            });
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('Hello Codewars!');
+          done();
+        });
+      });
 
-            it('should work with the example two oldest ages', function(done) {
-                runner.run({
-                    language: 'cpp',
-                    code: `
+      it('should work with the example two oldest ages', function(done) {
+        runner.run({
+          language: 'cpp',
+          code: `
                         #include <list>
                         #include <iostream>
                         using namespace std;
@@ -243,7 +243,7 @@ describe('cpp runner', function () {
                             return list<int> {nextOldest, oldest};
                         }
                     `,
-                    fixture: `
+          fixture: `
                         list<int> results = two_oldest_ages({ 1, 5, 87, 45, 8, 8 });
                         Describe(two_oldest_ages_test)
                         {
@@ -257,23 +257,23 @@ describe('cpp runner', function () {
                             }
                         };
                     `
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>two_oldest_ages_test');
-                    expect(buffer.stdout).to.contain('<IT::>should_return_the_oldest');
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    expect(buffer.stdout).to.contain('<IT::>thing_inherit_from_base');
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
-                });
-            })
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>two_oldest_ages_test');
+          expect(buffer.stdout).to.contain('<IT::>should_return_the_oldest');
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          expect(buffer.stdout).to.contain('<IT::>thing_inherit_from_base');
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          done();
+        });
+      })
 
-            it('should only display errors once', function(done) {
-                runner.run({
-                    language: 'cpp',
-                    code: `
+      it('should only display errors once', function(done) {
+        runner.run({
+          language: 'cpp',
+          code: `
                         //
                     `,
-                    fixture: `
+          fixture: `
                         Describe(tests)
                         {
                             It(should_do_something_0)
@@ -290,18 +290,18 @@ describe('cpp runner', function () {
                             }
                         };
                     `
-                }, function(buffer) {
-                    expect(buffer.stdout.match(/Expected: equal to 2/g).length).to.equal(1);
-                    expect(buffer.stdout.match(/Expected: equal to 456/g).length).to.equal(1);
-                    expect(buffer.stdout.match(/Expected: equal to b/g).length).to.equal(1);
-                    done();
-                });
-            })
+        }, function(buffer) {
+          expect(buffer.stdout.match(/Expected: equal to 2/g).length).to.equal(1);
+          expect(buffer.stdout.match(/Expected: equal to 456/g).length).to.equal(1);
+          expect(buffer.stdout.match(/Expected: equal to b/g).length).to.equal(1);
+          done();
+        });
+      })
 
-            it('should work with the virtual bug fix example', function(done) {
-                runner.run({
-                    language: 'cpp',
-                    code: `
+      it('should work with the virtual bug fix example', function(done) {
+        runner.run({
+          language: 'cpp',
+          code: `
                         struct Entity {
                             int run() {
                                 return speed();
@@ -317,7 +317,7 @@ describe('cpp runner', function () {
                             }
                         };
                     `,
-                    fixture: `
+          fixture: `
                         Entity e;
                         Player p;
 
@@ -335,21 +335,21 @@ describe('cpp runner', function () {
                             }
                         };
                     `
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>entity');
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>player');
-                    expect(buffer.stdout).to.contain('<IT::>should_run_at_speed_5');
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    expect(buffer.stdout).to.contain('<IT::>should_run_at_speed_10');
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
-                });
-            })
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>entity');
+          expect(buffer.stdout).to.contain('<DESCRIBE::>player');
+          expect(buffer.stdout).to.contain('<IT::>should_run_at_speed_5');
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          expect(buffer.stdout).to.contain('<IT::>should_run_at_speed_10');
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          done();
+        });
+      })
 
-            it('should handle inheritance like a champ', function(done) {
-                runner.run({
-                    language: 'cpp',
-                    setup: `
+      it('should handle inheritance like a champ', function(done) {
+        runner.run({
+          language: 'cpp',
+          setup: `
                         class Base 
                         {
                         public: 
@@ -357,7 +357,7 @@ describe('cpp runner', function () {
                             int member_var = 42;
                         };
                     `,
-                    code: `
+          code: `
                         class Thing: public Base
                         {
                         public:
@@ -366,7 +366,7 @@ describe('cpp runner', function () {
                             }
                         };
                     `,
-                    fixture: `
+          fixture: `
                         Thing t;
                         Describe(inheritance_tests)
                         {
@@ -380,17 +380,17 @@ describe('cpp runner', function () {
                             }
                         };
                     `
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>inheritance_tests');
-                    expect(buffer.stdout).to.contain('<IT::>should_access_the_base_var');
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    expect(buffer.stdout).to.contain('<IT::>thing_inherit_from_base');
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
-                });
-            })
-
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>inheritance_tests');
+          expect(buffer.stdout).to.contain('<IT::>should_access_the_base_var');
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          expect(buffer.stdout).to.contain('<IT::>thing_inherit_from_base');
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          done();
         });
+      })
 
     });
+
+  });
 });

--- a/test/runners/crystal_spec.js
+++ b/test/runners/crystal_spec.js
@@ -3,59 +3,59 @@ var runner = require('../runner');
 
 
 describe('crystal runner', function () {
-    describe('.run', function () {
-        runner.assertCodeExamples('crystal');
+  describe('.run', function () {
+    runner.assertCodeExamples('crystal');
 
-        it('should handle basic code evaluation', function (done) {
-            runner.run({language: 'crystal', code: 'puts 42'}, function (buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
+    it('should handle basic code evaluation', function (done) {
+      runner.run({language: 'crystal', code: 'puts 42'}, function (buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
+    });
 
-        describe('spec', function () {
-            it('should handle a basic assertion', function (done) {
-                runner.run({language: 'crystal',
-                        code: 'a = 1',
-                        fixture: 'describe "test" do\n' +
+    describe('spec', function () {
+      it('should handle a basic assertion', function (done) {
+        runner.run({language: 'crystal',
+          code: 'a = 1',
+          fixture: 'describe "test" do\n' +
                         'it("test2") { 1.should eq(1)}\n' +
                         'end',
-                        testFramework: 'spec'}, function (buffer) {
-                        expect(buffer.stdout).to.include('<DESCRIBE::>test\n<IT::>test2\n<PASSED::>');
-                        done();
-                    }
+          testFramework: 'spec'}, function (buffer) {
+          expect(buffer.stdout).to.include('<DESCRIBE::>test\n<IT::>test2\n<PASSED::>');
+          done();
+        }
                 );
-            });
+      });
             
-            it('should handle a basic failed assertion', function (done) {
-                runner.run({language: 'crystal',
-                        code: 'a = 1',
-                        fixture: 'describe "test" do\n' +
+      it('should handle a basic failed assertion', function (done) {
+        runner.run({language: 'crystal',
+          code: 'a = 1',
+          fixture: 'describe "test" do\n' +
                         'it("test2") { 1.should eq(2)}\n' +
                         'end',
-                        testFramework: 'spec'}, function (buffer) {
-                        expect(buffer.stdout).to.contain('<DESCRIBE::>test\n<IT::>test2');
-                        expect(buffer.stdout).to.contain('<FAILED::>');
-                        expect(buffer.stdout).to.not.contain('<PASSED::>');
-                        done();
-                    }
+          testFramework: 'spec'}, function (buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>test\n<IT::>test2');
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          expect(buffer.stdout).to.not.contain('<PASSED::>');
+          done();
+        }
                 );
-            });
-            it('should handle errored code', function (done) {
-                runner.run({language: 'crystal',
-                        code: 'A = 1',
-                        fixture: 'describe "test" do\n' +
+      });
+      it('should handle errored code', function (done) {
+        runner.run({language: 'crystal',
+          code: 'A = 1',
+          fixture: 'describe "test" do\n' +
                         'it("test2") { A.should eq 1 }\n' +
                         'it("test2") { A.idontexist()}\n' +
                         'end',
-                        testFramework: 'spec'}, function (buffer) {
-                        expect(buffer.stdout).to.eq('');
-                        expect(buffer.stderr).to.contain('undefined method');
-                        done();
-                    }
+          testFramework: 'spec'}, function (buffer) {
+          expect(buffer.stdout).to.eq('');
+          expect(buffer.stderr).to.contain('undefined method');
+          done();
+        }
                 );
-            });
-        });
+      });
     });
+  });
 
 });

--- a/test/runners/csharp_spec.js
+++ b/test/runners/csharp_spec.js
@@ -1,101 +1,101 @@
 var expect = require('chai').expect,
-    runner = require('../runner'),
-    fs = require('fs');
+  runner = require('../runner'),
+  fs = require('fs');
 
 describe( 'c# runner', function() {
-    describe( '.run', function() {
-        runner.assertCodeExamples('csharp');
+  describe( '.run', function() {
+    runner.assertCodeExamples('csharp');
 
-        it('should handle basic code evaluation', function (done) {
-            runner.run({language: 'csharp',
-                code: 'public class Hello1 { public static void Main() { System.Console.WriteLine("Hello, World!");}}'
-            }, function (buffer)
+    it('should handle basic code evaluation', function (done) {
+      runner.run({language: 'csharp',
+        code: 'public class Hello1 { public static void Main() { System.Console.WriteLine("Hello, World!");}}'
+      }, function (buffer)
             {
                 //console.log(buffer);
-                expect(buffer.stdout).to.contain('Hello, World!\n');
-                done();
-            });
-        });
+        expect(buffer.stdout).to.contain('Hello, World!\n');
+        done();
+      });
+    });
 
-        it('should handle setup', function (done) {
-            runner.run({language: 'csharp',
-                setup: 'public class Preloaded { public static string hello = "Hello, World!"; }',
-                code: 'public class Hello1 { public static void Main() { System.Console.WriteLine(Preloaded.hello);}}'
-            }, function (buffer)
+    it('should handle setup', function (done) {
+      runner.run({language: 'csharp',
+        setup: 'public class Preloaded { public static string hello = "Hello, World!"; }',
+        code: 'public class Hello1 { public static void Main() { System.Console.WriteLine(Preloaded.hello);}}'
+      }, function (buffer)
             {
-                expect(buffer.stdout).to.contain('Hello, World!\n');
-                done();
-            });
-        });
+        expect(buffer.stdout).to.contain('Hello, World!\n');
+        done();
+      });
+    });
 
-        it('should handle basic nunit tests', function (done) {
-            runner.run({ language: 'csharp',
-                code: 'namespace Bank { using System; public class Account { private decimal balance; public void Deposit(decimal amount) { Console.WriteLine("slorgs"); balance += amount; } public void Withdraw(decimal amount) { balance -= amount; } public void TransferFunds(Account destination, decimal amount) { } public decimal Balance { get { return balance; } } } } ',
-                fixture: 'namespace Bank { using NUnit.Framework; [TestFixture] public class AccountTest { [Test] public void TransferFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); source.TransferFunds(destination, 100m); Assert.AreEqual(250m, destination.Balance); Assert.AreEqual(100m, source.Balance); } [Test] public void CheckFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); Assert.AreEqual(200m, source.Balance); } } } ' }, function (buffer)
+    it('should handle basic nunit tests', function (done) {
+      runner.run({ language: 'csharp',
+        code: 'namespace Bank { using System; public class Account { private decimal balance; public void Deposit(decimal amount) { Console.WriteLine("slorgs"); balance += amount; } public void Withdraw(decimal amount) { balance -= amount; } public void TransferFunds(Account destination, decimal amount) { } public decimal Balance { get { return balance; } } } } ',
+        fixture: 'namespace Bank { using NUnit.Framework; [TestFixture] public class AccountTest { [Test] public void TransferFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); source.TransferFunds(destination, 100m); Assert.AreEqual(250m, destination.Balance); Assert.AreEqual(100m, source.Balance); } [Test] public void CheckFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); Assert.AreEqual(200m, source.Balance); } } } ' }, function (buffer)
             {
                 //console.log(buffer);
-                expect(buffer.stdout).to.contain("slorgs");
-                expect(buffer.stdout).to.contain("<PASSED::>");
-                expect(buffer.stdout).to.contain("<FAILED::>");
-                expect(buffer.stdout).to.contain("<DESCRIBE::>");
-                expect(buffer.stdout).to.contain("<IT::>");
-                done();
-            });
-        });
+        expect(buffer.stdout).to.contain("slorgs");
+        expect(buffer.stdout).to.contain("<PASSED::>");
+        expect(buffer.stdout).to.contain("<FAILED::>");
+        expect(buffer.stdout).to.contain("<DESCRIBE::>");
+        expect(buffer.stdout).to.contain("<IT::>");
+        done();
+      });
+    });
 
-        it('should handle bad code', function (done) {
-            runner.run({ language: 'csharp',
-                code: 'namespace Bank { using System; using System.Drawing; public class Account { private decimal balance; public void Deposit(decimal amount) { Console.WriteLine("slorgs"); balance += amount; } public void Withdraw(decimal amount) { balance -= Amount; } public void TransferFunds(Account destination, decimal amount) { } public decimal Balance { get { return balance; } } } } ',
-                fixture: 'namespace Bank { using NUnit.Framework; [TestFixture] public class AccountTest { [Test] public void TransferFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); source.TransferFunds(destination, 100m); Assert.AreEqual(250m, destination.Balance); Assert.AreEqual(100m, source.Balance); } [Test] public void CheckFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); Assert.AreEqual(200m, source.Balance); } } } ' }, function (buffer)
+    it('should handle bad code', function (done) {
+      runner.run({ language: 'csharp',
+        code: 'namespace Bank { using System; using System.Drawing; public class Account { private decimal balance; public void Deposit(decimal amount) { Console.WriteLine("slorgs"); balance += amount; } public void Withdraw(decimal amount) { balance -= Amount; } public void TransferFunds(Account destination, decimal amount) { } public decimal Balance { get { return balance; } } } } ',
+        fixture: 'namespace Bank { using NUnit.Framework; [TestFixture] public class AccountTest { [Test] public void TransferFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); source.TransferFunds(destination, 100m); Assert.AreEqual(250m, destination.Balance); Assert.AreEqual(100m, source.Balance); } [Test] public void CheckFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); Assert.AreEqual(200m, source.Balance); } } } ' }, function (buffer)
             {
-                console.log(buffer);
-                expect(buffer.stdout).to.not.contain("lib/runners/csharp.js");
-                expect(buffer.stderr).to.contain("does not exist in the current context");
-                done();
-            });
-        });
+        console.log(buffer);
+        expect(buffer.stdout).to.not.contain("lib/runners/csharp.js");
+        expect(buffer.stderr).to.contain("does not exist in the current context");
+        done();
+      });
+    });
 
-        it('should handle compilation errors with clean output', function (done) {
-            runner.run({
-                language: 'csharp',
-                format: 'json',
-                code: 'public class CheckChoose{ public static void Main(){} public static long Checkchoose(long m, int n){}}'
-            }, function (buffer)
+    it('should handle compilation errors with clean output', function (done) {
+      runner.run({
+        language: 'csharp',
+        format: 'json',
+        code: 'public class CheckChoose{ public static void Main(){} public static long Checkchoose(long m, int n){}}'
+      }, function (buffer)
             {
                 // console.log(buffer);
-                console.log('');
-                expect(buffer.stdout).to.not.contain('stdout');
-                expect(buffer.stderr).to.not.contain('stdout');
-                expect(buffer.stderr).to.not.equal('');
-                done();
-            });
-        });
+        console.log('');
+        expect(buffer.stdout).to.not.contain('stdout');
+        expect(buffer.stderr).to.not.contain('stdout');
+        expect(buffer.stderr).to.not.equal('');
+        done();
+      });
+    });
 
-        it('should handle partially passed code', function (done) {
-            runner.run({ language: 'csharp',
-                code: 'using System; public class Account { } ',
-                fixture: 'using NUnit.Framework; [TestFixture] public class AccountTest { [Test] public void A() { Assert.AreEqual(1, 1); } [Test] public void Z() { Assert.AreEqual(1, 1); throw new System.Exception(); } } ' }, function (buffer)
+    it('should handle partially passed code', function (done) {
+      runner.run({ language: 'csharp',
+        code: 'using System; public class Account { } ',
+        fixture: 'using NUnit.Framework; [TestFixture] public class AccountTest { [Test] public void A() { Assert.AreEqual(1, 1); } [Test] public void Z() { Assert.AreEqual(1, 1); throw new System.Exception(); } } ' }, function (buffer)
             {
-                expect(buffer.stdout).to.contain("<ERROR::>");
-                done();
-            });
-        });
+        expect(buffer.stdout).to.contain("<ERROR::>");
+        done();
+      });
+    });
 
-        it('should handle project mode', function (done) {
-            runner.run({ language: 'csharp',
+    it('should handle project mode', function (done) {
+      runner.run({ language: 'csharp',
                 // references: ['SkiaSharp.dll'],
-                files: {
-                    'foo.sh': 'test',
-                    'solution.cs': 'namespace Bank { using System; public class Account { private decimal balance; public void Deposit(decimal amount) { Console.WriteLine("slorgs"); balance += amount; } public void Withdraw(decimal amount) { balance -= amount; } public void TransferFunds(Account destination, decimal amount) { } public decimal Balance { get { return balance; } } } } ',
-                    'spec.cs': 'namespace Bank { using NUnit.Framework; [TestFixture] public class AccountTest { [Test] public void TransferFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); source.TransferFunds(destination, 100m); Assert.AreEqual(250m, destination.Balance); Assert.AreEqual(100m, source.Balance); } [Test] public void CheckFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); Assert.AreEqual(200m, source.Balance); } } } '
-                }
-            }, function (buffer)
+        files: {
+          'foo.sh': 'test',
+          'solution.cs': 'namespace Bank { using System; public class Account { private decimal balance; public void Deposit(decimal amount) { Console.WriteLine("slorgs"); balance += amount; } public void Withdraw(decimal amount) { balance -= amount; } public void TransferFunds(Account destination, decimal amount) { } public decimal Balance { get { return balance; } } } } ',
+          'spec.cs': 'namespace Bank { using NUnit.Framework; [TestFixture] public class AccountTest { [Test] public void TransferFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); source.TransferFunds(destination, 100m); Assert.AreEqual(250m, destination.Balance); Assert.AreEqual(100m, source.Balance); } [Test] public void CheckFunds() { Account source = new Account(); source.Deposit(200m); Account destination = new Account(); destination.Deposit(150m); Assert.AreEqual(200m, source.Balance); } } } '
+        }
+      }, function (buffer)
             {
                 //console.log(buffer);
-                expect(buffer.stdout).to.contain("slorgs");
-                expect(buffer.stdout).to.contain("<PASSED::>");
-                done();
-            });
-        });
+        expect(buffer.stdout).to.contain("slorgs");
+        expect(buffer.stdout).to.contain("<PASSED::>");
+        done();
+      });
     });
+  });
 });

--- a/test/runners/elixir_spec.js
+++ b/test/runners/elixir_spec.js
@@ -2,101 +2,101 @@ var expect = require('chai').expect;
 var runner = require('../runner');
 
 describe('elixir runner', function() {
-    describe('.run', function() {
-        runner.assertCodeExamples('elixir');
+  describe('.run', function() {
+    runner.assertCodeExamples('elixir');
 
-        it('handles basic code evaluation', function(done) {
-            runner.run({language: 'elixir', code: 'IO.puts "This was real. And it was me. I had lived that life, and I had died that death. I was staring at the very end of me. ― Hilary Duff, Elixir (2010)"'}, function(buffer) {
-                expect(buffer.stdout).to.contain('This was real');
-                done();
-            });
+    it('handles basic code evaluation', function(done) {
+      runner.run({language: 'elixir', code: 'IO.puts "This was real. And it was me. I had lived that life, and I had died that death. I was staring at the very end of me. ― Hilary Duff, Elixir (2010)"'}, function(buffer) {
+        expect(buffer.stdout).to.contain('This was real');
+        done();
+      });
+    });
+
+    describe('ex_unit', function() {
+      it('handles a simple test unit defininition', function(done) {
+        runner.run({language: 'elixir', code: 'defmodule AEqual1 do\n def a, do: 1\nend', fixture: 'defmodule TestAEqual1 do\nuse ExUnit.Case\nimport AEqual1, only: [a: 0]\ntest "a is equal 1" do\nassert a() == 1\nend\nend', testFramework: 'ex_unit'}, function(buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>TestAEqual1');
+          expect(buffer.stdout).to.contain('<IT::>a is equal 1\n<PASSED::>Test Passed\n');
+          expect(buffer.stdout).to.match(/<COMPLETEDIN::>Finished in [0-9.]+ seconds \([0-9.]+s on load, [0-9.]+s on tests\)/);
+          done();
         });
+      });
+      it('handles test unit with a couple of defininitions', function(done) {
+        runner.run({language: 'elixir', code: 'defmodule YesNo do\n def yes, do: "yes"\n def no, do: "no"\nend', fixture: 'defmodule TestYesNo do\nuse ExUnit.Case\ntest ".yes is yes" do\nassert YesNo.yes == "yes"\nend\ntest ".no is no" do\nassert YesNo.no == "no"\nend\nend', testFramework: 'ex_unit'}, function(buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>TestYesNo');
+          expect(buffer.stdout).to.contain('<IT::>.yes is yes\n<PASSED::>Test Passed\n');
+          expect(buffer.stdout).to.contain('<IT::>.no is no\n<PASSED::>Test Passed\n');
+          expect(buffer.stdout).to.match(/<COMPLETEDIN::>Finished in [0-9.]+ seconds \([0-9.]+s on load, [0-9.]+s on tests\)/);
+          done();
+        });
+      });
+      it('handles test which does not pass', function(done) {
+        runner.run({language: 'elixir', code: 'defmodule NotPass do\n def can_i_enter?, do: :no\nend', fixture: 'defmodule TestNotPass do\nuse ExUnit.Case\ntest "passes if works" do\nassert NotPass.can_i_enter? == :yes\nend\nend', testFramework: 'ex_unit'}, function(buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>TestNotPass');
+          expect(buffer.stdout).to.contain('<IT::>passes if works\n<FAILED::>passes if works');
+          expect(buffer.stdout).to.match(/<COMPLETEDIN::>Finished in [0-9.]+ seconds \([0-9.]+s on load, [0-9.]+s on tests\)/);
+          done();
+        });
+      });
+      it('handles test unit with pass and not-pass tests', function(done) {
+        runner.run({language: 'elixir', code: 'defmodule YesBrokenNo do\n def yes, do: "yes"\n def no, do: "yes"\nend', fixture: 'defmodule TestYesBrokenNo do\nuse ExUnit.Case\ntest ".yes is yes" do\nassert YesBrokenNo.yes == "yes"\nend\ntest ".no is no" do\nassert YesBrokenNo.no == "no"\nend\nend', testFramework: 'ex_unit'}, function(buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>TestYesBrokenNo');
+          expect(buffer.stdout).to.contain('<IT::>.yes is yes\n<PASSED::>Test Passed\n');
+          expect(buffer.stdout).to.contain('<IT::>.no is no\n<FAILED::>.no is no');
+          expect(buffer.stdout).to.match(/<COMPLETEDIN::>Finished in [0-9.]+ seconds \([0-9.]+s on load, [0-9.]+s on tests\)/);
+          done();
+        });
+      });
 
-        describe('ex_unit', function() {
-            it('handles a simple test unit defininition', function(done) {
-                runner.run({language: 'elixir', code: 'defmodule AEqual1 do\n def a, do: 1\nend', fixture: 'defmodule TestAEqual1 do\nuse ExUnit.Case\nimport AEqual1, only: [a: 0]\ntest "a is equal 1" do\nassert a() == 1\nend\nend', testFramework: 'ex_unit'}, function(buffer) {
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestAEqual1');
-                    expect(buffer.stdout).to.contain('<IT::>a is equal 1\n<PASSED::>Test Passed\n');
-                    expect(buffer.stdout).to.match(/<COMPLETEDIN::>Finished in [0-9.]+ seconds \([0-9.]+s on load, [0-9.]+s on tests\)/);
-                    done();
-                });
-            });
-            it('handles test unit with a couple of defininitions', function(done) {
-                runner.run({language: 'elixir', code: 'defmodule YesNo do\n def yes, do: "yes"\n def no, do: "no"\nend', fixture: 'defmodule TestYesNo do\nuse ExUnit.Case\ntest ".yes is yes" do\nassert YesNo.yes == "yes"\nend\ntest ".no is no" do\nassert YesNo.no == "no"\nend\nend', testFramework: 'ex_unit'}, function(buffer) {
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestYesNo');
-                    expect(buffer.stdout).to.contain('<IT::>.yes is yes\n<PASSED::>Test Passed\n');
-                    expect(buffer.stdout).to.contain('<IT::>.no is no\n<PASSED::>Test Passed\n');
-                    expect(buffer.stdout).to.match(/<COMPLETEDIN::>Finished in [0-9.]+ seconds \([0-9.]+s on load, [0-9.]+s on tests\)/);
-                    done();
-                });
-            });
-            it('handles test which does not pass', function(done) {
-                runner.run({language: 'elixir', code: 'defmodule NotPass do\n def can_i_enter?, do: :no\nend', fixture: 'defmodule TestNotPass do\nuse ExUnit.Case\ntest "passes if works" do\nassert NotPass.can_i_enter? == :yes\nend\nend', testFramework: 'ex_unit'}, function(buffer) {
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestNotPass');
-                    expect(buffer.stdout).to.contain('<IT::>passes if works\n<FAILED::>passes if works');
-                    expect(buffer.stdout).to.match(/<COMPLETEDIN::>Finished in [0-9.]+ seconds \([0-9.]+s on load, [0-9.]+s on tests\)/);
-                    done();
-                });
-            });
-            it('handles test unit with pass and not-pass tests', function(done) {
-                runner.run({language: 'elixir', code: 'defmodule YesBrokenNo do\n def yes, do: "yes"\n def no, do: "yes"\nend', fixture: 'defmodule TestYesBrokenNo do\nuse ExUnit.Case\ntest ".yes is yes" do\nassert YesBrokenNo.yes == "yes"\nend\ntest ".no is no" do\nassert YesBrokenNo.no == "no"\nend\nend', testFramework: 'ex_unit'}, function(buffer) {
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestYesBrokenNo');
-                    expect(buffer.stdout).to.contain('<IT::>.yes is yes\n<PASSED::>Test Passed\n');
-                    expect(buffer.stdout).to.contain('<IT::>.no is no\n<FAILED::>.no is no');
-                    expect(buffer.stdout).to.match(/<COMPLETEDIN::>Finished in [0-9.]+ seconds \([0-9.]+s on load, [0-9.]+s on tests\)/);
-                    done();
-                });
-            });
+      describe('compilation errors', function() {
+        it('catches compilation error of the code module', function(done) {
+          runner.run({language: 'elixir', code: 'defodule BrokenModule do\n def broken, do: true\nend', fixture: 'defmodule TestBrokenModule do\nend', testFramework: 'ex_unit'}, function(buffer) {
+            console.log(buffer)
+            expect(buffer.stdout).to.contain('<ERROR::>solution:1: undefined function defodule/2\n');
+            done();
+          });
+        });
+        it('catches compilation error of the fixture module', function(done) {
+          runner.run({language: 'elixir', code: 'defmodule BrokenFixture do\n def broken, do: true\nend', fixture: 'defmodule TestBrokenFixture do\n -> hanging_arrow \n end', testFramework: 'ex_unit'}, function(buffer) {
+            expect(buffer.stdout).to.contain('<ERROR::>fixture:2: unhandled operator ->');
+            done();
+          });
+        });
+      });
 
-            describe('compilation errors', function() {
-              it('catches compilation error of the code module', function(done) {
-                  runner.run({language: 'elixir', code: 'defodule BrokenModule do\n def broken, do: true\nend', fixture: 'defmodule TestBrokenModule do\nend', testFramework: 'ex_unit'}, function(buffer) {
-                      console.log(buffer)
-                      expect(buffer.stdout).to.contain('<ERROR::>solution:1: undefined function defodule/2\n');
-                      done();
-                  });
-              });
-              it('catches compilation error of the fixture module', function(done) {
-                  runner.run({language: 'elixir', code: 'defmodule BrokenFixture do\n def broken, do: true\nend', fixture: 'defmodule TestBrokenFixture do\n -> hanging_arrow \n end', testFramework: 'ex_unit'}, function(buffer) {
-                      expect(buffer.stdout).to.contain('<ERROR::>fixture:2: unhandled operator ->');
-                      done();
-                  });
-              });
-            });
-
-            describe('runtime errors', function() {
-              it('catches runtime error of the code module', function(done) {
-                  runner.run({language: 'elixir', code: 'defmodule RuntimeIssue do\n def make_issue do\n 5 = 8\nend\nend', fixture: 'defmodule TestRuntimeIssue do\nuse ExUnit.Case\ntest "have runtime issue" do\n RuntimeIssue.make_issue \nend\nend', testFramework: 'ex_unit'}, function(buffer) {
-                      expect(buffer.stdout).to.contain('<DESCRIBE::>TestRuntimeIssue');
-                      expect(buffer.stdout).to.contain('<IT::>have runtime issue\n<FAILED::>have runtime issue');
-                      done();
-                  });
-              });
-              it('catches runtime error of the fixture module', function(done) {
-                  runner.run({language: 'elixir', code: 'defmodule FixtureIssue do\n def no_issue do\n :no_issue\nend\nend', fixture: 'defmodule TestFixtureIssue do\nuse ExUnit.Case\ntest "have fixture issue" do\n ModuleNotExist.call_it() \nend\nend', testFramework: 'ex_unit'}, function(buffer) {
-                      expect(buffer.stdout).to.contain('<DESCRIBE::>TestFixtureIssue');
-                      expect(buffer.stdout).to.contain('<IT::>have fixture issue\n<FAILED::>have fixture issue');
-                      done();
-                  });
-              });
-            });
+      describe('runtime errors', function() {
+        it('catches runtime error of the code module', function(done) {
+          runner.run({language: 'elixir', code: 'defmodule RuntimeIssue do\n def make_issue do\n 5 = 8\nend\nend', fixture: 'defmodule TestRuntimeIssue do\nuse ExUnit.Case\ntest "have runtime issue" do\n RuntimeIssue.make_issue \nend\nend', testFramework: 'ex_unit'}, function(buffer) {
+            expect(buffer.stdout).to.contain('<DESCRIBE::>TestRuntimeIssue');
+            expect(buffer.stdout).to.contain('<IT::>have runtime issue\n<FAILED::>have runtime issue');
+            done();
+          });
+        });
+        it('catches runtime error of the fixture module', function(done) {
+          runner.run({language: 'elixir', code: 'defmodule FixtureIssue do\n def no_issue do\n :no_issue\nend\nend', fixture: 'defmodule TestFixtureIssue do\nuse ExUnit.Case\ntest "have fixture issue" do\n ModuleNotExist.call_it() \nend\nend', testFramework: 'ex_unit'}, function(buffer) {
+            expect(buffer.stdout).to.contain('<DESCRIBE::>TestFixtureIssue');
+            expect(buffer.stdout).to.contain('<IT::>have fixture issue\n<FAILED::>have fixture issue');
+            done();
+          });
+        });
+      });
             
-            describe('no fixtures', function() {
+      describe('no fixtures', function() {
               // Due to ExUnit.start, it can add COMPLETEDIN:: at the end.
               // That's why we match with .contain and not .equal
-              it('handles correctly empty fixture', function(done) {
-                  runner.run({language: 'elixir', code: 'IO.puts "Hello"', fixture: '', testFramework: 'ex_unit'}, function(buffer) {
-                      expect(buffer.stdout).to.contain('Hello\n');
-                      done();
-                  });
-              });
-              it('handles correctly fixture with just comments', function(done) {
-                  runner.run({language: 'elixir', code: 'IO.puts "Hello comment"', fixture: '# this is comment', testFramework: 'ex_unit'}, function(buffer) {
-                      expect(buffer.stdout).to.contain('Hello comment\n');
-                      done();
-                  });
-              });
-            });
+        it('handles correctly empty fixture', function(done) {
+          runner.run({language: 'elixir', code: 'IO.puts "Hello"', fixture: '', testFramework: 'ex_unit'}, function(buffer) {
+            expect(buffer.stdout).to.contain('Hello\n');
+            done();
+          });
         });
+        it('handles correctly fixture with just comments', function(done) {
+          runner.run({language: 'elixir', code: 'IO.puts "Hello comment"', fixture: '# this is comment', testFramework: 'ex_unit'}, function(buffer) {
+            expect(buffer.stdout).to.contain('Hello comment\n');
+            done();
+          });
+        });
+      });
     });
+  });
 });

--- a/test/runners/erlang_spec.js
+++ b/test/runners/erlang_spec.js
@@ -2,59 +2,59 @@ var expect = require('chai').expect;
 var runner = require('../runner');
 
 describe('erlang runner', function () {
-    describe('.run', function () {
-        it('should handle setup code and imports', function (done) {
-            runner.run({
-                language: 'erlang',
-                setup: [
-                    '-module(foo).',
-                    '-export([bar/0]).',
-                    'bar() -> io:format("baz").'
-                ].join('\n'),
-                code: [
-                    'foo:bar(), init:stop().'
-                ].join('\n')
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('baz');
-                done();
-            });
-        });
-        it('should handle basic code evaluation', function (done) {
-            runner.run({
-                language: 'erlang',
-                code: 'io:fwrite("42\n"), init:stop().'
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
-        it('should be running the most recent erlang version', function (done) {
-            runner.run({
-                language: 'erlang',
-                code: 'io:fwrite(erlang:system_info(otp_release)), init:stop().'
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('18');
-                done();
-            });
-        });
+  describe('.run', function () {
+    it('should handle setup code and imports', function (done) {
+      runner.run({
+        language: 'erlang',
+        setup: [
+          '-module(foo).',
+          '-export([bar/0]).',
+          'bar() -> io:format("baz").'
+        ].join('\n'),
+        code: [
+          'foo:bar(), init:stop().'
+        ].join('\n')
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('baz');
+        done();
+      });
     });
-    describe('codewars test framework (eunit)', function () {
-        it('should be able to run a basic test', function (done) {
-            runner.run({
-                language: 'erlang',
-                code: [
-                    '-module(solution).',
-                    '-export([foo/0]).',
-                    'foo() -> "bar".',
-                ].join('\n'),
-                fixture: [
-                    'foo_test() -> "bar" = solution:foo().'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stdout).to.contain('Test passed.');
-                done();
-            });
-        });
+    it('should handle basic code evaluation', function (done) {
+      runner.run({
+        language: 'erlang',
+        code: 'io:fwrite("42\n"), init:stop().'
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
     });
+    it('should be running the most recent erlang version', function (done) {
+      runner.run({
+        language: 'erlang',
+        code: 'io:fwrite(erlang:system_info(otp_release)), init:stop().'
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('18');
+        done();
+      });
+    });
+  });
+  describe('codewars test framework (eunit)', function () {
+    it('should be able to run a basic test', function (done) {
+      runner.run({
+        language: 'erlang',
+        code: [
+          '-module(solution).',
+          '-export([foo/0]).',
+          'foo() -> "bar".',
+        ].join('\n'),
+        fixture: [
+          'foo_test() -> "bar" = solution:foo().'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stdout).to.contain('Test passed.');
+        done();
+      });
+    });
+  });
 });

--- a/test/runners/fsharp_spec.js
+++ b/test/runners/fsharp_spec.js
@@ -3,67 +3,67 @@ var runner = require('../runner');
 
 
 describe( 'fsharp runner', function(){
-    describe( '.run', function(){
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'fsharp', code: 'printfn "42"'}, function(buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
+  describe( '.run', function(){
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'fsharp', code: 'printfn "42"'}, function(buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
     });
+  });
 
-    describe('using Fuchu for testing', function(){
-        runner.assertCodeExamples('fsharp');
+  describe('using Fuchu for testing', function(){
+    runner.assertCodeExamples('fsharp');
 
-        it('should be able to run a basic test', function(done){
-            runner.run({
-                language: 'fsharp',
-                code: [
-                    'type Person = {name: string};;',
-                    'let greet (person: Person) = "Hello, " + person.name + "!";;',
-                ].join('\n'),
-                fixture: [
-                    'module Tests = begin',
-                    '   open Fuchu',
-                    '   let suite = ',
-                    '       testList "Person" [',
-                    '           testCase ".greet" <| (fun _ -> ',
-                    '               let person: Person = { name = "Jack" } in ',
-                    '               Assert.Equal("Greet", "Hello, Jack!", (greet person))',
-                    '           )',
-                    '       ]',
-                    'end'
-                ].join('\n')
-            }, function(buffer){
-                console.log(buffer);
-                expect(buffer.stdout).to.contain("<IT::>Person/.greet\n<PASSED::>Person/.greet\n<COMPLETEDIN::>");
-                done();
-            })
-        })
-        it('should be able to handle a failing test', function(done){
-            runner.run({
-                language: 'fsharp',
-                code: [
-                    'type Person = {name: string};;',
-                    'let greet (person: Person) = "Hello, " + person.name + "!";;',
-                ].join('\n'),
-                fixture: [
-                    'module Tests = begin',
-                    '   open Fuchu',
-                    '   let suite = ',
-                    '       testList "Broken" [',
-                    '           testCase "test" <| (fun _ -> ',
-                    '               Assert.Equal("Broken test", true, false)',
-                    '           )',
-                    '       ]',
-                    'end'
-                ].join('\n')
-            }, function(buffer){
-                console.log(buffer);
-                expect(buffer.stdout).to.contain("<IT::>Broken/test\n<FAILED::><:LF:>Broken test");
-                expect(buffer.stdout).to.contain("\n<COMPLETEDIN::>");
-                done();
-            })
-        })
-    });
+    it('should be able to run a basic test', function(done){
+      runner.run({
+        language: 'fsharp',
+        code: [
+          'type Person = {name: string};;',
+          'let greet (person: Person) = "Hello, " + person.name + "!";;',
+        ].join('\n'),
+        fixture: [
+          'module Tests = begin',
+          '   open Fuchu',
+          '   let suite = ',
+          '       testList "Person" [',
+          '           testCase ".greet" <| (fun _ -> ',
+          '               let person: Person = { name = "Jack" } in ',
+          '               Assert.Equal("Greet", "Hello, Jack!", (greet person))',
+          '           )',
+          '       ]',
+          'end'
+        ].join('\n')
+      }, function(buffer){
+        console.log(buffer);
+        expect(buffer.stdout).to.contain("<IT::>Person/.greet\n<PASSED::>Person/.greet\n<COMPLETEDIN::>");
+        done();
+      })
+    })
+    it('should be able to handle a failing test', function(done){
+      runner.run({
+        language: 'fsharp',
+        code: [
+          'type Person = {name: string};;',
+          'let greet (person: Person) = "Hello, " + person.name + "!";;',
+        ].join('\n'),
+        fixture: [
+          'module Tests = begin',
+          '   open Fuchu',
+          '   let suite = ',
+          '       testList "Broken" [',
+          '           testCase "test" <| (fun _ -> ',
+          '               Assert.Equal("Broken test", true, false)',
+          '           )',
+          '       ]',
+          'end'
+        ].join('\n')
+      }, function(buffer){
+        console.log(buffer);
+        expect(buffer.stdout).to.contain("<IT::>Broken/test\n<FAILED::><:LF:>Broken test");
+        expect(buffer.stdout).to.contain("\n<COMPLETEDIN::>");
+        done();
+      })
+    })
+  });
 });

--- a/test/runners/gas_spec.js
+++ b/test/runners/gas_spec.js
@@ -3,45 +3,45 @@ var runner = require('../runner');
 
 
 describe('gas runner', function () {
-    describe('.run', function () {
-        it('should handle basic code evaluation (no libc)', function (done) {
-            runner.run({language: 'gas',
-                    code: [
-                        '   .global _start',
-                        '   .text',
-                        '_start:',
-                        '   mov     $1, %rax',
-                        '   mov     $1, %rdi',
-                        '   mov     $message, %rsi',
-                        '   mov     $8, %rdx',
-                        '   syscall',
-                        '   mov     $60, %rax',
-                        '   xor     %rdi, %rdi',
-                        '   syscall',
-                        'message:',
-                        '   .ascii "PV = nRT"'
-                    ].join('\n')},
+  describe('.run', function () {
+    it('should handle basic code evaluation (no libc)', function (done) {
+      runner.run({language: 'gas',
+        code: [
+          '   .global _start',
+          '   .text',
+          '_start:',
+          '   mov     $1, %rax',
+          '   mov     $1, %rdi',
+          '   mov     $message, %rsi',
+          '   mov     $8, %rdx',
+          '   syscall',
+          '   mov     $60, %rax',
+          '   xor     %rdi, %rdi',
+          '   syscall',
+          'message:',
+          '   .ascii "PV = nRT"'
+        ].join('\n')},
                 function (buffer) {
-                    expect(buffer.stdout).to.equal('PV = nRT');
-                    done();
+                  expect(buffer.stdout).to.equal('PV = nRT');
+                  done();
                 });
-        });
-        it('should handle basic code evaluation (with libc)', function (done) {
-            runner.run({language: 'gas',
-                    code: [
-                        '   .global  main',
-                        '   .text',
-                        'main:',
-                        '   mov     $message, %rdi',
-                        '   call    puts',
-                        '   ret',
-                        'message:',
-                        '   .asciz "Gas works with libc, too"'
-                    ].join('\n')},
-                function (buffer) {
-                    expect(buffer.stdout).to.equal('Gas works with libc, too\n');
-                    done();
-                });
-        });
     });
+    it('should handle basic code evaluation (with libc)', function (done) {
+      runner.run({language: 'gas',
+        code: [
+          '   .global  main',
+          '   .text',
+          'main:',
+          '   mov     $message, %rdi',
+          '   call    puts',
+          '   ret',
+          'message:',
+          '   .asciz "Gas works with libc, too"'
+        ].join('\n')},
+                function (buffer) {
+                  expect(buffer.stdout).to.equal('Gas works with libc, too\n');
+                  done();
+                });
+    });
+  });
 });

--- a/test/runners/groovy_spec.js
+++ b/test/runners/groovy_spec.js
@@ -3,12 +3,12 @@ var runner = require('../runner');
 
 
 describe( 'groovy runner', function(){
-    describe( '.run', function(){
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'groovy', code: "println '42'"}, function(buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
+  describe( '.run', function(){
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'groovy', code: "println '42'"}, function(buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
     });
+  });
 });

--- a/test/runners/haskell_spec.js
+++ b/test/runners/haskell_spec.js
@@ -1,626 +1,626 @@
 var expect = require('chai').expect,
-    runner = require('../runner');
+  runner = require('../runner');
 
 describe('haskell runner', function () {
-    describe('.run', function () {
-        runner.assertCodeExamples('haskell');
+  describe('.run', function () {
+    runner.assertCodeExamples('haskell');
 
-        it('should handle basic code evaluation', function (done) {
-            runner.run({language: 'haskell',
-                code: 'main = putStrLn "42"'
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
-        it('should handle running a module with imports', function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module Foo where',
-                    'import Control.Monad (filterM)',
-                    'powerset :: [a] -> [[a]]',
-                    'powerset = filterM (const [True,False])',
-                    'main :: IO ()',
-                    'main = putStr $ show $ powerset [1..3]'
-                ].join('\n')
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('[[1,2,3],[1,2],[1,3],[1],[2,3],[2],[3],[]]');
-                done();
-            });
-        });
-        it('should handle setup code', function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module Foo where',
-                    'import Foo.Utils as Setup (powerset)',
-                    'main :: IO ()',
-                    'main = putStr $ show $ Setup.powerset [1..3]'
-                ].join('\n'),
-                setup: [
-                    'module Foo.Utils (powerset) where',
-                    'import Control.Monad (filterM)',
-                    'powerset :: [a] -> [[a]]',
-                    'powerset = filterM (const [True,False])'
-                ].join('\n')
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('[[1,2,3],[1,2],[1,3],[1],[2,3],[2],[3],[]]');
-                done();
-            });
-        });
-        it('should handle skipping module declaration', function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'import Foo.Utils as Setup (powerset)',
-                    'main :: IO ()',
-                    'main = putStr $ show $ Setup.powerset [1..3]'
-                ].join('\n'),
-                setup: [
-                    'module Foo.Utils (powerset) where',
-                    'import Control.Monad (filterM)',
-                    'powerset :: [a] -> [[a]]',
-                    'powerset = filterM (const [True,False])'
-                ].join('\n')
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('[[1,2,3],[1,2],[1,3],[1],[2,3],[2],[3],[]]');
-                done();
-            });
-        });
+    it('should handle basic code evaluation', function (done) {
+      runner.run({language: 'haskell',
+        code: 'main = putStrLn "42"'
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
     });
-
-    describe('codewars test framework (hspec)', function () {
-        it('should be able to run a basic test', function (done) {
-            runner.run({
-                language: 'haskell',
-                code: 'module Foo where',
-                fixture: [
-                    'module Basic.Test where',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Prelude.head" $ do',
-                    '    it "returns the first element of a list" $ do',
-                    '      head [23 ..] `shouldBe` (23 :: Int)'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>Prelude.head');
-                expect(buffer.stdout).to.contain('<IT::>returns the first element of a list');
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                done();
-            });
-        });
-        it("should work even if test module name isn't specified", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: 'module Foo where',
-                fixture: [
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Prelude.head" $ do',
-                    '    it "returns the first element of a list" $ do',
-                    '      head [23 ..] `shouldBe` (23 :: Int)'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>Prelude.head');
-                expect(buffer.stdout).to.contain('<IT::>returns the first element of a list');
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                done();
-            });
-        });
-        it("should work be able to import the code", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'x :: Int',
-                    'x = 1'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (x)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "x" $ do',
-                    '    it "is 1" $ do',
-                    '      x `shouldBe` (1 :: Int)'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>x');
-                expect(buffer.stdout).to.contain('<IT::>is 1');
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                done();
-            });
-        });
-        it("should be able to import the code even when code module name is unspecified (the default is module name for the code is 'Main')", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'x :: Int',
-                    'x = 1'
-                ].join('\n'),
-                fixture: [
-                    'module Basic.Test where',
-                    'import Main (x)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "x" $ do',
-                    '    it "is 1" $ do',
-                    '      x `shouldBe` (1 :: Int)'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>x');
-                expect(buffer.stdout).to.contain('<IT::>is 1');
-                done();
-            });
-        });
-        it("should report when something is wrong", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: 'x = 1',
-                fixture: [
-                    'module Sad.Path.Test where',
-                    'import Test.Hspec',
-                    'import Main (x)',
-                    'main = hspec $ do',
-                    '  describe "x" $ do',
-                    '    it "is 2" $ do',
-                    '      x `shouldBe` 2'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>x');
-                expect(buffer.stdout).to.contain('<IT::>is 2');
-                expect(buffer.stdout).to.contain('<FAILED::>expected: 2');
-		expect(buffer.stdout).to.contain('but got: 1');
-                done();
-            });
-        });
-        it("should print as a side effect", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: 'x = do putStrLn "Test" ; return 1',
-                fixture: [
-                    'module PrintEffect where',
-                    'import Test.Hspec',
-                    'import Main (x)',
-                    'main = hspec $ do',
-                    '  describe "x" $ do',
-                    '    it "prints and returns 1" $ do',
-                    '      xval <- x',
-                    '      xval `shouldBe` 1'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>x');
-                expect(buffer.stdout).to.contain('Test\n<IT::>prints and returns 1');
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                done();
-            });
-        });
-        it("should fail fast", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: 'x = 1',
-                fixture: [
-                    'module Fast.Fail.Test where',
-                    'import Test.Hspec',
-                    'import Main (x)',
-                    'main = hspec $ do',
-                    '  describe "x" $ do',
-                    '    it "is not really 2" $ do',
-                    '      x `shouldBe` 2',
-                    '    it "should never get here" $ do',
-                    '      x `shouldBe` 3'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>x');
-                expect(buffer.stdout).to.contain('<IT::>is not really 2');
-                expect(buffer.stdout).to.contain('<FAILED::>expected: 2');
-		expect(buffer.stdout).to.contain('but got: 1');
-                expect(buffer.stdout).to.not.contain('<IT::>should never get here');
-                expect(buffer.stdout).to.not.contain('<FAILED::>expected: 3 but got: 1');
-                done();
-            });
-        });
-        it("should report exceptions as errors", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: 'x = head []',
-                fixture: [
-                    'module Fast.Fail.Test where',
-                    'import Test.Hspec',
-                    'import Main (x)',
-                    'main = hspec $ do',
-                    '  describe "exception" $ do',
-                    '    it "should throw" $ do',
-                    '      x `shouldBe` 2'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>exception');
-                expect(buffer.stdout).to.contain('<IT::>should throw');
-                expect(buffer.stdout).to.contain('<ERROR::>ErrorCall (Prelude.head: empty list)');
-                done();
-            });
-        });
-        it("should be able to hide a module from the code code", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'x :: Int',
-                    'x = 1'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (x)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a module (happy path)" $ do',
-                    '    it "Data.Monoid is hidden" $ do',
-                    '      hidden $ Module \"Data.Monoid\"'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Data.Monoid is hidden');
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                done();
-            });
-        });
-        it("should fail if a module which is supposed to be hidden is not", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'import Data.Monoid',
-                    'x :: Int',
-                    'x = 1'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (x)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a module (sad path)" $ do',
-                    '    it "Data.Monoid is not hidden!" $ do',
-                    '      hidden $ Module \"Data.Monoid\"'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Data.Monoid is not hidden!');
-                expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Data.Monoid');
-                done();
-            });
-        });
-        it("should recognize when things are hidden from a particular module", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'import Data.List hiding (reverse)',
-                    'reverse :: [a] -> [a]',
-                    'reverse = foldl (flip (:)) []'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (reverse)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a particular function (happy path)" $ do',
-                    '    it "Data.List.reverse is hidden" $ do',
-                    '      hidden $ FromModule \"Data.List\" \"reverse\"'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Data.List.reverse is hidden');
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                done();
-            });
-        });
-        it("should fail when a symbol from a module that ought to be hidden is not", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'import Data.List (intercalate)',
-                    'reverse :: [a] -> [a]',
-                    'reverse = foldl (flip (:)) []'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (reverse)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a particular function (sad path)" $ do',
-                    '    it "Data.List.intercalate is not hidden!" $ do',
-                    '      hidden $ FromModule \"Data.List\" \"intercalate\"'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Data.List.intercalate is not hidden!');
-                expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Data.List.intercalate');
-                done();
-            });
-        });
-        it("should fail when a symbol from a module that ought to be hidden is not because the whole module was imported", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'import Data.List',
-                    'reverse :: [a] -> [a]',
-                    'reverse = foldl (flip (:)) []'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (reverse)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a particular function (sad path)" $ do',
-                    '    it "Data.List.intercalate is not hidden, because the whole module was imported!" $ do',
-                    '      hidden $ FromModule \"Data.List\" \"intercalate\"'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Data.List.intercalate is not hidden, because the whole module was imported!');
-                expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Data.List.intercalate');
-                done();
-            });
-        });
-        it("should fail when a symbol from a module that ought to be hidden is not because it wasn't hidden properly", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'import Data.List hiding (reverse)',
-                    'import Control.Monad hiding ((=<<))',
-                    'reverse :: [a] -> [a]',
-                    'reverse = foldl (flip (:)) []'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (reverse)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a particular function (sad path)" $ do',
-                    '    it "Control.Monad.>=> is not hidden, because we forgot!" $ do',
-                    '      hidden $ FromModule \"Control.Monad\" \">=>\"'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Control.Monad.>=> is not hidden, because we forgot!');
-                expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Control.Monad.>=>');
-                done();
-            });
-        });
-        it("should fail when a function is hidden once in a module, but later imported", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'import Data.List hiding (reverse)',
-                    'import Control.Monad hiding ((>=>))',
-                    'import Control.Monad ((>=>))',
-                    'reverse :: [a] -> [a]',
-                    'reverse = foldl (flip (:)) []'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (reverse)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a particular function (sad path)" $ do',
-                    '    it "Control.Monad.>=> is not hidden, because we imported it after all!" $ do',
-                    '      hidden $ FromModule \"Control.Monad\" \">=>\"'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Control.Monad.>=> is not hidden, because we imported it after all!');
-                expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Control.Monad.>=>');
-                done();
-            });
-        });
-        it("should fail when a function is hidden once in a module, but later imported as qualified", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'import Data.List hiding (reverse)',
-                    'import Control.Monad hiding ((>=>))',
-                    'import qualified Control.Monad as WhatMonadRhymesWith',
-                    'reverse :: [a] -> [a]',
-                    'reverse = foldl (flip (:)) []'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (reverse)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a particular function (sad path)" $ do',
-                    '    it "Control.Monad.>=> is not hidden, because we imported Control.Monad qualified!" $ do',
-                    '      hidden $ FromModule \"Control.Monad\" \">=>\"'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Control.Monad.>=> is not hidden, because we imported Control.Monad qualified!');
-                expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Control.Monad.>=>');
-                done();
-            });
-        });
-        it("should be able to hide Prelude functions", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'import Prelude hiding (reverse)',
-                    'reverse :: [a] -> [a]',
-                    'reverse = foldl (flip (:)) []'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (reverse)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a particular function from Prelude (happy path)" $ do',
-                    '    it "Prelude.reverse is hidden" $ do',
-                    '      hidden $ FromModule \"Prelude\" \"reverse\"'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Prelude.reverse is hidden');
-                expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                done();
-            });
-        });
-        it("should detect when we failed to hide a Prelude function", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'module CodeWars.Solution where',
-                    'reverse :: [a] -> [a]',
-                    'reverse = foldl (flip (:)) []'
-                ].join('\n'),
-                fixture: [
-                    'import CodeWars.Solution (reverse)',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a particular function from Prelude (sad path)" $ do',
-                    '    it "Prelude.reverse is NOT hidden!" $ do',
-                    '      hidden $ FromModule \"Prelude\" \"reverse\"'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Prelude.reverse is NOT hidden!');
-                expect(buffer.stdout).to.contain('<FAILED::>');
-                done();
-            });
-        });
-        it("should detect when we hid a Prelude function, even when we forgot to say our module name", function (done) {
-            runner.run({
-                language: 'haskell',
-                code: [
-                    'import Prelude hiding (reverse)',
-                    'reverse :: [a] -> [a]',
-                    'reverse = foldl (flip (:)) []'
-                ].join('\n'),
-                fixture: [
-                    'module Default.Module.Name.Is.Main.Test where',
-                    'import qualified Main',
-                    'import Test.Hspec',
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "Testing BlackListing a particular function from Prelude, when module name is not specified (happy path)" $ do',
-                    '    it "Prelude.reverse is indeed hidden" $ do',
-                    '      hidden [FromModule \"Prelude\" \"reverse\"]',
-                    '  describe "Main.reverse reverses a thing" $ do',
-                    '    it "Main.reverse is functionally the same as Prelude.reverse" $ do',
-                    '      let testInput = [1..10]',
-                    '      Main.reverse testInput `shouldBe` reverse testInput',
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Prelude.reverse is indeed hidden');
-                expect(buffer.stdout).to.contain('Main.reverse is functionally the same as Prelude.reverse');
-                expect(buffer.stdout).to.contain('<PASSED::>');
-                done();
-            });
-        });
+    it('should handle running a module with imports', function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module Foo where',
+          'import Control.Monad (filterM)',
+          'powerset :: [a] -> [[a]]',
+          'powerset = filterM (const [True,False])',
+          'main :: IO ()',
+          'main = putStr $ show $ powerset [1..3]'
+        ].join('\n')
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('[[1,2,3],[1,2],[1,3],[1],[2,3],[2],[3],[]]');
+        done();
+      });
     });
-    describe('haskell', function () {
-        it('can handle SQLite interaction', function (done) {
-            runner.run({language: 'haskell',
-                code: [
-                    '{-# LANGUAGE QuasiQuotes, TemplateHaskell, TypeFamilies #-}',
-                    '{-# LANGUAGE OverloadedStrings, GADTs, FlexibleContexts, MultiParamTypeClasses #-}',
-                    '{-# LANGUAGE NoMonomorphismRestriction, GeneralizedNewtypeDeriving #-}',
-                    'module Movies where',
-                    'import Database.Persist (insertMany)',
-                    'import Database.Persist.Sqlite (runSqlite, runMigration)',
-                    'import Database.Persist.TH (mkPersist, mkMigrate, persistUpperCase, share, sqlSettings)',
-                    'share [mkPersist sqlSettings, mkMigrate "migrateTables"] [persistUpperCase|',
-                    'Movies',
-                    '   title    String',
-                    '   year     Int',
-                    '   rating   Int',
-                    '   deriving Eq Show',
-                    '|]',
-                    'mkMoviesDB :: IO ()',
-                    'mkMoviesDB = runSqlite "/tmp/movies.db" $ do',
-                    '  runMigration migrateTables',
-                    '  insertMany',
-                    '    [ Movies "Rise of the Planet of the Apes" 2011 77',
-                    '    , Movies "Dawn of the Planet of the Apes" 2014 91',
-                    '    , Movies "Alien" 1979 97',
-                    '    , Movies "Aliens" 1986 98',
-                    '    , Movies "Mad Max" 1979 95',
-                    '    , Movies "Mad Max 2: The Road Warrior" 1981 100',
-                    '    ]',
-                    '  return ()'
-                ].join('\n'),
-                fixture: [
-                    '{-# LANGUAGE QuasiQuotes, TemplateHaskell, TypeFamilies #-}',
-                    '{-# LANGUAGE OverloadedStrings, GADTs, FlexibleContexts #-}',
-                    '{-# LANGUAGE NoMonomorphismRestriction #-}',
-                    'import Test.Hspec',
-                    'import Database.Persist',
-                    'import Control.Monad.IO.Class (MonadIO(liftIO))',
-                    'import Database.Persist.Sqlite (runSqlite)',
-                    'import Database.Persist.Sql (rawQuery)',
-                    'import Data.Conduit (($$), (=$))',
-                    'import Data.Conduit.List as CL',
-                    'import Data.Text (pack, unpack)',
-                    'import Movies (mkMoviesDB)',
-                    'import Control.Monad (when)',
-                    'import System.Posix.Files (fileExist)',
-                    'import System.Directory (removeFile)',
-
-                    'data Movie = Movie String Integer Integer deriving (Eq, Show)',
-
-                    'moviesDBFileName :: String',
-                    'moviesDBFileName = "/tmp/movies.db"',
-
-                    'getMovies :: IO [Movie]',
-                    'getMovies = runSqlite (pack moviesDBFileName) $ do',
-                    '  rawQuery "select Title, Year, Rating from Movies" [] $$ CL.map toMovie =$ consume',
-                    '  where',
-                    '    toMovie [PersistText title, PersistInt64 year, PersistInt64 rating] =',
-                    '      Movie (unpack title) (toInteger year) (toInteger rating)',
-
-                    'deleteIfExists :: String -> IO ()',
-                    'deleteIfExists fileName = do',
-                    '  exists <- fileExist fileName',
-                    '  when exists $ removeFile fileName',
-
-                    'main :: IO ()',
-                    'main = hspec $ do',
-                    '  describe "/tmp/movies.db" ',
-                    '  $ before (deleteIfExists moviesDBFileName)',
-                    '  $ after_ (deleteIfExists moviesDBFileName)',
-                    '  $ do',
-                    '    it "contains the movies we expect" $ do',
-                    '      mkMoviesDB',
-                    '      movies <- getMovies',
-                    '      liftIO $ movies `shouldBe` [ Movie "Rise of the Planet of the Apes" 2011 77',
-                    '                                 , Movie "Dawn of the Planet of the Apes" 2014 91',
-                    '                                 , Movie "Alien" 1979 97,Movie "Aliens" 1986 98',
-                    '                                 , Movie "Mad Max" 1979 95',
-                    '                                 , Movie "Mad Max 2: The Road Warrior" 1981 100]'
-                ].join('\n')
-            }, function (buffer) {
-                console.log(buffer);
-                expect(buffer.stdout).to.contain('Test Passed');
-                done();
-            });
-        });
+    it('should handle setup code', function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module Foo where',
+          'import Foo.Utils as Setup (powerset)',
+          'main :: IO ()',
+          'main = putStr $ show $ Setup.powerset [1..3]'
+        ].join('\n'),
+        setup: [
+          'module Foo.Utils (powerset) where',
+          'import Control.Monad (filterM)',
+          'powerset :: [a] -> [[a]]',
+          'powerset = filterM (const [True,False])'
+        ].join('\n')
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('[[1,2,3],[1,2],[1,3],[1],[2,3],[2],[3],[]]');
+        done();
+      });
     });
+    it('should handle skipping module declaration', function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'import Foo.Utils as Setup (powerset)',
+          'main :: IO ()',
+          'main = putStr $ show $ Setup.powerset [1..3]'
+        ].join('\n'),
+        setup: [
+          'module Foo.Utils (powerset) where',
+          'import Control.Monad (filterM)',
+          'powerset :: [a] -> [[a]]',
+          'powerset = filterM (const [True,False])'
+        ].join('\n')
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('[[1,2,3],[1,2],[1,3],[1],[2,3],[2],[3],[]]');
+        done();
+      });
+    });
+  });
+
+  describe('codewars test framework (hspec)', function () {
+    it('should be able to run a basic test', function (done) {
+      runner.run({
+        language: 'haskell',
+        code: 'module Foo where',
+        fixture: [
+          'module Basic.Test where',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Prelude.head" $ do',
+          '    it "returns the first element of a list" $ do',
+          '      head [23 ..] `shouldBe` (23 :: Int)'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>Prelude.head');
+        expect(buffer.stdout).to.contain('<IT::>returns the first element of a list');
+        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+        done();
+      });
+    });
+    it("should work even if test module name isn't specified", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: 'module Foo where',
+        fixture: [
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Prelude.head" $ do',
+          '    it "returns the first element of a list" $ do',
+          '      head [23 ..] `shouldBe` (23 :: Int)'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>Prelude.head');
+        expect(buffer.stdout).to.contain('<IT::>returns the first element of a list');
+        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+        done();
+      });
+    });
+    it("should work be able to import the code", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'x :: Int',
+          'x = 1'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (x)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "x" $ do',
+          '    it "is 1" $ do',
+          '      x `shouldBe` (1 :: Int)'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>x');
+        expect(buffer.stdout).to.contain('<IT::>is 1');
+        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+        done();
+      });
+    });
+    it("should be able to import the code even when code module name is unspecified (the default is module name for the code is 'Main')", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'x :: Int',
+          'x = 1'
+        ].join('\n'),
+        fixture: [
+          'module Basic.Test where',
+          'import Main (x)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "x" $ do',
+          '    it "is 1" $ do',
+          '      x `shouldBe` (1 :: Int)'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>x');
+        expect(buffer.stdout).to.contain('<IT::>is 1');
+        done();
+      });
+    });
+    it("should report when something is wrong", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: 'x = 1',
+        fixture: [
+          'module Sad.Path.Test where',
+          'import Test.Hspec',
+          'import Main (x)',
+          'main = hspec $ do',
+          '  describe "x" $ do',
+          '    it "is 2" $ do',
+          '      x `shouldBe` 2'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>x');
+        expect(buffer.stdout).to.contain('<IT::>is 2');
+        expect(buffer.stdout).to.contain('<FAILED::>expected: 2');
+        expect(buffer.stdout).to.contain('but got: 1');
+        done();
+      });
+    });
+    it("should print as a side effect", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: 'x = do putStrLn "Test" ; return 1',
+        fixture: [
+          'module PrintEffect where',
+          'import Test.Hspec',
+          'import Main (x)',
+          'main = hspec $ do',
+          '  describe "x" $ do',
+          '    it "prints and returns 1" $ do',
+          '      xval <- x',
+          '      xval `shouldBe` 1'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>x');
+        expect(buffer.stdout).to.contain('Test\n<IT::>prints and returns 1');
+        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+        done();
+      });
+    });
+    it("should fail fast", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: 'x = 1',
+        fixture: [
+          'module Fast.Fail.Test where',
+          'import Test.Hspec',
+          'import Main (x)',
+          'main = hspec $ do',
+          '  describe "x" $ do',
+          '    it "is not really 2" $ do',
+          '      x `shouldBe` 2',
+          '    it "should never get here" $ do',
+          '      x `shouldBe` 3'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>x');
+        expect(buffer.stdout).to.contain('<IT::>is not really 2');
+        expect(buffer.stdout).to.contain('<FAILED::>expected: 2');
+        expect(buffer.stdout).to.contain('but got: 1');
+        expect(buffer.stdout).to.not.contain('<IT::>should never get here');
+        expect(buffer.stdout).to.not.contain('<FAILED::>expected: 3 but got: 1');
+        done();
+      });
+    });
+    it("should report exceptions as errors", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: 'x = head []',
+        fixture: [
+          'module Fast.Fail.Test where',
+          'import Test.Hspec',
+          'import Main (x)',
+          'main = hspec $ do',
+          '  describe "exception" $ do',
+          '    it "should throw" $ do',
+          '      x `shouldBe` 2'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('<DESCRIBE::>exception');
+        expect(buffer.stdout).to.contain('<IT::>should throw');
+        expect(buffer.stdout).to.contain('<ERROR::>ErrorCall (Prelude.head: empty list)');
+        done();
+      });
+    });
+    it("should be able to hide a module from the code code", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'x :: Int',
+          'x = 1'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (x)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a module (happy path)" $ do',
+          '    it "Data.Monoid is hidden" $ do',
+          '      hidden $ Module \"Data.Monoid\"'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Data.Monoid is hidden');
+        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+        done();
+      });
+    });
+    it("should fail if a module which is supposed to be hidden is not", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'import Data.Monoid',
+          'x :: Int',
+          'x = 1'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (x)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a module (sad path)" $ do',
+          '    it "Data.Monoid is not hidden!" $ do',
+          '      hidden $ Module \"Data.Monoid\"'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Data.Monoid is not hidden!');
+        expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Data.Monoid');
+        done();
+      });
+    });
+    it("should recognize when things are hidden from a particular module", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'import Data.List hiding (reverse)',
+          'reverse :: [a] -> [a]',
+          'reverse = foldl (flip (:)) []'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (reverse)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a particular function (happy path)" $ do',
+          '    it "Data.List.reverse is hidden" $ do',
+          '      hidden $ FromModule \"Data.List\" \"reverse\"'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Data.List.reverse is hidden');
+        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+        done();
+      });
+    });
+    it("should fail when a symbol from a module that ought to be hidden is not", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'import Data.List (intercalate)',
+          'reverse :: [a] -> [a]',
+          'reverse = foldl (flip (:)) []'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (reverse)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a particular function (sad path)" $ do',
+          '    it "Data.List.intercalate is not hidden!" $ do',
+          '      hidden $ FromModule \"Data.List\" \"intercalate\"'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Data.List.intercalate is not hidden!');
+        expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Data.List.intercalate');
+        done();
+      });
+    });
+    it("should fail when a symbol from a module that ought to be hidden is not because the whole module was imported", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'import Data.List',
+          'reverse :: [a] -> [a]',
+          'reverse = foldl (flip (:)) []'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (reverse)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a particular function (sad path)" $ do',
+          '    it "Data.List.intercalate is not hidden, because the whole module was imported!" $ do',
+          '      hidden $ FromModule \"Data.List\" \"intercalate\"'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Data.List.intercalate is not hidden, because the whole module was imported!');
+        expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Data.List.intercalate');
+        done();
+      });
+    });
+    it("should fail when a symbol from a module that ought to be hidden is not because it wasn't hidden properly", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'import Data.List hiding (reverse)',
+          'import Control.Monad hiding ((=<<))',
+          'reverse :: [a] -> [a]',
+          'reverse = foldl (flip (:)) []'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (reverse)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a particular function (sad path)" $ do',
+          '    it "Control.Monad.>=> is not hidden, because we forgot!" $ do',
+          '      hidden $ FromModule \"Control.Monad\" \">=>\"'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Control.Monad.>=> is not hidden, because we forgot!');
+        expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Control.Monad.>=>');
+        done();
+      });
+    });
+    it("should fail when a function is hidden once in a module, but later imported", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'import Data.List hiding (reverse)',
+          'import Control.Monad hiding ((>=>))',
+          'import Control.Monad ((>=>))',
+          'reverse :: [a] -> [a]',
+          'reverse = foldl (flip (:)) []'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (reverse)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a particular function (sad path)" $ do',
+          '    it "Control.Monad.>=> is not hidden, because we imported it after all!" $ do',
+          '      hidden $ FromModule \"Control.Monad\" \">=>\"'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Control.Monad.>=> is not hidden, because we imported it after all!');
+        expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Control.Monad.>=>');
+        done();
+      });
+    });
+    it("should fail when a function is hidden once in a module, but later imported as qualified", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'import Data.List hiding (reverse)',
+          'import Control.Monad hiding ((>=>))',
+          'import qualified Control.Monad as WhatMonadRhymesWith',
+          'reverse :: [a] -> [a]',
+          'reverse = foldl (flip (:)) []'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (reverse)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a particular function (sad path)" $ do',
+          '    it "Control.Monad.>=> is not hidden, because we imported Control.Monad qualified!" $ do',
+          '      hidden $ FromModule \"Control.Monad\" \">=>\"'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Control.Monad.>=> is not hidden, because we imported Control.Monad qualified!');
+        expect(buffer.stdout).to.contain('<FAILED::>Import declarations must hide Control.Monad.>=>');
+        done();
+      });
+    });
+    it("should be able to hide Prelude functions", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'import Prelude hiding (reverse)',
+          'reverse :: [a] -> [a]',
+          'reverse = foldl (flip (:)) []'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (reverse)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a particular function from Prelude (happy path)" $ do',
+          '    it "Prelude.reverse is hidden" $ do',
+          '      hidden $ FromModule \"Prelude\" \"reverse\"'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Prelude.reverse is hidden');
+        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+        done();
+      });
+    });
+    it("should detect when we failed to hide a Prelude function", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'module CodeWars.Solution where',
+          'reverse :: [a] -> [a]',
+          'reverse = foldl (flip (:)) []'
+        ].join('\n'),
+        fixture: [
+          'import CodeWars.Solution (reverse)',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a particular function from Prelude (sad path)" $ do',
+          '    it "Prelude.reverse is NOT hidden!" $ do',
+          '      hidden $ FromModule \"Prelude\" \"reverse\"'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Prelude.reverse is NOT hidden!');
+        expect(buffer.stdout).to.contain('<FAILED::>');
+        done();
+      });
+    });
+    it("should detect when we hid a Prelude function, even when we forgot to say our module name", function (done) {
+      runner.run({
+        language: 'haskell',
+        code: [
+          'import Prelude hiding (reverse)',
+          'reverse :: [a] -> [a]',
+          'reverse = foldl (flip (:)) []'
+        ].join('\n'),
+        fixture: [
+          'module Default.Module.Name.Is.Main.Test where',
+          'import qualified Main',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "Testing BlackListing a particular function from Prelude, when module name is not specified (happy path)" $ do',
+          '    it "Prelude.reverse is indeed hidden" $ do',
+          '      hidden [FromModule \"Prelude\" \"reverse\"]',
+          '  describe "Main.reverse reverses a thing" $ do',
+          '    it "Main.reverse is functionally the same as Prelude.reverse" $ do',
+          '      let testInput = [1..10]',
+          '      Main.reverse testInput `shouldBe` reverse testInput',
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Prelude.reverse is indeed hidden');
+        expect(buffer.stdout).to.contain('Main.reverse is functionally the same as Prelude.reverse');
+        expect(buffer.stdout).to.contain('<PASSED::>');
+        done();
+      });
+    });
+  });
+  describe('haskell', function () {
+    it('can handle SQLite interaction', function (done) {
+      runner.run({language: 'haskell',
+        code: [
+          '{-# LANGUAGE QuasiQuotes, TemplateHaskell, TypeFamilies #-}',
+          '{-# LANGUAGE OverloadedStrings, GADTs, FlexibleContexts, MultiParamTypeClasses #-}',
+          '{-# LANGUAGE NoMonomorphismRestriction, GeneralizedNewtypeDeriving #-}',
+          'module Movies where',
+          'import Database.Persist (insertMany)',
+          'import Database.Persist.Sqlite (runSqlite, runMigration)',
+          'import Database.Persist.TH (mkPersist, mkMigrate, persistUpperCase, share, sqlSettings)',
+          'share [mkPersist sqlSettings, mkMigrate "migrateTables"] [persistUpperCase|',
+          'Movies',
+          '   title    String',
+          '   year     Int',
+          '   rating   Int',
+          '   deriving Eq Show',
+          '|]',
+          'mkMoviesDB :: IO ()',
+          'mkMoviesDB = runSqlite "/tmp/movies.db" $ do',
+          '  runMigration migrateTables',
+          '  insertMany',
+          '    [ Movies "Rise of the Planet of the Apes" 2011 77',
+          '    , Movies "Dawn of the Planet of the Apes" 2014 91',
+          '    , Movies "Alien" 1979 97',
+          '    , Movies "Aliens" 1986 98',
+          '    , Movies "Mad Max" 1979 95',
+          '    , Movies "Mad Max 2: The Road Warrior" 1981 100',
+          '    ]',
+          '  return ()'
+        ].join('\n'),
+        fixture: [
+          '{-# LANGUAGE QuasiQuotes, TemplateHaskell, TypeFamilies #-}',
+          '{-# LANGUAGE OverloadedStrings, GADTs, FlexibleContexts #-}',
+          '{-# LANGUAGE NoMonomorphismRestriction #-}',
+          'import Test.Hspec',
+          'import Database.Persist',
+          'import Control.Monad.IO.Class (MonadIO(liftIO))',
+          'import Database.Persist.Sqlite (runSqlite)',
+          'import Database.Persist.Sql (rawQuery)',
+          'import Data.Conduit (($$), (=$))',
+          'import Data.Conduit.List as CL',
+          'import Data.Text (pack, unpack)',
+          'import Movies (mkMoviesDB)',
+          'import Control.Monad (when)',
+          'import System.Posix.Files (fileExist)',
+          'import System.Directory (removeFile)',
+
+          'data Movie = Movie String Integer Integer deriving (Eq, Show)',
+
+          'moviesDBFileName :: String',
+          'moviesDBFileName = "/tmp/movies.db"',
+
+          'getMovies :: IO [Movie]',
+          'getMovies = runSqlite (pack moviesDBFileName) $ do',
+          '  rawQuery "select Title, Year, Rating from Movies" [] $$ CL.map toMovie =$ consume',
+          '  where',
+          '    toMovie [PersistText title, PersistInt64 year, PersistInt64 rating] =',
+          '      Movie (unpack title) (toInteger year) (toInteger rating)',
+
+          'deleteIfExists :: String -> IO ()',
+          'deleteIfExists fileName = do',
+          '  exists <- fileExist fileName',
+          '  when exists $ removeFile fileName',
+
+          'main :: IO ()',
+          'main = hspec $ do',
+          '  describe "/tmp/movies.db" ',
+          '  $ before (deleteIfExists moviesDBFileName)',
+          '  $ after_ (deleteIfExists moviesDBFileName)',
+          '  $ do',
+          '    it "contains the movies we expect" $ do',
+          '      mkMoviesDB',
+          '      movies <- getMovies',
+          '      liftIO $ movies `shouldBe` [ Movie "Rise of the Planet of the Apes" 2011 77',
+          '                                 , Movie "Dawn of the Planet of the Apes" 2014 91',
+          '                                 , Movie "Alien" 1979 97,Movie "Aliens" 1986 98',
+          '                                 , Movie "Mad Max" 1979 95',
+          '                                 , Movie "Mad Max 2: The Road Warrior" 1981 100]'
+        ].join('\n')
+      }, function (buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.contain('Test Passed');
+        done();
+      });
+    });
+  });
 });

--- a/test/runners/java_spec.js
+++ b/test/runners/java_spec.js
@@ -3,29 +3,29 @@ var runner = require('../runner');
 
 
 describe('java runner', function () {
-    describe('.run', function () {
-        it('should handle basic code evaluation', function (done) {
-            runner.run({language: 'java',
-                code: [
-                    'class Solution {',
-                    '   static void main(String[] args){',
-                    '        System.out.println("42");',
-                    '   }',
-                    '}'].join('\n')
-            }, function (buffer) {
-                expect(buffer.stdout).to.contain('42\n');
-                done();
-            });
-        });
+  describe('.run', function () {
+    it('should handle basic code evaluation', function (done) {
+      runner.run({language: 'java',
+        code: [
+          'class Solution {',
+          '   static void main(String[] args){',
+          '        System.out.println("42");',
+          '   }',
+          '}'].join('\n')
+      }, function (buffer) {
+        expect(buffer.stdout).to.contain('42\n');
+        done();
+      });
     });
-    describe('junit', function () {
-        it('should handle basic junit tests', function (done) {
-            runner.run({language: 'java',
-                code: 'public class Solution {\n'
+  });
+  describe('junit', function () {
+    it('should handle basic junit tests', function (done) {
+      runner.run({language: 'java',
+        code: 'public class Solution {\n'
                     + '    public Solution(){}\n'
                     + '    public int testthing(){return 3;}\n'
                     + '}\n',
-                fixture: 'import static org.junit.Assert.assertEquals;\n'
+        fixture: 'import static org.junit.Assert.assertEquals;\n'
                     + 'import org.junit.Test;\n'
                     + 'import org.junit.runners.JUnit4;\n'
                     + 'public class TestFixture {\n'
@@ -36,18 +36,18 @@ describe('java runner', function () {
                     + '        assertEquals("wow", 3, s.testthing());\n'
                     + '        System.out.println("test out");\n'
                     + '}}'
-            }, function (buffer) {
-                expect(buffer.stdout).to.contain('<DESCRIBE::>myTestFunction(TestFixture)<:LF:>\ntest out\n\n<PASSED::>Test Passed<:LF:>\n');
-                done();
-            });
-        });
-        it('should handle junit tests failing', function (done) {
-            runner.run({language: 'java',
-                code: 'public class Solution {\n'
+      }, function (buffer) {
+        expect(buffer.stdout).to.contain('<DESCRIBE::>myTestFunction(TestFixture)<:LF:>\ntest out\n\n<PASSED::>Test Passed<:LF:>\n');
+        done();
+      });
+    });
+    it('should handle junit tests failing', function (done) {
+      runner.run({language: 'java',
+        code: 'public class Solution {\n'
                     + '    public Solution(){}\n'
                     + '    public int testthing(){return 3;}\n'
                     + '}\n',
-                fixture: 'import static org.junit.Assert.assertEquals;\n'
+        fixture: 'import static org.junit.Assert.assertEquals;\n'
                     + 'import org.junit.Test;\n'
                     + 'import org.junit.runners.JUnit4;\n'
                     + 'public class TestFixture {\n'
@@ -58,18 +58,18 @@ describe('java runner', function () {
                     + '        assertEquals("Failed Message", 5, s.testthing());\n'
                     + '        System.out.println("test out");\n'
                     + '}}'
-            }, function (buffer) {
-                expect(buffer.stdout).to.contain('<DESCRIBE::>myTestFunction(TestFixture)<:LF:>\n\n<FAILED::>Failed Message expected:<5> but was:<3><:LF:>\n');
-                done();
-            });
-        });
-        it('should report junit messages', function (done) {
-            runner.run({language: 'java',
-                code: 'public class Solution {\n'
+      }, function (buffer) {
+        expect(buffer.stdout).to.contain('<DESCRIBE::>myTestFunction(TestFixture)<:LF:>\n\n<FAILED::>Failed Message expected:<5> but was:<3><:LF:>\n');
+        done();
+      });
+    });
+    it('should report junit messages', function (done) {
+      runner.run({language: 'java',
+        code: 'public class Solution {\n'
                     + '    public Solution(){}\n'
                     + '    public String testthing(){ return null; }\n'
                     + '}\n',
-                fixture: 'import static org.junit.Assert.assertEquals;\n'
+        fixture: 'import static org.junit.Assert.assertEquals;\n'
                     + 'import org.junit.Test;\n'
                     + 'import org.junit.runners.JUnit4;\n'
                     + 'public class TestFixture {\n'
@@ -78,11 +78,11 @@ describe('java runner', function () {
                     + '        Solution s = new Solution();\n'
                     + '        assertEquals("Failed Message", 1, s.testthing().length());\n'
                     + '}}'
-            }, function (buffer) {
-                expect(buffer.stdout).to.contain('<FAILED::>Runtime Error Occurred');
-                expect(buffer.stdout).to.contain('NullPointerException');
-                done();
-            });
-        });
+      }, function (buffer) {
+        expect(buffer.stdout).to.contain('<FAILED::>Runtime Error Occurred');
+        expect(buffer.stdout).to.contain('NullPointerException');
+        done();
+      });
     });
+  });
 });

--- a/test/runners/javascript_spec.js
+++ b/test/runners/javascript_spec.js
@@ -1,73 +1,73 @@
 var expect = require('chai').expect,
-    runner = require('../runner');
+  runner = require('../runner');
 
 describe( 'javascript runner', function(){
-    describe( '.run', function(){
+  describe( '.run', function(){
 
-        runner.assertCodeExamples('javascript');
+    runner.assertCodeExamples('javascript');
 
         //----------------------------------------------------------------------------------------
         // Basics
         //----------------------------------------------------------------------------------------
 
-        describe( 'basics', function() {
-            it('should handle basic code evaluation', function (done) {
-                runner.run({language: 'javascript', code: 'console.log(42)'}, function (buffer) {
-                    expect(buffer.stdout).to.equal('42\n');
-                    done();
-                });
-            });
-            it('should handle JSON.stringify ', function (done) {
-                runner.run({language: 'javascript', code: 'console.log(JSON.stringify({a: 1}))'}, function (buffer) {
-                    console.log(buffer.stderr);
-                    expect(buffer.stdout).to.contain('{"a":1}');
-                    done();
-                });
-            });
-            it('should handle importing files from a gist', function (done) {
-                runner.run({
-                    language: 'javascript',
-                    code: 'console.log(require("./gist.js").name)',
-                    gist: '3acc7b81436ffe4ad20800e242ccaff6'
-                }, function (buffer) {
-                    expect(buffer.stdout).to.contain('Example Test');
-                    done();
-                });
-            });
+    describe( 'basics', function() {
+      it('should handle basic code evaluation', function (done) {
+        runner.run({language: 'javascript', code: 'console.log(42)'}, function (buffer) {
+          expect(buffer.stdout).to.equal('42\n');
+          done();
+        });
+      });
+      it('should handle JSON.stringify ', function (done) {
+        runner.run({language: 'javascript', code: 'console.log(JSON.stringify({a: 1}))'}, function (buffer) {
+          console.log(buffer.stderr);
+          expect(buffer.stdout).to.contain('{"a":1}');
+          done();
+        });
+      });
+      it('should handle importing files from a gist', function (done) {
+        runner.run({
+          language: 'javascript',
+          code: 'console.log(require("./gist.js").name)',
+          gist: '3acc7b81436ffe4ad20800e242ccaff6'
+        }, function (buffer) {
+          expect(buffer.stdout).to.contain('Example Test');
+          done();
+        });
+      });
 
-            it('should handle unicode characters', function (done) {
-                runner.run({language: 'javascript', code: 'console.log("✓")'}, function (buffer) {
-                    expect(buffer.stdout).to.include("✓");
-                    done();
-                });
-            });
+      it('should handle unicode characters', function (done) {
+        runner.run({language: 'javascript', code: 'console.log("✓")'}, function (buffer) {
+          expect(buffer.stdout).to.include("✓");
+          done();
+        });
+      });
 
-            it('should be able to access solution.txt', function (done) {
-                runner.run({
-                    language: 'javascript',
-                    code: `
+      it('should be able to access solution.txt', function (done) {
+        runner.run({
+          language: 'javascript',
+          code: `
                         console.log(1+4);
                         console.log(require('fs').readFileSync('/home/codewarrior/solution.txt', 'utf8'));
                     `
-                }, function (buffer) {
-                    expect(buffer.stdout).to.contain("5");
-                    expect(buffer.stdout).to.contain("1+4");
-                    done();
-                });
-            });
-            it('should allow a shell script to be ran', function (done) {
-                runner.run({
-                    language: 'javascript',
-                    bash: 'echo "test 123" >> /home/codewarrior/test.txt ; ls',
-                    code: `
+        }, function (buffer) {
+          expect(buffer.stdout).to.contain("5");
+          expect(buffer.stdout).to.contain("1+4");
+          done();
+        });
+      });
+      it('should allow a shell script to be ran', function (done) {
+        runner.run({
+          language: 'javascript',
+          bash: 'echo "test 123" >> /home/codewarrior/test.txt ; ls',
+          code: `
                         console.log(require('fs').readFileSync('/home/codewarrior/test.txt', 'utf8'));
                     `
-                }, function (buffer) {
-                    expect(buffer.stdout).to.contain("test 123");
-                    expect(buffer.shell.stdout.length).to.be.gt(0);
-                    done();
-                });
-            });
+        }, function (buffer) {
+          expect(buffer.stdout).to.contain("test 123");
+          expect(buffer.shell.stdout.length).to.be.gt(0);
+          done();
+        });
+      });
 
             // it('should be able to handle large output data', function (done) {
             //     runner.run({
@@ -83,29 +83,29 @@ describe( 'javascript runner', function(){
             //     });
             // });
 
-            it('should handle es6 code evaluation', function (done) {
-                runner.run({language: 'javascript', code: 'let a = 42; console.log(42);'}, function (buffer) {
-                    expect(buffer.stdout).to.equal('42\n');
-                    done();
-                });
-            });
+      it('should handle es6 code evaluation', function (done) {
+        runner.run({language: 'javascript', code: 'let a = 42; console.log(42);'}, function (buffer) {
+          expect(buffer.stdout).to.equal('42\n');
+          done();
+        });
+      });
 
-            it('should handle bad babel syntax', function (done) {
-                runner.run({
-                    language: 'javascript',
-                    languageVersion: '6.x/babel',
-                    code: 'var a = function(){returns 42;};\na();'
-                }, function (buffer) {
-                    expect(buffer.stderr).to.contain('Unexpected token');
-                    done();
-                });
-            });
+      it('should handle bad babel syntax', function (done) {
+        runner.run({
+          language: 'javascript',
+          languageVersion: '6.x/babel',
+          code: 'var a = function(){returns 42;};\na();'
+        }, function (buffer) {
+          expect(buffer.stderr).to.contain('Unexpected token');
+          done();
+        });
+      });
 
-            it('should handle mongodb service with mongoose', function (done) {
-                runner.run({
-                    language: 'javascript',
-                    services: ['mongodb'],
-                    code: `
+      it('should handle mongodb service with mongoose', function (done) {
+        runner.run({
+          language: 'javascript',
+          services: ['mongodb'],
+          code: `
                         var mongoose = require('mongoose');
                         mongoose.Promise = global.Promise;
                         mongoose.connect('mongodb://localhost/spec');
@@ -121,17 +121,17 @@ describe( 'javascript runner', function(){
                           process.exit();
                         });
                     `
-                }, function (buffer) {
-                    expect(buffer.stdout).to.contain('meow');
-                    done();
-                });
-            });
+        }, function (buffer) {
+          expect(buffer.stdout).to.contain('meow');
+          done();
+        });
+      });
 
-            it('should handle redis service', function (done) {
-                runner.run({
-                    language: 'javascript',
-                    services: ['redis'],
-                    code: `
+      it('should handle redis service', function (done) {
+        runner.run({
+          language: 'javascript',
+          services: ['redis'],
+          code: `
                         var redis = require('redis'),
                             Promise = require('bluebird');
         
@@ -145,62 +145,62 @@ describe( 'javascript runner', function(){
                             })
                         });
                     `
-                }, function (buffer) {
-                    expect(buffer.stdout).to.contain('bar');
-                    done();
-                });
-            });
+        }, function (buffer) {
+          expect(buffer.stdout).to.contain('bar');
+          done();
+        });
+      });
 
-            it('should handle react syntax', function (done) {
-                runner.run({
-                        language: 'javascript',
-                        languageVersion: '6.6.0/babel',
-                        code: `
+      it('should handle react syntax', function (done) {
+        runner.run({
+          language: 'javascript',
+          languageVersion: '6.6.0/babel',
+          code: `
                         var React = require("react");
                         var ReactDOM = require("react-dom/server");
                         let render = (el) => ReactDOM.renderToStaticMarkup(el);
                         var div = <div><h3>Test</h3></div>;
                         console.log(render(div));
                     `
-                    },
+        },
                     function (buffer) {
-                        expect(buffer.stdout).to.contain('<div><h3>Test</h3></div>');
-                        done();
+                      expect(buffer.stdout).to.contain('<div><h3>Test</h3></div>');
+                      done();
                     });
-            });
+      });
 
-            it('should handle react syntax using 0.10.x', function (done) {
-                runner.run({
-                        language: 'javascript',
-                        languageVersion: '0.10.x/babel',
-                        code: `
+      it('should handle react syntax using 0.10.x', function (done) {
+        runner.run({
+          language: 'javascript',
+          languageVersion: '0.10.x/babel',
+          code: `
                         var React = require("react");
                         var ReactDOM = require("react-dom/server");
                         let render = (el) => ReactDOM.renderToStaticMarkup(el);
                         var div = <div><h3>Test</h3></div>;
                         console.log(render(div));
                     `
-                    },
+        },
                     function (buffer) {
-                        expect(buffer.stdout).to.contain('<div><h3>Test</h3></div>');
-                        done();
+                      expect(buffer.stdout).to.contain('<div><h3>Test</h3></div>');
+                      done();
                     });
-            });
+      });
 
-            it('should load libraries', function (done) {
-                runner.run({
-                    language: 'javascript',
-                    code: 'var _ = require("lodash");console.log(_.map([1], n => n * 2));'
-                }, function (buffer) {
-                    expect(buffer.stdout).to.contain('[ 2 ]');
-                    done();
-                });
-            });
+      it('should load libraries', function (done) {
+        runner.run({
+          language: 'javascript',
+          code: 'var _ = require("lodash");console.log(_.map([1], n => n * 2));'
+        }, function (buffer) {
+          expect(buffer.stdout).to.contain('[ 2 ]');
+          done();
+        });
+      });
 
-            it('should work with SQLite', function (done) {
-                runner.run({
-                    language: 'javascript',
-                    code: `
+      it('should work with SQLite', function (done) {
+        runner.run({
+          language: 'javascript',
+          code: `
                         var sqlite3 = require('sqlite3');
                         var db = new sqlite3.Database(':memory:');
                         db.serialize(function() {
@@ -217,89 +217,89 @@ describe( 'javascript runner', function(){
         
                         db.close();
                     `
-                }, function (buffer) {
-                    expect(buffer.stdout).to.contain('Ipsum 0');
-                    expect(buffer.stdout).to.contain('Ipsum 9');
-                    done();
-                });
-            });
-
-            it('should handle stderr', function (done) {
-                runner.run({language: 'javascript', code: 'console.error("404 Not Found")'}, function (buffer) {
-                    expect(buffer.stderr).to.equal('404 Not Found\n');
-                    done();
-                });
-            });
-
-            it('should handle stdout and stderr', function (done) {
-                runner.run({
-                    language: 'javascript',
-                    code: 'console.log("stdout"); console.error("stderr")'
-                }, function (buffer) {
-                    expect(buffer.stdout).to.equal('stdout\n');
-                    expect(buffer.stderr).to.equal('stderr\n');
-                    done();
-                });
-            });
+        }, function (buffer) {
+          expect(buffer.stdout).to.contain('Ipsum 0');
+          expect(buffer.stdout).to.contain('Ipsum 9');
+          done();
         });
+      });
+
+      it('should handle stderr', function (done) {
+        runner.run({language: 'javascript', code: 'console.error("404 Not Found")'}, function (buffer) {
+          expect(buffer.stderr).to.equal('404 Not Found\n');
+          done();
+        });
+      });
+
+      it('should handle stdout and stderr', function (done) {
+        runner.run({
+          language: 'javascript',
+          code: 'console.log("stdout"); console.error("stderr")'
+        }, function (buffer) {
+          expect(buffer.stdout).to.equal('stdout\n');
+          expect(buffer.stderr).to.equal('stderr\n');
+          done();
+        });
+      });
+    });
 
 
         //----------------------------------------------------------------------------------------
         // Mocha BDD
         //----------------------------------------------------------------------------------------
 
-        describe('mocha bdd', function() {
-            it( 'should handle outputting objects', function(done){
-                runner.run({
-                    language: 'javascript',
-                    code: 'var a = {b: 2};console.log(this);',
-                    fixture: 'var assert = require("chai").assert;describe("test", function(){it("should be 2", function(){assert.equal(2, a.b);})});',
-                    testFramework: 'mocha_bdd'},
+    describe('mocha bdd', function() {
+      it( 'should handle outputting objects', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};console.log(this);',
+          fixture: 'var assert = require("chai").assert;describe("test", function(){it("should be 2", function(){assert.equal(2, a.b);})});',
+          testFramework: 'mocha_bdd'},
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<PASSED::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<PASSED::>');
+                      done();
                     });
-            });
-            it( 'should handle no trailing semicolons', function(done){
-                runner.run({
-                    language: 'javascript',
-                    code: 'var a = 2',
-                    fixture: 'var assert = require("chai").assert;describe("test", function(){it("should be 2", function(){assert.equal(2, a);})});',
-                    testFramework: 'mocha_bdd'},
+      });
+      it( 'should handle no trailing semicolons', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = 2',
+          fixture: 'var assert = require("chai").assert;describe("test", function(){it("should be 2", function(){assert.equal(2, a);})});',
+          testFramework: 'mocha_bdd'},
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<PASSED::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<PASSED::>');
+                      done();
                     });
-            });
-            it( 'should handle failures', function(done){
-                runner.run({
-                    language: 'javascript',
-                    code: 'var a = {b: 2};',
-                    fixture: 'var assert = require("chai").assert;describe("test", function(){describe("failures", function(){it("should be 1", function(){assert.equal(1, a.b);})})});',
-                    testFramework: 'mocha_bdd'},
+      });
+      it( 'should handle failures', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};',
+          fixture: 'var assert = require("chai").assert;describe("test", function(){describe("failures", function(){it("should be 1", function(){assert.equal(1, a.b);})})});',
+          testFramework: 'mocha_bdd'},
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<FAILED::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<FAILED::>');
+                      done();
                     });
-            });
+      });
 
-            it( 'should handle errors', function(done){
-                runner.run({
-                    language: 'javascript',
-                    code: 'var a = {b: 2};',
-                    fixture: 'describe("test", function(){describe("failures", function(){it("should be 1", function(){throw new Error("test error");})})});',
-                    testFramework: 'mocha_bdd'},
+      it( 'should handle errors', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};',
+          fixture: 'describe("test", function(){describe("failures", function(){it("should be 1", function(){throw new Error("test error");})})});',
+          testFramework: 'mocha_bdd'},
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<ERROR::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<ERROR::>');
+                      done();
                     });
-            });
+      });
 
-            it( 'should support options files', function(done){
-                runner.run({
-                    language: 'javascript',
-                    code: 'var name = require("./config.js").name',
-                    fixture: `
+      it( 'should support options files', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var name = require("./config.js").name',
+          fixture: `
                         var expect = require('chai').expect;
                         describe("files", function(){
                             it("should be able to require the file", function(){
@@ -307,23 +307,23 @@ describe( 'javascript runner', function(){
                             });
                         });
                     `,
-                    files: {
-                        "config.js": "module.exports.name = 'example';"
-                    },
-                    testFramework: 'mocha_bdd'},
+          files: {
+            "config.js": "module.exports.name = 'example';"
+          },
+          testFramework: 'mocha_bdd'},
                     function(buffer) {
-                        console.log(buffer.stdout);
-                        console.log(buffer.stderr);
-                        expect(buffer.stdout).to.contain('<PASSED::>');
-                        done();
+                      console.log(buffer.stdout);
+                      console.log(buffer.stderr);
+                      expect(buffer.stdout).to.contain('<PASSED::>');
+                      done();
                     });
-            });
+      });
 
-            it( 'should load chai-display', function(done){
-                runner.run({
-                    language: 'javascript',
-                    code: 'global.name = "example";',
-                    fixture: `
+      it( 'should load chai-display', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'global.name = "example";',
+          fixture: `
                         var expect = require('chai').expect;
                         require("chai-display");
                         describe("files", function(){
@@ -332,20 +332,20 @@ describe( 'javascript runner', function(){
                             });
                         });
                     `,
-                    testFramework: 'mocha_bdd'},
+          testFramework: 'mocha_bdd'},
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<PASSED::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<PASSED::>');
+                      done();
                     });
-            });
+      });
 
-              describe ('projectMode support', function () {
-                it( 'should handle tests', function(done){
-                  runner.run({
-                      language: 'javascript',
-                      files: {
-                        'helper.js': 'module.exports.name = "helper"',
-                        'spec.js': `
+      describe ('projectMode support', function () {
+        it( 'should handle tests', function(done){
+          runner.run({
+            language: 'javascript',
+            files: {
+              'helper.js': 'module.exports.name = "helper"',
+              'spec.js': `
                             var helper = require("./helper.js");
                             var assert = require("chai").assert;
                             describe("test", function(){
@@ -354,136 +354,136 @@ describe( 'javascript runner', function(){
                                 })
                             });
                         `
-                      },
-                      testFramework: 'mocha_bdd'},
+            },
+            testFramework: 'mocha_bdd'},
                     function(buffer) {
                       // console.log(buffer.stdout)
                       // console.log(buffer.stderr)
                       expect(buffer.stdout).to.contain('<PASSED::>');
                       done();
                     });
-                });
-              });
         });
+      });
+    });
 
 
         //----------------------------------------------------------------------------------------
         // Mocha TDD
         //----------------------------------------------------------------------------------------
 
-        describe('mocha tdd', function() {
-            it( 'should handle outputting objects', function(done){
-                runner.run({
-                        language: 'javascript',
-                        code: 'var a = {b: 2};console.log(this);',
-                        fixture: 'var assert = require("chai").assert;suite("test", function(){test("should be 2", function(){assert.equal(2, a.b);})});',
-                        testFramework: 'mocha_tdd'},
+    describe('mocha tdd', function() {
+      it( 'should handle outputting objects', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};console.log(this);',
+          fixture: 'var assert = require("chai").assert;suite("test", function(){test("should be 2", function(){assert.equal(2, a.b);})});',
+          testFramework: 'mocha_tdd'},
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<PASSED::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<PASSED::>');
+                      done();
                     });
-            });
-            it( 'should handle failures', function(done){
-                runner.run({
-                        language: 'javascript',
-                        code: 'var a = {b: 2};',
-                        fixture: 'var assert = require("assert"); suite("test", function(){suite("failures", function(){test("should be 1", function(){assert.equal(1, a.b);})})});',
-                        testFramework: 'mocha_tdd'},
+      });
+      it( 'should handle failures', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};',
+          fixture: 'var assert = require("assert"); suite("test", function(){suite("failures", function(){test("should be 1", function(){assert.equal(1, a.b);})})});',
+          testFramework: 'mocha_tdd'},
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<FAILED::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<FAILED::>');
+                      done();
                     });
-            });
-            it( 'should handle chai failures', function(done){
-                runner.run({
-                        language: 'javascript',
-                        code: 'var a = {b: 2};',
-                        fixture: 'var assert = require("chai").assert; suite("test", function(){suite("failures", function(){test("should be 1", function(){assert.equal(1, a.b);})})});',
-                        testFramework: 'mocha_tdd'},
+      });
+      it( 'should handle chai failures', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};',
+          fixture: 'var assert = require("chai").assert; suite("test", function(){suite("failures", function(){test("should be 1", function(){assert.equal(1, a.b);})})});',
+          testFramework: 'mocha_tdd'},
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<FAILED::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<FAILED::>');
+                      done();
                     });
-            });
-            it( 'should handle errors', function(done){
-                runner.run({
-                        language: 'javascript',
-                        code: 'var a = {b: 2};',
-                        fixture: 'suite("test", function(){suite("failures", function(){test("should be 1", function(){throw new Error("test error");})})});',
-                        testFramework: 'mocha_tdd'},
+      });
+      it( 'should handle errors', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};',
+          fixture: 'suite("test", function(){suite("failures", function(){test("should be 1", function(){throw new Error("test error");})})});',
+          testFramework: 'mocha_tdd'},
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<ERROR::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<ERROR::>');
+                      done();
                     });
-            });
-        });
+      });
+    });
 
 
         //----------------------------------------------------------------------------------------
         // CW-2
         //----------------------------------------------------------------------------------------
 
-        describe('cw-2', function() {
-            it( 'should handle outputting objects', function(done){
-                runner.run({
-                    language: 'javascript',
-                    code: 'var a = {b: 2};',
-                    fixture: 'Test.expect(false, a);',
-                    testFramework: 'cw-2'
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('{ b: 2 }');
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    done();
-                });
-            });
-            it( 'should handle outputting objects with 0.10.33', function(done){
+    describe('cw-2', function() {
+      it( 'should handle outputting objects', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};',
+          fixture: 'Test.expect(false, a);',
+          testFramework: 'cw-2'
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('{ b: 2 }');
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          done();
+        });
+      });
+      it( 'should handle outputting objects with 0.10.33', function(done){
                 // only 0.10.33 allows us to declare a without var
-                runner.run({
-                    language: 'javascript',
-                    languageVersion: '0.10.33',
-                    code: 'a = {b: 2};',
-                    fixture: 'Test.expect(false, a);',
-                    testFramework: 'cw-2'
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('{ b: 2 }');
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    done();
-                });
-            });
+        runner.run({
+          language: 'javascript',
+          languageVersion: '0.10.33',
+          code: 'a = {b: 2};',
+          fixture: 'Test.expect(false, a);',
+          testFramework: 'cw-2'
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('{ b: 2 }');
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          done();
+        });
+      });
 
-            it('should handle a basic assertion', function(done){
-                runner.run({language: 'javascript', code: 'var a = 1', fixture: 'Test.expect(a == 1);', testFramework: 'cw-2'}, function(buffer) {
-                    expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                    done();
-                });
-            });
+      it('should handle a basic assertion', function(done){
+        runner.run({language: 'javascript', code: 'var a = 1', fixture: 'Test.expect(a == 1);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
 
-            it('should handle comments as fixture', function(done){
-                runner.run({language: 'javascript', code: 'console.log(42)', fixture: '//', testFramework: 'cw-2'}, function(buffer) {
-                    expect(buffer.stdout).to.equal('42\n');
-                    done();
-                });
-            });
+      it('should handle comments as fixture', function(done){
+        runner.run({language: 'javascript', code: 'console.log(42)', fixture: '//', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('42\n');
+          done();
+        });
+      });
 
-            it('should handle a basic failed test', function(done){
-                runner.run({language: 'javascript', code: 'var a = 1', fixture: 'Test.expect(a == 2)', testFramework: 'cw-2'}, function(buffer) {
-                    expect(buffer.stdout).to.equal('<FAILED::>Value is not what was expected\n');
-                    done();
-                });
-            });
+      it('should handle a basic failed test', function(done){
+        runner.run({language: 'javascript', code: 'var a = 1', fixture: 'Test.expect(a == 2)', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('<FAILED::>Value is not what was expected\n');
+          done();
+        });
+      });
 
-            it('should handle logging objects', function(done){
-                runner.run({language: 'javascript', code:'console.log({a: 1});', testFramework: 'cw-2'}, function(buffer) {
-                    expect(buffer.stdout).to.equal('{ a: 1 }\n');
-                    done();
-                });
-            });
+      it('should handle logging objects', function(done){
+        runner.run({language: 'javascript', code:'console.log({a: 1});', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('{ a: 1 }\n');
+          done();
+        });
+      });
 
-            it('should handled nested describes', function(done) {
-                runner.run({
-                    language: 'javascript',
-                    code: `var a = 1`,
-                    fixture: `
+      it('should handled nested describes', function(done) {
+        runner.run({
+          language: 'javascript',
+          code: `var a = 1`,
+          fixture: `
                         describe("top", function(){
                             describe("2nd", function(){
                                 it("should a", function(){
@@ -495,20 +495,20 @@ describe( 'javascript runner', function(){
                             });
                         });
                     `,
-                    testFramework: 'cw-2'
-                }, function(buffer) {
-                    expect(buffer.stdout).to.include(`<DESCRIBE::>top\n<DESCRIBE::>2nd\n<IT::>should a\n`);
-                    done();
-                });
-            });
+          testFramework: 'cw-2'
+        }, function(buffer) {
+          expect(buffer.stdout).to.include(`<DESCRIBE::>top\n<DESCRIBE::>2nd\n<IT::>should a\n`);
+          done();
+        });
+      });
 
-            describe ('projectMode support', function () {
-              it( 'should handle test cases', function(done){
-                runner.run({
-                    language: 'javascript',
-                    files: {
-                      'helper.js': 'module.exports.name = "helper"',
-                      'spec.js': `
+      describe ('projectMode support', function () {
+        it( 'should handle test cases', function(done){
+          runner.run({
+            language: 'javascript',
+            files: {
+              'helper.js': 'module.exports.name = "helper"',
+              'spec.js': `
                           var helper = require("./helper.js");
                           var assert = require("chai").assert;
                           describe("test", function(){
@@ -517,41 +517,41 @@ describe( 'javascript runner', function(){
                               })
                           });
                       `
-                    },
-                    testFramework: 'cw-2'},
+            },
+            testFramework: 'cw-2'},
                   function(buffer) {
                     // console.log(buffer.stdout)
                     // console.log(buffer.stderr)
                     expect(buffer.stdout).to.contain('<PASSED::>');
                     done();
                   });
-              });
-            });
+        });
+      });
 
-            describe("async handling", function() {
-                it( 'should throw a timeout if code runs too long', function(done) {
-                    runner.run({
-                        language: 'javascript',
-                        code: 'function solution() {}',
-                        fixture: `
+      describe("async handling", function() {
+        it( 'should throw a timeout if code runs too long', function(done) {
+          runner.run({
+            language: 'javascript',
+            code: 'function solution() {}',
+            fixture: `
                             describe("test", 2, function(){
                                 it("should do something", function(done){
                                 });
                             });
                         `,
-                        testFramework: 'cw-2'
-                    },
+            testFramework: 'cw-2'
+          },
                     function(buffer) {
-                        expect(buffer.stdout).to.include("<ERROR::>`it` function timed out. Function ran longer than 2ms\n<COMPLETEDIN::>")
-                        done();
+                      expect(buffer.stdout).to.include("<ERROR::>`it` function timed out. Function ran longer than 2ms\n<COMPLETEDIN::>")
+                      done();
                     });
-                });
+        });
 
-                it( 'should render in proper order', function(done) {
-                    runner.run({
-                        language: 'javascript',
-                        code: 'function solution(cb) {setTimeout(() => cb("ok"), 0)}',
-                        fixture: `
+        it( 'should render in proper order', function(done) {
+          runner.run({
+            language: 'javascript',
+            code: 'function solution(cb) {setTimeout(() => cb("ok"), 0)}',
+            fixture: `
                             describe("test", true, function(){
                                 it("should do something", function(done){
                                     solution((msg) => {
@@ -562,77 +562,77 @@ describe( 'javascript runner', function(){
                                 });
                             });
                         `,
-                        testFramework: 'cw-2'
-                    },
+            testFramework: 'cw-2'
+          },
                     function(buffer) {
-                        expect(buffer.stdout).to.include("<IT::>should do something\nran solution\n<PASSED::>Test Passed: Value == \'ok\'\n<COMPLETEDIN::>")
-                        done();
+                      expect(buffer.stdout).to.include("<IT::>should do something\nran solution\n<PASSED::>Test Passed: Value == \'ok\'\n<COMPLETEDIN::>")
+                      done();
                     });
-                });
-            });
+        });
+      });
 
-            describe('error handling', function() {
-                it( 'should handle a mix of failures and successes', function(done) {
-                    runner.run({language: 'javascript',
-                                code:'var a = 1',
-                                fixture: 'describe("test", function(){\n' +
+      describe('error handling', function() {
+        it( 'should handle a mix of failures and successes', function(done) {
+          runner.run({language: 'javascript',
+            code:'var a = 1',
+            fixture: 'describe("test", function(){\n' +
                                 'it("test1", function(){ Test.expect(false) });' +
                                 'it("test2", function(){ Test.expect(true)});})',
-                                testFramework: 'cw-2'}, function(buffer) {
-                                    expect(buffer.stdout).to.contain('<FAILED::>Value is not what was expected');
-                                    expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                                    done();
-                                });
-                });
-                it('should gracefully handle custom errors', function(done) {
-                    runner.run({language: 'javascript',
-                                code:'var a = 1',
-                                fixture: 'describe("test", function(){\n' +
+            testFramework: 'cw-2'}, function(buffer) {
+            expect(buffer.stdout).to.contain('<FAILED::>Value is not what was expected');
+            expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+            done();
+          });
+        });
+        it('should gracefully handle custom errors', function(done) {
+          runner.run({language: 'javascript',
+            code:'var a = 1',
+            fixture: 'describe("test", function(){\n' +
                                 'it("test1", function(){ throw "boom!" });' +
                                 'it("test2", function(){ Test.expect(true)});})',
-                                testFramework: 'cw-2'}, function(buffer) {
-                                    expect(buffer.stdout).to.contain('<ERROR::>');
-                                    expect(buffer.stdout).to.contain('boom!');
-                                    expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                                    done();
-                                });
-                });
-                it('should gracefully handle reference errors', function(done) {
-                    runner.run({language: 'javascript',
-                                code:'var a = 1',
-                                fixture: 'describe("test", function(){\n' +
+            testFramework: 'cw-2'}, function(buffer) {
+            expect(buffer.stdout).to.contain('<ERROR::>');
+            expect(buffer.stdout).to.contain('boom!');
+            expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+            done();
+          });
+        });
+        it('should gracefully handle reference errors', function(done) {
+          runner.run({language: 'javascript',
+            code:'var a = 1',
+            fixture: 'describe("test", function(){\n' +
                                 'it("test1", function(){ b.test() });' +
                                 'it("test2", function(){ Test.expect(true)});})',
-                                testFramework: 'cw-2'}, function(buffer) {
-                                    expect(buffer.stdout).to.contain('<ERROR::>');
-                                    expect(buffer.stdout).to.contain('<:LF:>');
-                                    expect(buffer.stdout).to.contain('ReferenceError:');
-                                    expect(buffer.stdout).to.not.contain('[eval]');
-                                    expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                                    done();
-                                });
-                });
-                it('should gracefully top level handle reference errors', function(done) {
-                    runner.run({language: 'javascript',
-                                code:'b.test()',
-                                fixture: 'describe("test", function(){\n' +
+            testFramework: 'cw-2'}, function(buffer) {
+            expect(buffer.stdout).to.contain('<ERROR::>');
+            expect(buffer.stdout).to.contain('<:LF:>');
+            expect(buffer.stdout).to.contain('ReferenceError:');
+            expect(buffer.stdout).to.not.contain('[eval]');
+            expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+            done();
+          });
+        });
+        it('should gracefully top level handle reference errors', function(done) {
+          runner.run({language: 'javascript',
+            code:'b.test()',
+            fixture: 'describe("test", function(){\n' +
                                 'it("test2", function(){ Test.expect(true)});})',
-                                testFramework: 'cw-2'}, function(buffer) {
-                                    expect(buffer.stdout).to.contain('<ERROR::>');
-                                    expect(buffer.stdout).to.contain('<:LF:>');
-                                    expect(buffer.stdout).to.contain('ReferenceError:');
-                                    expect(buffer.stdout).to.not.contain('[eval]');
-                                    expect(buffer.stdout).to.not.contain('Object.Test.handleError');
-                                    done();
-                                });
-                });
-            });
+            testFramework: 'cw-2'}, function(buffer) {
+            expect(buffer.stdout).to.contain('<ERROR::>');
+            expect(buffer.stdout).to.contain('<:LF:>');
+            expect(buffer.stdout).to.contain('ReferenceError:');
+            expect(buffer.stdout).to.not.contain('[eval]');
+            expect(buffer.stdout).to.not.contain('Object.Test.handleError');
+            done();
+          });
+        });
+      });
 
-            it( 'should support options files', function(done){
-                runner.run({
-                        language: 'javascript',
-                        code: 'var name = require("/workspace/config.js").name',
-                        fixture: `
+      it( 'should support options files', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var name = require("/workspace/config.js").name',
+          fixture: `
                         var expect = require('chai').expect;
                         describe("files", function(){
                             it("should be able to require the file", function(){
@@ -640,22 +640,22 @@ describe( 'javascript runner', function(){
                             });
                         });
                     `,
-                        files: {
-                            "config.js": "module.exports.name = 'example';"
-                        },
-                        testFramework: 'cw-2'},
+          files: {
+            "config.js": "module.exports.name = 'example';"
+          },
+          testFramework: 'cw-2'},
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<PASSED::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<PASSED::>');
+                      done();
                     });
-            });
+      });
 
-            describe('Fix #259', function() {
-                it('should prevent global reassignment cheat', function(done) {
-                    runner.run({
-                        language: 'javascript',
-                        languageVersion: '6.6.0',
-                        code: `
+      describe('Fix #259', function() {
+        it('should prevent global reassignment cheat', function(done) {
+          runner.run({
+            language: 'javascript',
+            languageVersion: '6.6.0',
+            code: `
                         global = Object.assign({}, global);
                         global.Test = Object.assign({}, Test);
                         var od = global.Test.describe;
@@ -667,50 +667,50 @@ describe( 'javascript runner', function(){
                           });
                         };
                         `,
-                        fixture: `Test.describe('Fail', function() { Test.it('should fail', function() { Test.expect(false); }); });`,
-                        testFramework: 'cw-2'
-                    }, function(buffer) {
-                        expect(buffer.stdout).to.not.contain('<PASSED::>');
-                        expect(buffer.stdout).to.contain('<ERROR::>');
-                        done();
-                    });
-                });
-            });
+            fixture: `Test.describe('Fail', function() { Test.it('should fail', function() { Test.expect(false); }); });`,
+            testFramework: 'cw-2'
+          }, function(buffer) {
+            expect(buffer.stdout).to.not.contain('<PASSED::>');
+            expect(buffer.stdout).to.contain('<ERROR::>');
+            done();
+          });
         });
+      });
+    });
 
 
         //----------------------------------------------------------------------------------------
         // Karma BDD
         //----------------------------------------------------------------------------------------
 
-        describe('karma bdd', function() {
-            it( 'warmup test', function(done){
-                runner.run({
-                        language: 'javascript',
-                        code: 'var a = {b: 2};',
-                        fixture: 'describe("test", function(){it("should be 2", function(){assert.equal(2, a.b);})});',
-                        testFramework: 'karma_bdd'
-                    },
+    describe('karma bdd', function() {
+      it( 'warmup test', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};',
+          fixture: 'describe("test", function(){it("should be 2", function(){assert.equal(2, a.b);})});',
+          testFramework: 'karma_bdd'
+        },
                     function(){ done(); }
                 );
-            });
-            it( 'should handle basic tests', function(done){
-                runner.run({
-                    language: 'javascript',
-                    code: 'var a = {b: 2};',
-                    fixture: 'describe("test", function(){it("should be 2", function(){assert.equal(2, a.b);})});',
-                    testFramework: 'karma_bdd'
-                },
+      });
+      it( 'should handle basic tests', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};',
+          fixture: 'describe("test", function(){it("should be 2", function(){assert.equal(2, a.b);})});',
+          testFramework: 'karma_bdd'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<PASSED::>');
+                  done();
                 });
-            });
-            it( 'should handle loading Angular', function(done){
-                runner.run({
-                    language: 'javascript',
-                    setup: '// @include-external angular@1.5',
-                    code: `
+      });
+      it( 'should handle loading Angular', function(done){
+        runner.run({
+          language: 'javascript',
+          setup: '// @include-external angular@1.5',
+          code: `
 angular.module('testModule', [])
     .factory('testService', function() {
         return {
@@ -719,7 +719,7 @@ angular.module('testModule', [])
                 }
         };
     });`,
-                    fixture: `
+          fixture: `
 describe("test", function(){
     beforeEach(module('testModule'));
     it("should multiply", inject(function(testService) {
@@ -727,20 +727,20 @@ describe("test", function(){
         expect(testService.double(2)).to.eql(4);
     }));
 });`,
-                    testFramework: 'karma_bdd'
-                },
+          testFramework: 'karma_bdd'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('\n<IT::>should multiply');
-                    expect(buffer.stdout).to.contain('\n<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('\n<IT::>should multiply');
+                  expect(buffer.stdout).to.contain('\n<PASSED::>');
+                  done();
                 });
-            });
+      });
 
-            it( 'should handle failures', function(done){
-                runner.run({
-                    language: 'javascript',
-                    setup: '// @include-external angular@1.5',
-                    code: `
+      it( 'should handle failures', function(done){
+        runner.run({
+          language: 'javascript',
+          setup: '// @include-external angular@1.5',
+          code: `
 angular.module('testModule', [])
     .factory('testService', function() {
         return {
@@ -749,27 +749,27 @@ angular.module('testModule', [])
                 }
         };
     });`,
-                    fixture: `
+          fixture: `
 describe("test", function(){
     beforeEach(module('testModule'));
     it("should multiply", inject(function(testService) {
         expect(testService.double(2)).to.eql(4);
     }));
 });`,
-                    testFramework: 'karma_bdd'
-                },
+          testFramework: 'karma_bdd'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('\n<IT::>should multiply');
-                    expect(buffer.stdout).to.contain('\n<FAILED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('\n<IT::>should multiply');
+                  expect(buffer.stdout).to.contain('\n<FAILED::>');
+                  done();
                 });
-            });
+      });
 
-            it( 'should handle code errors', function(done){
-                runner.run({
-                    language: 'javascript',
-                    setup: '// @include-external angular@1.5',
-                    code: `
+      it( 'should handle code errors', function(done){
+        runner.run({
+          language: 'javascript',
+          setup: '// @include-external angular@1.5',
+          code: `
 angular.module('testModule', [])
     .factory('testService', function() {
         return {
@@ -778,26 +778,26 @@ angular.module('testModule', [])
                 }
         };
     });`,
-                    fixture: `
+          fixture: `
 describe("test", function(){
     beforeEach(module('testModule'));
     it("should multiply", inject(function(testService) {
         expect(testService.double(2)).to.eql(4);
     }));
 });`,
-                    testFramework: 'karma_bdd'
-                },
+          testFramework: 'karma_bdd'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('\n<FAILED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('\n<FAILED::>');
+                  done();
                 });
-            });
+      });
 
-            it( 'should handle test errors', function(done){
-                runner.run({
-                    language: 'javascript',
-                    setup: '// @include-external angular@1.5',
-                    code: `
+      it( 'should handle test errors', function(done){
+        runner.run({
+          language: 'javascript',
+          setup: '// @include-external angular@1.5',
+          code: `
 angular.module('testModule', [])
     .factory('testService', function() {
         return {
@@ -806,7 +806,7 @@ angular.module('testModule', [])
                 }
         };
     });`,
-                    fixture: `
+          fixture: `
 describe("test", function(){
     beforeEach(module('testModule'));
     it("should multiply", inject(function(testService) {
@@ -814,56 +814,56 @@ describe("test", function(){
         expect(testServie.double(3)).to.eql(6);
     }));
 });`,
-                    testFramework: 'karma_bdd'
-                },
+          testFramework: 'karma_bdd'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('\n<FAILED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('\n<FAILED::>');
+                  done();
                 });
-            });
+      });
 
-            it( 'should handle projectMode', function(done){
-                runner.run({
-                        language: 'javascript',
-                        files: {
-                            '.runner/config.json': '{}',
-                            '.runner/setup.sh': 'echo 123',
-                            'test.css': '.a {font-weight: bold}',
-                            'main.js': 'var a = {b: 2};',
-                            'spec.js': 'describe("test", function(){it("should be 2", function(){assert.equal(2, a.b);})});'
-                        },
-                        testFramework: 'karma_bdd'
-                    },
+      it( 'should handle projectMode', function(done){
+        runner.run({
+          language: 'javascript',
+          files: {
+            '.runner/config.json': '{}',
+            '.runner/setup.sh': 'echo 123',
+            'test.css': '.a {font-weight: bold}',
+            'main.js': 'var a = {b: 2};',
+            'spec.js': 'describe("test", function(){it("should be 2", function(){assert.equal(2, a.b);})});'
+          },
+          testFramework: 'karma_bdd'
+        },
                     function(buffer) {
-                        expect(buffer.stdout).to.contain('<PASSED::>');
-                        done();
+                      expect(buffer.stdout).to.contain('<PASSED::>');
+                      done();
                     });
-            });
-        });
+      });
+    });
 
 
         //----------------------------------------------------------------------------------------
         // Karma TDD
         //----------------------------------------------------------------------------------------
 
-        describe('karma tdd', function() {
-            it( 'should handle basic tests', function(done){
-                runner.run({
-                    language: 'javascript',
-                    code: 'var a = {b: 2};',
-                    fixture: 'suite("test", function(){test("should be 2", function(){assert.equal(2, a.b);})});',
-                    testFramework: 'karma_tdd'
-                },
+    describe('karma tdd', function() {
+      it( 'should handle basic tests', function(done){
+        runner.run({
+          language: 'javascript',
+          code: 'var a = {b: 2};',
+          fixture: 'suite("test", function(){test("should be 2", function(){assert.equal(2, a.b);})});',
+          testFramework: 'karma_tdd'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<PASSED::>');
+                  done();
                 });
-            });
-            it( 'should handle loading Angular', function(done){
-                runner.run({
-                    language: 'javascript',
-                    setup: '// @include-external angular@1.5',
-                    code: `
+      });
+      it( 'should handle loading Angular', function(done){
+        runner.run({
+          language: 'javascript',
+          setup: '// @include-external angular@1.5',
+          code: `
 angular.module('testModule', [])
     .factory('testService', function() {
         return {
@@ -872,7 +872,7 @@ angular.module('testModule', [])
                 }
         };
     });`,
-                    fixture: `
+          fixture: `
 suite("test", function(){
     setup(module('testModule'));
     test("should multiply", inject(function(testService) {
@@ -880,20 +880,20 @@ suite("test", function(){
         expect(testService.double(2)).to.eql(4);
     }));
 });`,
-                    testFramework: 'karma_tdd'
-                },
+          testFramework: 'karma_tdd'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('\n<IT::>should multiply');
-                    expect(buffer.stdout).to.contain('\n<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('\n<IT::>should multiply');
+                  expect(buffer.stdout).to.contain('\n<PASSED::>');
+                  done();
                 });
-            });
+      });
 
-            it( 'should handle failures', function(done){
-                runner.run({
-                    language: 'javascript',
-                    setup: '// @include-external angular@1.5',
-                    code: `
+      it( 'should handle failures', function(done){
+        runner.run({
+          language: 'javascript',
+          setup: '// @include-external angular@1.5',
+          code: `
 angular.module('testModule', [])
     .factory('testService', function() {
         return {
@@ -902,27 +902,27 @@ angular.module('testModule', [])
                 }
         };
     });`,
-                    fixture: `
+          fixture: `
 suite("test", function(){
     setup(module('testModule'));
     test("should multiply", inject(function(testService) {
         expect(testService.double(2)).to.eql(4);
     }));
 });`,
-                    testFramework: 'karma_tdd'
-                },
+          testFramework: 'karma_tdd'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('\n<IT::>should multiply');
-                    expect(buffer.stdout).to.contain('\n<FAILED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('\n<IT::>should multiply');
+                  expect(buffer.stdout).to.contain('\n<FAILED::>');
+                  done();
                 });
-            });
+      });
 
-            it( 'should handle code errors', function(done){
-                runner.run({
-                    language: 'javascript',
-                    setup: '// @include-external angular@1.5',
-                    code: `
+      it( 'should handle code errors', function(done){
+        runner.run({
+          language: 'javascript',
+          setup: '// @include-external angular@1.5',
+          code: `
 angular.module('testModule', [])
     .factory('testService', function() {
         return {
@@ -931,26 +931,26 @@ angular.module('testModule', [])
                 }
         };
     });`,
-                    fixture: `
+          fixture: `
 suite("test", function(){
     setup(module('testModule'));
     test("should multiply", inject(function(testService) {
         expect(testService.double(2)).to.eql(4);
     }));
 });`,
-                    testFramework: 'karma_tdd'
-                },
+          testFramework: 'karma_tdd'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('\n<FAILED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('\n<FAILED::>');
+                  done();
                 });
-            });
+      });
 
-            it( 'should handle test errors', function(done){
-                runner.run({
-                    language: 'javascript',
-                    setup: '// @include-external angular@1.5',
-                    code: `
+      it( 'should handle test errors', function(done){
+        runner.run({
+          language: 'javascript',
+          setup: '// @include-external angular@1.5',
+          code: `
 angular.module('testModule', [])
     .factory('testService', function() {
         return {
@@ -959,7 +959,7 @@ angular.module('testModule', [])
                 }
         };
     });`,
-                    fixture: `
+          fixture: `
 suite("test", function(){
     setup(module('testModule'));
     test("should multiply", inject(function(testService) {
@@ -967,13 +967,13 @@ suite("test", function(){
         expect(testServie.double(3)).to.eql(6);
     }));
 });`,
-                    testFramework: 'karma_tdd'
-                },
+          testFramework: 'karma_tdd'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('\n<FAILED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('\n<FAILED::>');
+                  done();
                 });
-            });
-        });
+      });
     });
+  });
 });

--- a/test/runners/julia_spec.js
+++ b/test/runners/julia_spec.js
@@ -4,15 +4,15 @@ var runner = require('../runner');
 describe('julia runner', function() {
   // These specs are compatible with both Julia 0.4.6
   describe('.run', function() {
-      it('should handle basic code evaluation', function(done) {
-        runner.run({
-          language: 'julia',
-          code: 'print("42")'
-        }, function(buffer) {
-          expect(buffer.stdout).to.equal('42');
-          done();
-        });
+    it('should handle basic code evaluation', function(done) {
+      runner.run({
+        language: 'julia',
+        code: 'print("42")'
+      }, function(buffer) {
+        expect(buffer.stdout).to.equal('42');
+        done();
       });
+    });
 
     it('should handle a basic assertion', function(done) {
       runner.run({

--- a/test/runners/kotlin_spec.js
+++ b/test/runners/kotlin_spec.js
@@ -3,37 +3,37 @@ var runner = require('../runner');
 
 
 describe( 'kotlin runner', function(){
-    describe( '.run', function(){
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({
-                language: 'kotlin',
-                code: `
+  describe( '.run', function(){
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({
+        language: 'kotlin',
+        code: `
 fun main(args : Array<String>) {
     println(42)
 }
 `
-            }, function(buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
-        it( 'should handle setup code', function(done){
-            runner.run({
-                language: 'kotlin',
-                setup: `
+      }, function(buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
+    });
+    it( 'should handle setup code', function(done){
+      runner.run({
+        language: 'kotlin',
+        setup: `
 fun greet(name : String) : String {
     return "Hello, " + name
 }
 `,
-                code: `
+        code: `
 fun main(args : Array<String>) {
     println(greet("Joe"))
 }
 `
-            }, function(buffer) {
-                expect(buffer.stdout).to.equal('Hello, Joe\n');
-                done();
-            });
-        });
+      }, function(buffer) {
+        expect(buffer.stdout).to.equal('Hello, Joe\n');
+        done();
+      });
     });
+  });
 });

--- a/test/runners/lisp_spec.js
+++ b/test/runners/lisp_spec.js
@@ -3,28 +3,28 @@ var runner = require('../runner');
 
 
 describe( 'lisp runner', function(){
-    describe( '.run', function(){
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'lisp', code: '(format t "~a~%" 42)'}, function(buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
+  describe( '.run', function(){
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'lisp', code: '(format t "~a~%" 42)'}, function(buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
+    });
 
-        it('should handle setup code and imports', function (done) {
-            runner.run({
-                language: 'lisp',
-                setup: [
-                    '(defun twice (x) (+ x x))'
-                ].join('\n'),
-                code: [
-                    '(format t "~a~%" (twice 4))'
-                ].join('\n')
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('8\n');
-                done();
-            });
-        });
+    it('should handle setup code and imports', function (done) {
+      runner.run({
+        language: 'lisp',
+        setup: [
+          '(defun twice (x) (+ x x))'
+        ].join('\n'),
+        code: [
+          '(format t "~a~%" (twice 4))'
+        ].join('\n')
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('8\n');
+        done();
+      });
+    });
 
-   });
+  });
 });

--- a/test/runners/lua_spec.js
+++ b/test/runners/lua_spec.js
@@ -3,29 +3,29 @@ var runner = require('../runner');
 
 
 describe('lua runner', function(){
-    describe('.run', function(){
-        it('should handle basic code evaluation', function(done){
-            runner.run({language: 'lua', code: 'print(42)'}, function(buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
+  describe('.run', function(){
+    it('should handle basic code evaluation', function(done){
+      runner.run({language: 'lua', code: 'print(42)'}, function(buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
     });
+  });
 });
 
 
 describe('busted', function() {
-    it('should handle basic code assertion', function(done) {
-        runner.run({
-          language: 'lua',
-          solution: `
+  it('should handle basic code assertion', function(done) {
+    runner.run({
+      language: 'lua',
+      solution: `
 local kata = {}
 function kata.add(a, b)
   return a + b
 end
 return kata
 `,
-          fixture: `
+      fixture: `
 local kata = require 'solution'
 describe("add", function()
   it("should add numbers", function()
@@ -33,23 +33,23 @@ describe("add", function()
   end)
 end)
 `
-        }, function(buffer) {
-            expect(buffer.stdout).to.contain('<PASSED::>');
-            done();
-        });
+    }, function(buffer) {
+      expect(buffer.stdout).to.contain('<PASSED::>');
+      done();
     });
+  });
 
-    it('should handle basic code assertion failure', function(done) {
-        runner.run({
-          language: 'lua',
-          solution: `
+  it('should handle basic code assertion failure', function(done) {
+    runner.run({
+      language: 'lua',
+      solution: `
 local kata = {}
 function kata.add(a, b)
   return a - b
 end
 return kata
 `,
-          fixture: `
+      fixture: `
 local kata = require 'solution'
 describe("add", function()
   it("should add numbers", function()
@@ -57,23 +57,23 @@ describe("add", function()
   end)
 end)
 `
-        }, function(buffer) {
-            expect(buffer.stdout).to.contain('<FAILED::>');
-            done();
-        });
+    }, function(buffer) {
+      expect(buffer.stdout).to.contain('<FAILED::>');
+      done();
     });
+  });
 
-    it('should handle mixed success and failure', function(done) {
-        runner.run({
-          language: 'lua',
-          solution: `
+  it('should handle mixed success and failure', function(done) {
+    runner.run({
+      language: 'lua',
+      solution: `
 local kata = {}
 function kata.add(a, b)
   return a - b
 end
 return kata
 `,
-          fixture: `
+      fixture: `
 local kata = require 'solution'
 describe("add", function()
   it("should add numbers", function()
@@ -84,17 +84,17 @@ describe("add", function()
   end)
 end)
 `
-        }, function(buffer) {
-            expect(buffer.stdout).to.contain('<PASSED::>');
-            expect(buffer.stdout).to.contain('<FAILED::>');
-            done();
-        });
+    }, function(buffer) {
+      expect(buffer.stdout).to.contain('<PASSED::>');
+      expect(buffer.stdout).to.contain('<FAILED::>');
+      done();
     });
+  });
 
-    it('should handle error', function(done) {
-        runner.run({
-          language: 'lua',
-          solution: `
+  it('should handle error', function(done) {
+    runner.run({
+      language: 'lua',
+      solution: `
 local kata = {}
 function kata.add(a, b)
   error("Error")
@@ -102,7 +102,7 @@ function kata.add(a, b)
 end
 return kata
 `,
-          fixture: `
+      fixture: `
 local kata = require 'solution'
 describe("add", function()
   it("should add numbers", function()
@@ -110,24 +110,24 @@ describe("add", function()
   end)
 end)
 `
-        }, function(buffer) {
-            expect(buffer.stdout).to.contain('<ERROR::>');
-            expect(buffer.stdout).to.contain('./solution.lua:4: Error');
-            done();
-        });
+    }, function(buffer) {
+      expect(buffer.stdout).to.contain('<ERROR::>');
+      expect(buffer.stdout).to.contain('./solution.lua:4: Error');
+      done();
     });
+  });
 
-    it('should output nested describes', function(done) {
-        runner.run({
-          language: 'lua',
-          solution: `
+  it('should output nested describes', function(done) {
+    runner.run({
+      language: 'lua',
+      solution: `
 local kata = {}
 function kata.add(a, b)
   return a + b
 end
 return kata
 `,
-          fixture: `
+      fixture: `
 -- from busted website
 describe("Busted unit testing framework", function()
   describe("should be awesome", function()
@@ -159,26 +159,26 @@ describe("Busted unit testing framework", function()
   end)
 end)
 `
-        }, function(buffer) {
-            const nested = [
-              '<DESCRIBE::>',
-              '  <DESCRIBE::>',
-              '    <IT::><PASSED::><COMPLETEDIN::>',
-              '    <IT::><PASSED::><COMPLETEDIN::>',
-              '    <IT::><PASSED::><COMPLETEDIN::>',
-              '    <IT::><PASSED::><COMPLETEDIN::>',
-              '  <COMPLETEDIN::>',
-              '<COMPLETEDIN::>'
-            ].join('').replace(/\s/g, '');
-            expect(buffer.stdout.match(/<(?:DESCRIBE|IT|PASSED|COMPLETEDIN)::>/g).join('')).to.equal(nested);
-            done();
-        });
+    }, function(buffer) {
+      const nested = [
+        '<DESCRIBE::>',
+        '  <DESCRIBE::>',
+        '    <IT::><PASSED::><COMPLETEDIN::>',
+        '    <IT::><PASSED::><COMPLETEDIN::>',
+        '    <IT::><PASSED::><COMPLETEDIN::>',
+        '    <IT::><PASSED::><COMPLETEDIN::>',
+        '  <COMPLETEDIN::>',
+        '<COMPLETEDIN::>'
+      ].join('').replace(/\s/g, '');
+      expect(buffer.stdout.match(/<(?:DESCRIBE|IT|PASSED|COMPLETEDIN)::>/g).join('')).to.equal(nested);
+      done();
     });
+  });
 
-    it('should allow solution to log', function(done) {
-        runner.run({
-          language: 'lua',
-          solution: `
+  it('should allow solution to log', function(done) {
+    runner.run({
+      language: 'lua',
+      solution: `
 local kata = {}
 function kata.add(a, b)
   print(a)
@@ -187,7 +187,7 @@ function kata.add(a, b)
 end
 return kata
 `,
-          fixture: `
+      fixture: `
 require 'busted.runner'()
 local kata = require 'solution'
 
@@ -197,15 +197,15 @@ describe("add", function()
   end)
 end)
 `
-        }, function(buffer) {
-            expect(buffer.stdout).to.contain('<PASSED::>');
-            expect(buffer.stdout).to.contain('1');
-            expect(buffer.stdout).to.contain('2');
-            done();
-        });
+    }, function(buffer) {
+      expect(buffer.stdout).to.contain('<PASSED::>');
+      expect(buffer.stdout).to.contain('1');
+      expect(buffer.stdout).to.contain('2');
+      done();
     });
+  });
 });
 
 describe('Examples', function() {
-    runner.assertCodeExamples('lua');
+  runner.assertCodeExamples('lua');
 });

--- a/test/runners/nasm_spec.js
+++ b/test/runners/nasm_spec.js
@@ -3,46 +3,46 @@ var runner = require('../runner');
 
 
 describe('nasm runner', function () {
-    describe('.run', function () {
-        it('should handle basic code evaluation (no libc)', function (done) {
-            runner.run({language: 'nasm',
-                    code: [
-                        '   global  _start',
-                        '   section .text',
-                        '_start:',
-                        '   mov     rax, 1',
-                        '   mov     rdi, 1',
-                        '   mov     rsi, message',
-                        '   mov     rdx, 25',
-                        '   syscall',
-                        '   mov     eax, 60',
-                        '   xor     rdi, rdi',
-                        '   syscall',
-                        'message:',
-                        'db      "Hello, Netwide Assembler!", 25'
-                    ].join('\n')},
+  describe('.run', function () {
+    it('should handle basic code evaluation (no libc)', function (done) {
+      runner.run({language: 'nasm',
+        code: [
+          '   global  _start',
+          '   section .text',
+          '_start:',
+          '   mov     rax, 1',
+          '   mov     rdi, 1',
+          '   mov     rsi, message',
+          '   mov     rdx, 25',
+          '   syscall',
+          '   mov     eax, 60',
+          '   xor     rdi, rdi',
+          '   syscall',
+          'message:',
+          'db      "Hello, Netwide Assembler!", 25'
+        ].join('\n')},
                 function (buffer) {
-                    expect(buffer.stdout).to.equal('Hello, Netwide Assembler!');
-                    done();
+                  expect(buffer.stdout).to.equal('Hello, Netwide Assembler!');
+                  done();
                 });
-        });
-        it('should handle basic code evaluation (with libc)', function (done) {
-            runner.run({language: 'nasm',
-                    code: [
-                        '   global  main',
-                        '   extern  puts',
-                        '   section .text',
-                        'main:',
-                        '   mov     rdi, message',
-                        '   call    puts',
-                        '   ret',
-                        'message:',
-                        'db      "Netwide Assembler together with LIBC!  Let\'s Port Codewars From Rails to THIS! \\m/", 0'
-                    ].join('\n')},
-                function (buffer) {
-                    expect(buffer.stdout).to.equal('Netwide Assembler together with LIBC!  Let\'s Port Codewars From Rails to THIS! \\m/\n');
-                    done();
-                });
-        });
     });
+    it('should handle basic code evaluation (with libc)', function (done) {
+      runner.run({language: 'nasm',
+        code: [
+          '   global  main',
+          '   extern  puts',
+          '   section .text',
+          'main:',
+          '   mov     rdi, message',
+          '   call    puts',
+          '   ret',
+          'message:',
+          'db      "Netwide Assembler together with LIBC!  Let\'s Port Codewars From Rails to THIS! \\m/", 0'
+        ].join('\n')},
+                function (buffer) {
+                  expect(buffer.stdout).to.equal('Netwide Assembler together with LIBC!  Let\'s Port Codewars From Rails to THIS! \\m/\n');
+                  done();
+                });
+    });
+  });
 });

--- a/test/runners/objc_spec.js
+++ b/test/runners/objc_spec.js
@@ -2,90 +2,90 @@ var expect = require('chai').expect;
 var runner = require('../runner');
 
 describe( 'objc runner', function(){
-	describe( '.run', function(){
-		runner.assertCodeExamples('objc');
+    describe( '.run', function(){
+        runner.assertCodeExamples('objc');
 
-		it( 'should handle basic code evaluation', function(done){
-			runner.run({
-				language: 'objc',
+        it( 'should handle basic code evaluation', function(done){
+            runner.run({
+                language: 'objc',
                 setup: false,
-				code: [
+                code: [
                     '#import <Foundation/Foundation.h>',
                     'int main (int argc, const char * argv[]) {',
-					'NSLog(@"Hello World");',
+                    'NSLog(@"Hello World");',
                     'return 0;',
                     '}'
-				].join('\n')
-			}, function(buffer) {
-				console.log("buffer", buffer);
-				expect(buffer.stdout).to.contain('Hello World\n');
-				done();
-			});
-		});
-		it('should handle basic code setup code', function(done) {
-			runner.run({
-				language: 'objc',
-				setup: 'int foo(void) { return 999; }',
-				setupHeader: [
-					'int foo(void);'
-				].join('\n'),
-				code: [
+                ].join('\n')
+            }, function(buffer) {
+                console.log("buffer", buffer);
+                expect(buffer.stdout).to.contain('Hello World\n');
+                done();
+            });
+        });
+        it('should handle basic code setup code', function(done) {
+            runner.run({
+                language: 'objc',
+                setup: 'int foo(void) { return 999; }',
+                setupHeader: [
+                    'int foo(void);'
+                ].join('\n'),
+                code: [
                     '#import <Foundation/Foundation.h>',
                     'int main (int argc, const char * argv[]) {',
                     'NSLog(@"A string: %i", foo());',
                     'return 0;',
                     '}'
-				].join('\n')
-			}, function(buffer) {
-				//console.log(buffer);
-				expect(buffer.stdout).to.contain('999');
-				done();
-			});
-		});		
-		it('should handle compile errors', function(done) {
-			runner.run({
-				language: 'objc',
-				setup: 'int foo(void) { return 999; }',
-				setupHeader: [
-					'int foo(void);'
-				].join('\n'),
-				code: `
+                ].join('\n')
+            }, function(buffer) {
+                //console.log(buffer);
+                expect(buffer.stdout).to.contain('999');
+                done();
+            });
+        });
+        it('should handle compile errors', function(done) {
+            runner.run({
+                language: 'objc',
+                setup: 'int foo(void) { return 999; }',
+                setupHeader: [
+                    'int foo(void);'
+                ].join('\n'),
+                code: `
                     #import <Foundation/Foundation.h>
-	                    int main (int argc, const char * argv[]) {
-	                    NSLog(@"A string: %i", foo(noexists));
-	                    return 0;
+                        int main (int argc, const char * argv[]) {
+                        NSLog(@"A string: %i", foo(noexists));
+                        return 0;
                     }
                     `
-			}, function(buffer) {
-				//console.log(buffer);
-				expect(buffer.stderr).to.contain("error: use of undeclared identifier 'noexists'");
-				done();
-			});
-		});
-		it('should handle setup code and imports', function(done) {
-			runner.run({
-				language: 'objc',
-				setup: 'int square(int a) { return a * a; }',
-				setupHeader: [
-					'int square(int a);'
-				].join('\n'),
-				code: [
+            }, function(buffer) {
+                //console.log(buffer);
+                expect(buffer.stderr).to.contain("error: use of undeclared identifier 'noexists'");
+                done();
+            });
+        });
+        it('should handle setup code and imports', function(done) {
+            runner.run({
+                language: 'objc',
+                setup: 'int square(int a) { return a * a; }',
+                setupHeader: [
+                    'int square(int a);'
+                ].join('\n'),
+                code: [
                     '#import <Foundation/Foundation.h>',
                     'int main (int argc, const char * argv[]) {',
                     'NSLog(@"Square: %i", square(6));',
                     'return 0;',
                     '}'
-				].join('\n')
-			}, function(buffer) {
-				//console.log(buffer);
-				expect(buffer.stdout).to.contain('Square: 36');
-				done();
-			});
-		});
-		it('should handle constructor classes, member functions and static', function(done) {
-			runner.run({
-				language: 'objc',
-				setup: [
+                ].join('\n')
+            }, function(buffer) {
+                //console.log(buffer);
+                expect(buffer.stdout).to.contain('Square: 36');
+                done();
+            });
+        });
+        it('should handle constructor classes, member functions and static', function(done) {
+            runner.run({
+                language: 'objc',
+                setup: [
                     'static int openAccounts = 0;',
                     '@implementation BankAccount',
                     '+ (BankAccount *) newAlloc {',
@@ -97,14 +97,14 @@ describe( 'objc runner', function(){
                     '}',
                     '@end'
                 ].join('\n'),
-				setupHeader: [
+                setupHeader: [
                     '#import <Foundation/Foundation.h>',
                     '@interface BankAccount: NSObject {}',
                     '+ (BankAccount *) newAlloc;',
                     '+ (int) totalOpen;',
                     '@end'
-				].join('\n'),
-				code: [
+                ].join('\n'),
+                code: [
                     'int main (int argc, const char * argv[]) {',
                     'NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];',
                     'BankAccount *account1, *account2;',
@@ -117,18 +117,18 @@ describe( 'objc runner', function(){
                     '[pool drain];',
                     'return 0;',
                     '}'
-				].join('\n')
-			}, function(buffer) {
-				//console.log(buffer);
+                ].join('\n')
+            }, function(buffer) {
+                //console.log(buffer);
                 console.log("buffer.stderr", buffer.stderr.split("\n"));
                 expect(buffer.stdout).to.contain('Number of BankAccount instances = 2');
-				done();
-			});
-		});
-		it('should handle constructor classes, member functions and instance properties', function(done) {
-			runner.run({
-				language: 'objc',
-				setup: [
+                done();
+            });
+        });
+        it('should handle constructor classes, member functions and instance properties', function(done) {
+            runner.run({
+                language: 'objc',
+                setup: [
                     '@implementation SimpleClass',
                     '@synthesize name;',
                     '@synthesize age;',
@@ -137,7 +137,7 @@ describe( 'objc runner', function(){
                     '}',
                     '@end'
                 ].join('\n'),
-				setupHeader: [
+                setupHeader: [
                     '#import <Foundation/Foundation.h>',
                     '@interface SimpleClass : NSObject {',
                         'NSString* name;',
@@ -147,8 +147,8 @@ describe( 'objc runner', function(){
                     '@property int age;',
                     '- (void)printName;',
                     '@end'
-				].join('\n'),
-				code: [
+                ].join('\n'),
+                code: [
                     'int main (int argc, const char * argv[]) {',
                         'NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];',
                         'SimpleClass *simple = [[SimpleClass alloc] init];',
@@ -159,46 +159,46 @@ describe( 'objc runner', function(){
                         '[pool drain];',
                     'return 0;',
                     '}'
-				].join('\n')
-			}, function(buffer) {
-				//console.log(buffer);
-				expect(buffer.stdout).to.contain('Name: Codewars and the age is 108');
-				done();
-			});
-		});
-		it('should handle unhandled exceptions', function(done) {
-			runner.run({
-				language: 'objc',
-				testFramework: 'unitkit',
-				code: `
-					#import <Foundation/Foundation.h>
+                ].join('\n')
+            }, function(buffer) {
+                //console.log(buffer);
+                expect(buffer.stdout).to.contain('Name: Codewars and the age is 108');
+                done();
+            });
+        });
+        it('should handle unhandled exceptions', function(done) {
+            runner.run({
+                language: 'objc',
+                testFramework: 'unitkit',
+                code: `
+                    #import <Foundation/Foundation.h>
 
-					NSString* FooException (NSString *str){ 
-						[NSException raise:@"FooException" format:@"Custom exception"]; 
-						return str;
-					}
-				`,
-				fixture: `
-					@implementation TestSuite
+                    NSString* FooException (NSString *str){
+                        [NSException raise:@"FooException" format:@"Custom exception"];
+                        return str;
+                    }
+                `,
+                fixture: `
+                    @implementation TestSuite
 
-					- (void) testsFooUnhandledException
-					{
-						UKStringsEqual(@"Blah", FooException(@"Blah"));
-					}
+                    - (void) testsFooUnhandledException
+                    {
+                        UKStringsEqual(@"Blah", FooException(@"Blah"));
+                    }
 
-					@end
-				`
-			}, function(buffer) {
-				//console.log(buffer);
-				expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
-				expect(buffer.stdout).to.contain('<IT::>testsFooUnhandledException');
-				expect(buffer.stdout).to.not.contain('<PASSED::>');
-				expect(buffer.stdout).to.contain('<FAILED::>');
-				expect(buffer.stdout).to.contain('NSException: FooException Custom exception');
-				expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-				done();
-			});
-		});		
+                    @end
+                `
+            }, function(buffer) {
+                //console.log(buffer);
+                expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
+                expect(buffer.stdout).to.contain('<IT::>testsFooUnhandledException');
+                expect(buffer.stdout).to.not.contain('<PASSED::>');
+                expect(buffer.stdout).to.contain('<FAILED::>');
+                expect(buffer.stdout).to.contain('NSException: FooException Custom exception');
+                expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+                done();
+            });
+        });
         it('should handle functions from standard library <math.h>', function(done) {
            runner.run({
                language: 'objc',
@@ -224,257 +224,257 @@ describe( 'objc runner', function(){
                language: 'objc',
                setup: false,
                code:`
-					#import <Foundation/Foundation.h>
+                    #import <Foundation/Foundation.h>
 
-					NSNumber *ICKGetMaxProfit(NSArray<NSNumber *> *stockPricesYesterday, NSUInteger length) {
-					    NSInteger minPrice, maxProfit;
+                    NSNumber *ICKGetMaxProfit(NSArray<NSNumber *> *stockPricesYesterday, NSUInteger length) {
+                        NSInteger minPrice, maxProfit;
 
-					    NSCAssert1(length >= 2, 
-					        @"parameter length: expected 2 or more but got %lu", (unsigned long)length);
+                        NSCAssert1(length >= 2,
+                            @"parameter length: expected 2 or more but got %lu", (unsigned long)length);
 
-					    minPrice = stockPricesYesterday[0].integerValue;
-					    maxProfit = stockPricesYesterday[1].integerValue - stockPricesYesterday[0].integerValue;
+                        minPrice = stockPricesYesterday[0].integerValue;
+                        maxProfit = stockPricesYesterday[1].integerValue - stockPricesYesterday[0].integerValue;
 
-					    for (NSUInteger i = 1; i < length; i++) {
-					        NSInteger currentPrice = stockPricesYesterday[i].integerValue;
-					        NSInteger potentialProfit = currentPrice - minPrice;
+                        for (NSUInteger i = 1; i < length; i++) {
+                            NSInteger currentPrice = stockPricesYesterday[i].integerValue;
+                            NSInteger potentialProfit = currentPrice - minPrice;
 
-					        maxProfit = MAX(maxProfit, potentialProfit);
-					        minPrice = MIN(minPrice, currentPrice);
-					    }
+                            maxProfit = MAX(maxProfit, potentialProfit);
+                            minPrice = MIN(minPrice, currentPrice);
+                        }
 
-					    return @(maxProfit);
-					}
+                        return @(maxProfit);
+                    }
 
 
-					int main (int argc, const char * argv[]) {
-					    NSArray *stockPricesYesterday = @[ @15, @20, @19];
-					    NSLog(@"%@", ICKGetMaxProfit(stockPricesYesterday,3));
-					    return 0;
-					}`
+                    int main (int argc, const char * argv[]) {
+                        NSArray *stockPricesYesterday = @[ @15, @20, @19];
+                        NSLog(@"%@", ICKGetMaxProfit(stockPricesYesterday,3));
+                        return 0;
+                    }`
             }, function(buffer) {
                 //console.log(buffer);
                 expect(buffer.stdout).to.contain('5');
                 done();
             });
         });
-	    it('should get the return code', function(done) {
-	        var solution = `
-    			int main (int argc, const char * argv[]) {
-              		return 10;
-              	}
+        it('should get the return code', function(done) {
+            var solution = `
+                int main (int argc, const char * argv[]) {
+                    return 10;
+                }
             `;
-	        runner.run({
-	            language: 'objc',
-	            code: solution
-	        }, function(buffer) {
-	        	//console.log(buffer);
-	            expect(buffer.exitCode).to.equal(10);
-	            expect(buffer.exitSignal).to.equal(null);
-	            done();
-	        });
-	    });
-	    it('should catch signals on crash', function(done) {
-	        var solution = `
-	        	#import <Foundation/Foundation.h>
-	        	int main (int argc, const char * argv[]) {	
-	                  int *nullPointer = nil;
-	                  *nullPointer = 0;
-	            }
-	        `;
-	        runner.run({
-	            language: 'objc',
-	            code: solution
-	        }, function(buffer) {
-	        	//console.log(buffer);
-	            expect(buffer.exitCode).to.equal(null);
-	            expect(buffer.exitSignal).to.equal('SIGSEGV');
-	            done();
-	        });
-	    });
+            runner.run({
+                language: 'objc',
+                code: solution
+            }, function(buffer) {
+                //console.log(buffer);
+                expect(buffer.exitCode).to.equal(10);
+                expect(buffer.exitSignal).to.equal(null);
+                done();
+            });
+        });
+        it('should catch signals on crash', function(done) {
+            var solution = `
+                #import <Foundation/Foundation.h>
+                int main (int argc, const char * argv[]) {
+                      int *nullPointer = nil;
+                      *nullPointer = 0;
+                }
+            `;
+            runner.run({
+                language: 'objc',
+                code: solution
+            }, function(buffer) {
+                //console.log(buffer);
+                expect(buffer.exitCode).to.equal(null);
+                expect(buffer.exitSignal).to.equal('SIGSEGV');
+                done();
+            });
+        });
 
-		describe('UnitKit', function() {
-			it('should perform unit testing', function(done) {
-				runner.run({
-					language: 'objc',
-					code: ' ',
-					testFramework: 'unitkit',
-					fixture: `
-						@implementation TestSuite
+        describe('UnitKit', function() {
+            it('should perform unit testing', function(done) {
+                runner.run({
+                    language: 'objc',
+                    code: ' ',
+                    testFramework: 'unitkit',
+                    fixture: `
+                        @implementation TestSuite
 
-						+ (void)testAClassMethod
-						{
-						   UKPass();
-						}
+                        + (void)testAClassMethod
+                        {
+                           UKPass();
+                        }
 
-						- (void)testIfPass
-						{
-						    UKPass();
-						}
+                        - (void)testIfPass
+                        {
+                            UKPass();
+                        }
 
-						@end
-					`
-				}, function(buffer) {
-					//console.log(buffer);
-					expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
-					expect(buffer.stdout).to.contain('<IT::>testAClassMethod');
-					expect(buffer.stdout).to.contain('<IT::>testIfPass');
-					expect(buffer.stdout).to.contain('<PASSED::>');
-					expect(buffer.stdout).to.not.contain('<FAILED::>');
-					expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-					done();
-				});
-			});
-			it('should handling failures', function(done) {
-				runner.run({
-					language: 'objc',
-					code: ' ',
-					testFramework: 'unitkit',
-					fixture: `
-						@implementation TestSuite
+                        @end
+                    `
+                }, function(buffer) {
+                    //console.log(buffer);
+                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
+                    expect(buffer.stdout).to.contain('<IT::>testAClassMethod');
+                    expect(buffer.stdout).to.contain('<IT::>testIfPass');
+                    expect(buffer.stdout).to.contain('<PASSED::>');
+                    expect(buffer.stdout).to.not.contain('<FAILED::>');
+                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+                    done();
+                });
+            });
+            it('should handling failures', function(done) {
+                runner.run({
+                    language: 'objc',
+                    code: ' ',
+                    testFramework: 'unitkit',
+                    fixture: `
+                        @implementation TestSuite
 
-						- (void) testsFailures
-						{
-						    UKFail();
-						    UKTrue(NO);
-						    UKFalse(YES);
-						    UKNil(@"fwip");
-						    UKNil(self);
-						    UKNotNil(nil);
-						    UKIntsEqual(3, 4);
-						    UKIntsNotEqual(3, 3);
-						    UKFloatsEqual(22.0, 33.0, 1.0);
-						    UKFloatsNotEqual(22.1, 22.2, 0.2);
-						    UKObjectsEqual(self, @"foo");
-						    UKObjectsNotEqual(self, self);
-						    UKObjectsSame(self, @"foo");
-						    UKObjectsNotSame(@"foo", @"foo");
-						    UKStringsEqual(@"fraggle", @"rock");
-						    UKStringsNotEqual(@"fraggle", @"fraggle");
-						    UKStringContains(@"fraggle", @"no");
-						    UKStringDoesNotContain(@"fraggle", @"fra");
-						}
+                        - (void) testsFailures
+                        {
+                            UKFail();
+                            UKTrue(NO);
+                            UKFalse(YES);
+                            UKNil(@"fwip");
+                            UKNil(self);
+                            UKNotNil(nil);
+                            UKIntsEqual(3, 4);
+                            UKIntsNotEqual(3, 3);
+                            UKFloatsEqual(22.0, 33.0, 1.0);
+                            UKFloatsNotEqual(22.1, 22.2, 0.2);
+                            UKObjectsEqual(self, @"foo");
+                            UKObjectsNotEqual(self, self);
+                            UKObjectsSame(self, @"foo");
+                            UKObjectsNotSame(@"foo", @"foo");
+                            UKStringsEqual(@"fraggle", @"rock");
+                            UKStringsNotEqual(@"fraggle", @"fraggle");
+                            UKStringContains(@"fraggle", @"no");
+                            UKStringDoesNotContain(@"fraggle", @"fra");
+                        }
 
-						@end
-					`
-				}, function(buffer) {
-					//console.log(buffer);
-					expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
-					expect(buffer.stdout).to.contain('<IT::>testsFailures');
-					expect(buffer.stdout).to.not.contain('<PASSED::>');
-					expect(buffer.stdout).to.contain('<FAILED::>');
-					expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-					done();
-				});
-			});		
-			it('should unit test with code', function(done) {
-				runner.run({
-					language: 'objc',
-					testFramework: 'unitkit',
-					code: `
-						#import <Foundation/Foundation.h>
+                        @end
+                    `
+                }, function(buffer) {
+                    //console.log(buffer);
+                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
+                    expect(buffer.stdout).to.contain('<IT::>testsFailures');
+                    expect(buffer.stdout).to.not.contain('<PASSED::>');
+                    expect(buffer.stdout).to.contain('<FAILED::>');
+                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+                    done();
+                });
+            });
+            it('should unit test with code', function(done) {
+                runner.run({
+                    language: 'objc',
+                    testFramework: 'unitkit',
+                    code: `
+                        #import <Foundation/Foundation.h>
 
-						NSString* Foo (NSString *str){return str;}
-					`,
-					fixture: `
-						@implementation TestSuite
+                        NSString* Foo (NSString *str){return str;}
+                    `,
+                    fixture: `
+                        @implementation TestSuite
 
-						- (void) testsFoo
-						{
-							UKStringsEqual(@"Blah", Foo(@"Blah"));
-							UKStringsNotEqual(@"fraggle", Foo(@"Blah"));
-						}
+                        - (void) testsFoo
+                        {
+                            UKStringsEqual(@"Blah", Foo(@"Blah"));
+                            UKStringsNotEqual(@"fraggle", Foo(@"Blah"));
+                        }
 
-						@end
-					`
-				}, function(buffer) {
-					//console.log(buffer);
-					expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
-					expect(buffer.stdout).to.contain('<IT::>testsFoo');
-					expect(buffer.stdout).to.contain('<PASSED::>');
-					expect(buffer.stdout).to.not.contain('<FAILED::>');
-					expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-					done();
-				});
-			});				
-			it('should handling exceptions', function(done) {
-				runner.run({
-					language: 'objc',
-					testFramework: 'unitkit',
-					code: `
-						#import <Foundation/Foundation.h>
+                        @end
+                    `
+                }, function(buffer) {
+                    //console.log(buffer);
+                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
+                    expect(buffer.stdout).to.contain('<IT::>testsFoo');
+                    expect(buffer.stdout).to.contain('<PASSED::>');
+                    expect(buffer.stdout).to.not.contain('<FAILED::>');
+                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+                    done();
+                });
+            });
+            it('should handling exceptions', function(done) {
+                runner.run({
+                    language: 'objc',
+                    testFramework: 'unitkit',
+                    code: `
+                        #import <Foundation/Foundation.h>
 
-						NSString* FooException (NSString *str){ 
-							[NSException raise:@"FooException" format:@"Custom exception"]; 
-							return str;
-						}
-					`,
-					fixture: `
-						@implementation TestSuite
+                        NSString* FooException (NSString *str){
+                            [NSException raise:@"FooException" format:@"Custom exception"];
+                            return str;
+                        }
+                    `,
+                    fixture: `
+                        @implementation TestSuite
 
-						- (void) testsFooException
-						{
-							UKRaisesException(FooException(@"Blah"));
-						}
+                        - (void) testsFooException
+                        {
+                            UKRaisesException(FooException(@"Blah"));
+                        }
 
-						@end
-					`
-				}, function(buffer) {
-					//console.log(buffer);
-					expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
-					expect(buffer.stdout).to.contain('<IT::>testsFooException');
-					expect(buffer.stdout).to.contain('<PASSED::>');
-					expect(buffer.stdout).to.not.contain('<FAILED::>');
-					expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-					done();
-				});
-			});			
-		});	
+                        @end
+                    `
+                }, function(buffer) {
+                    //console.log(buffer);
+                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
+                    expect(buffer.stdout).to.contain('<IT::>testsFooException');
+                    expect(buffer.stdout).to.contain('<PASSED::>');
+                    expect(buffer.stdout).to.not.contain('<FAILED::>');
+                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+                    done();
+                });
+            });
+        });
 
-	    describe('CW', function() {
-			it('should perform unit testing and test for failure (test equal())', function(done) {
-				runner.run({
-					language: 'objc',
-					code: 'NSString* Foo (NSString *str){return str;}',
-					testFramework: 'cw',
-					fixture: `
-						describe(@"String match", ^() {
-							it(@"should not match", ^() {
-								equal(@"Blah", Foo(@"Blah1"));
-							});
-						});
-					`
-				}, function(buffer) {
-					console.log(buffer);
-					expect(buffer.stdout).to.contain('<DESCRIBE::>String match');
-					expect(buffer.stdout).to.contain('<IT::>should not match');
-					expect(buffer.stdout).to.contain('<FAILED::>Expected "Blah" (NSConstantString) but instead got "Blah1" (NSConstantString)');
-					expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-					done();
-				});
-			});
-			it('should perform unit testing and pass the test (test notEqual())', function(done) {
-				runner.run({
-					language: 'objc',
-					code: 'NSString* Foo (NSString *str){return str;}',
-					testFramework: 'cw',
-					fixture: [
-						'describe(@"String not match", ^() {',
-							'it(@"should pass", ^() {',
-								'notEqual(@"Blah", Foo(@"Blah"));',
-							'});',
-						'});'
-					].join('\n')
-				}, function(buffer) {
-					console.log(buffer);
-					expect(buffer.stdout).to.contain('<FAILED::>Value is not supposed to equal "Blah" (NSConstantString)');
-					expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-					expect(buffer.stdout).to.contain('<IT::>should pass');
-					expect(buffer.stdout).to.contain('<DESCRIBE::>String not match');
-					expect(buffer.stderr).to.equal('');
-					done();
-				});
-			});
-		});
-	});
+        describe('CW', function() {
+            it('should perform unit testing and test for failure (test equal())', function(done) {
+                runner.run({
+                    language: 'objc',
+                    code: 'NSString* Foo (NSString *str){return str;}',
+                    testFramework: 'cw',
+                    fixture: `
+                        describe(@"String match", ^() {
+                            it(@"should not match", ^() {
+                                equal(@"Blah", Foo(@"Blah1"));
+                            });
+                        });
+                    `
+                }, function(buffer) {
+                    console.log(buffer);
+                    expect(buffer.stdout).to.contain('<DESCRIBE::>String match');
+                    expect(buffer.stdout).to.contain('<IT::>should not match');
+                    expect(buffer.stdout).to.contain('<FAILED::>Expected "Blah" (NSConstantString) but instead got "Blah1" (NSConstantString)');
+                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+                    done();
+                });
+            });
+            it('should perform unit testing and pass the test (test notEqual())', function(done) {
+                runner.run({
+                    language: 'objc',
+                    code: 'NSString* Foo (NSString *str){return str;}',
+                    testFramework: 'cw',
+                    fixture: [
+                        'describe(@"String not match", ^() {',
+                            'it(@"should pass", ^() {',
+                                'notEqual(@"Blah", Foo(@"Blah"));',
+                            '});',
+                        '});'
+                    ].join('\n')
+                }, function(buffer) {
+                    console.log(buffer);
+                    expect(buffer.stdout).to.contain('<FAILED::>Value is not supposed to equal "Blah" (NSConstantString)');
+                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+                    expect(buffer.stdout).to.contain('<IT::>should pass');
+                    expect(buffer.stdout).to.contain('<DESCRIBE::>String not match');
+                    expect(buffer.stderr).to.equal('');
+                    done();
+                });
+            });
+        });
+    });
 });

--- a/test/runners/objc_spec.js
+++ b/test/runners/objc_spec.js
@@ -2,175 +2,175 @@ var expect = require('chai').expect;
 var runner = require('../runner');
 
 describe( 'objc runner', function(){
-    describe( '.run', function(){
-        runner.assertCodeExamples('objc');
+  describe( '.run', function(){
+    runner.assertCodeExamples('objc');
 
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({
-                language: 'objc',
-                setup: false,
-                code: [
-                    '#import <Foundation/Foundation.h>',
-                    'int main (int argc, const char * argv[]) {',
-                    'NSLog(@"Hello World");',
-                    'return 0;',
-                    '}'
-                ].join('\n')
-            }, function(buffer) {
-                console.log("buffer", buffer);
-                expect(buffer.stdout).to.contain('Hello World\n');
-                done();
-            });
-        });
-        it('should handle basic code setup code', function(done) {
-            runner.run({
-                language: 'objc',
-                setup: 'int foo(void) { return 999; }',
-                setupHeader: [
-                    'int foo(void);'
-                ].join('\n'),
-                code: [
-                    '#import <Foundation/Foundation.h>',
-                    'int main (int argc, const char * argv[]) {',
-                    'NSLog(@"A string: %i", foo());',
-                    'return 0;',
-                    '}'
-                ].join('\n')
-            }, function(buffer) {
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({
+        language: 'objc',
+        setup: false,
+        code: [
+          '#import <Foundation/Foundation.h>',
+          'int main (int argc, const char * argv[]) {',
+          'NSLog(@"Hello World");',
+          'return 0;',
+          '}'
+        ].join('\n')
+      }, function(buffer) {
+        console.log("buffer", buffer);
+        expect(buffer.stdout).to.contain('Hello World\n');
+        done();
+      });
+    });
+    it('should handle basic code setup code', function(done) {
+      runner.run({
+        language: 'objc',
+        setup: 'int foo(void) { return 999; }',
+        setupHeader: [
+          'int foo(void);'
+        ].join('\n'),
+        code: [
+          '#import <Foundation/Foundation.h>',
+          'int main (int argc, const char * argv[]) {',
+          'NSLog(@"A string: %i", foo());',
+          'return 0;',
+          '}'
+        ].join('\n')
+      }, function(buffer) {
                 //console.log(buffer);
-                expect(buffer.stdout).to.contain('999');
-                done();
-            });
-        });
-        it('should handle compile errors', function(done) {
-            runner.run({
-                language: 'objc',
-                setup: 'int foo(void) { return 999; }',
-                setupHeader: [
-                    'int foo(void);'
-                ].join('\n'),
-                code: `
+        expect(buffer.stdout).to.contain('999');
+        done();
+      });
+    });
+    it('should handle compile errors', function(done) {
+      runner.run({
+        language: 'objc',
+        setup: 'int foo(void) { return 999; }',
+        setupHeader: [
+          'int foo(void);'
+        ].join('\n'),
+        code: `
                     #import <Foundation/Foundation.h>
                         int main (int argc, const char * argv[]) {
                         NSLog(@"A string: %i", foo(noexists));
                         return 0;
                     }
                     `
-            }, function(buffer) {
+      }, function(buffer) {
                 //console.log(buffer);
-                expect(buffer.stderr).to.contain("error: use of undeclared identifier 'noexists'");
-                done();
-            });
-        });
-        it('should handle setup code and imports', function(done) {
-            runner.run({
-                language: 'objc',
-                setup: 'int square(int a) { return a * a; }',
-                setupHeader: [
-                    'int square(int a);'
-                ].join('\n'),
-                code: [
-                    '#import <Foundation/Foundation.h>',
-                    'int main (int argc, const char * argv[]) {',
-                    'NSLog(@"Square: %i", square(6));',
-                    'return 0;',
-                    '}'
-                ].join('\n')
-            }, function(buffer) {
+        expect(buffer.stderr).to.contain("error: use of undeclared identifier 'noexists'");
+        done();
+      });
+    });
+    it('should handle setup code and imports', function(done) {
+      runner.run({
+        language: 'objc',
+        setup: 'int square(int a) { return a * a; }',
+        setupHeader: [
+          'int square(int a);'
+        ].join('\n'),
+        code: [
+          '#import <Foundation/Foundation.h>',
+          'int main (int argc, const char * argv[]) {',
+          'NSLog(@"Square: %i", square(6));',
+          'return 0;',
+          '}'
+        ].join('\n')
+      }, function(buffer) {
                 //console.log(buffer);
-                expect(buffer.stdout).to.contain('Square: 36');
-                done();
-            });
-        });
-        it('should handle constructor classes, member functions and static', function(done) {
-            runner.run({
-                language: 'objc',
-                setup: [
-                    'static int openAccounts = 0;',
-                    '@implementation BankAccount',
-                    '+ (BankAccount *) newAlloc {',
-                    'openAccounts++;',
-                    'return [BankAccount alloc];',
-                    '}',
-                    '+ (int) totalOpen {',
-                    'return openAccounts;',
-                    '}',
-                    '@end'
-                ].join('\n'),
-                setupHeader: [
-                    '#import <Foundation/Foundation.h>',
-                    '@interface BankAccount: NSObject {}',
-                    '+ (BankAccount *) newAlloc;',
-                    '+ (int) totalOpen;',
-                    '@end'
-                ].join('\n'),
-                code: [
-                    'int main (int argc, const char * argv[]) {',
-                    'NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];',
-                    'BankAccount *account1, *account2;',
-                    'account1 = [[BankAccount newAlloc] init];',
-                    'account2 = [[BankAccount newAlloc] init];',
-                    'int count = [BankAccount totalOpen];',
-                    'NSLog (@"Number of BankAccount instances = %i", count);',
-                    '[account1 release];',
-                    '[account2 release];',
-                    '[pool drain];',
-                    'return 0;',
-                    '}'
-                ].join('\n')
-            }, function(buffer) {
+        expect(buffer.stdout).to.contain('Square: 36');
+        done();
+      });
+    });
+    it('should handle constructor classes, member functions and static', function(done) {
+      runner.run({
+        language: 'objc',
+        setup: [
+          'static int openAccounts = 0;',
+          '@implementation BankAccount',
+          '+ (BankAccount *) newAlloc {',
+          'openAccounts++;',
+          'return [BankAccount alloc];',
+          '}',
+          '+ (int) totalOpen {',
+          'return openAccounts;',
+          '}',
+          '@end'
+        ].join('\n'),
+        setupHeader: [
+          '#import <Foundation/Foundation.h>',
+          '@interface BankAccount: NSObject {}',
+          '+ (BankAccount *) newAlloc;',
+          '+ (int) totalOpen;',
+          '@end'
+        ].join('\n'),
+        code: [
+          'int main (int argc, const char * argv[]) {',
+          'NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];',
+          'BankAccount *account1, *account2;',
+          'account1 = [[BankAccount newAlloc] init];',
+          'account2 = [[BankAccount newAlloc] init];',
+          'int count = [BankAccount totalOpen];',
+          'NSLog (@"Number of BankAccount instances = %i", count);',
+          '[account1 release];',
+          '[account2 release];',
+          '[pool drain];',
+          'return 0;',
+          '}'
+        ].join('\n')
+      }, function(buffer) {
                 //console.log(buffer);
-                console.log("buffer.stderr", buffer.stderr.split("\n"));
-                expect(buffer.stdout).to.contain('Number of BankAccount instances = 2');
-                done();
-            });
-        });
-        it('should handle constructor classes, member functions and instance properties', function(done) {
-            runner.run({
-                language: 'objc',
-                setup: [
-                    '@implementation SimpleClass',
-                    '@synthesize name;',
-                    '@synthesize age;',
-                    '- (void)printName {',
-                        'NSLog(@"Name: %@ and the age is %d", name, age);',
-                    '}',
-                    '@end'
-                ].join('\n'),
-                setupHeader: [
-                    '#import <Foundation/Foundation.h>',
-                    '@interface SimpleClass : NSObject {',
-                        'NSString* name;',
-                        'int age;',
-                    '}',
-                    '@property NSString* name;',
-                    '@property int age;',
-                    '- (void)printName;',
-                    '@end'
-                ].join('\n'),
-                code: [
-                    'int main (int argc, const char * argv[]) {',
-                        'NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];',
-                        'SimpleClass *simple = [[SimpleClass alloc] init];',
-                        'simple.name = @"Codewars";',
-                        'simple.age = 108;',
-                        '[simple printName];',
-                        '[simple release];',
-                        '[pool drain];',
-                    'return 0;',
-                    '}'
-                ].join('\n')
-            }, function(buffer) {
+        console.log("buffer.stderr", buffer.stderr.split("\n"));
+        expect(buffer.stdout).to.contain('Number of BankAccount instances = 2');
+        done();
+      });
+    });
+    it('should handle constructor classes, member functions and instance properties', function(done) {
+      runner.run({
+        language: 'objc',
+        setup: [
+          '@implementation SimpleClass',
+          '@synthesize name;',
+          '@synthesize age;',
+          '- (void)printName {',
+          'NSLog(@"Name: %@ and the age is %d", name, age);',
+          '}',
+          '@end'
+        ].join('\n'),
+        setupHeader: [
+          '#import <Foundation/Foundation.h>',
+          '@interface SimpleClass : NSObject {',
+          'NSString* name;',
+          'int age;',
+          '}',
+          '@property NSString* name;',
+          '@property int age;',
+          '- (void)printName;',
+          '@end'
+        ].join('\n'),
+        code: [
+          'int main (int argc, const char * argv[]) {',
+          'NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];',
+          'SimpleClass *simple = [[SimpleClass alloc] init];',
+          'simple.name = @"Codewars";',
+          'simple.age = 108;',
+          '[simple printName];',
+          '[simple release];',
+          '[pool drain];',
+          'return 0;',
+          '}'
+        ].join('\n')
+      }, function(buffer) {
                 //console.log(buffer);
-                expect(buffer.stdout).to.contain('Name: Codewars and the age is 108');
-                done();
-            });
-        });
-        it('should handle unhandled exceptions', function(done) {
-            runner.run({
-                language: 'objc',
-                testFramework: 'unitkit',
-                code: `
+        expect(buffer.stdout).to.contain('Name: Codewars and the age is 108');
+        done();
+      });
+    });
+    it('should handle unhandled exceptions', function(done) {
+      runner.run({
+        language: 'objc',
+        testFramework: 'unitkit',
+        code: `
                     #import <Foundation/Foundation.h>
 
                     NSString* FooException (NSString *str){
@@ -178,7 +178,7 @@ describe( 'objc runner', function(){
                         return str;
                     }
                 `,
-                fixture: `
+        fixture: `
                     @implementation TestSuite
 
                     - (void) testsFooUnhandledException
@@ -188,42 +188,42 @@ describe( 'objc runner', function(){
 
                     @end
                 `
-            }, function(buffer) {
+      }, function(buffer) {
                 //console.log(buffer);
-                expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
-                expect(buffer.stdout).to.contain('<IT::>testsFooUnhandledException');
-                expect(buffer.stdout).to.not.contain('<PASSED::>');
-                expect(buffer.stdout).to.contain('<FAILED::>');
-                expect(buffer.stdout).to.contain('NSException: FooException Custom exception');
-                expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-                done();
-            });
-        });
-        it('should handle functions from standard library <math.h>', function(done) {
-           runner.run({
-               language: 'objc',
-               setup: false,
-               code:[
-                   '#import <Foundation/Foundation.h>',
-                   '#include <math.h>',
-                   'int main (int argc, const char * argv[]) {',
-                     '@autoreleasepool{',
-                       'NSLog(@"%.f", sqrt(pow(5, 2)) );',
-                     '}',
-                     'return 0;',
-                   '}'
-               ].join('\n')
-            }, function(buffer) {
+        expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
+        expect(buffer.stdout).to.contain('<IT::>testsFooUnhandledException');
+        expect(buffer.stdout).to.not.contain('<PASSED::>');
+        expect(buffer.stdout).to.contain('<FAILED::>');
+        expect(buffer.stdout).to.contain('NSException: FooException Custom exception');
+        expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+        done();
+      });
+    });
+    it('should handle functions from standard library <math.h>', function(done) {
+      runner.run({
+        language: 'objc',
+        setup: false,
+        code:[
+          '#import <Foundation/Foundation.h>',
+          '#include <math.h>',
+          'int main (int argc, const char * argv[]) {',
+          '@autoreleasepool{',
+          'NSLog(@"%.f", sqrt(pow(5, 2)) );',
+          '}',
+          'return 0;',
+          '}'
+        ].join('\n')
+      }, function(buffer) {
                 //console.log(buffer);
-                expect(buffer.stdout).to.contain('5');
-                done();
-            });
-        });
-        it('should support modern objc', function(done) {
-           runner.run({
-               language: 'objc',
-               setup: false,
-               code:`
+        expect(buffer.stdout).to.contain('5');
+        done();
+      });
+    });
+    it('should support modern objc', function(done) {
+      runner.run({
+        language: 'objc',
+        setup: false,
+        code:`
                     #import <Foundation/Foundation.h>
 
                     NSNumber *ICKGetMaxProfit(NSArray<NSNumber *> *stockPricesYesterday, NSUInteger length) {
@@ -252,54 +252,54 @@ describe( 'objc runner', function(){
                         NSLog(@"%@", ICKGetMaxProfit(stockPricesYesterday,3));
                         return 0;
                     }`
-            }, function(buffer) {
+      }, function(buffer) {
                 //console.log(buffer);
-                expect(buffer.stdout).to.contain('5');
-                done();
-            });
-        });
-        it('should get the return code', function(done) {
-            var solution = `
+        expect(buffer.stdout).to.contain('5');
+        done();
+      });
+    });
+    it('should get the return code', function(done) {
+      var solution = `
                 int main (int argc, const char * argv[]) {
                     return 10;
                 }
             `;
-            runner.run({
-                language: 'objc',
-                code: solution
-            }, function(buffer) {
+      runner.run({
+        language: 'objc',
+        code: solution
+      }, function(buffer) {
                 //console.log(buffer);
-                expect(buffer.exitCode).to.equal(10);
-                expect(buffer.exitSignal).to.equal(null);
-                done();
-            });
-        });
-        it('should catch signals on crash', function(done) {
-            var solution = `
+        expect(buffer.exitCode).to.equal(10);
+        expect(buffer.exitSignal).to.equal(null);
+        done();
+      });
+    });
+    it('should catch signals on crash', function(done) {
+      var solution = `
                 #import <Foundation/Foundation.h>
                 int main (int argc, const char * argv[]) {
                       int *nullPointer = nil;
                       *nullPointer = 0;
                 }
             `;
-            runner.run({
-                language: 'objc',
-                code: solution
-            }, function(buffer) {
+      runner.run({
+        language: 'objc',
+        code: solution
+      }, function(buffer) {
                 //console.log(buffer);
-                expect(buffer.exitCode).to.equal(null);
-                expect(buffer.exitSignal).to.equal('SIGSEGV');
-                done();
-            });
-        });
+        expect(buffer.exitCode).to.equal(null);
+        expect(buffer.exitSignal).to.equal('SIGSEGV');
+        done();
+      });
+    });
 
-        describe('UnitKit', function() {
-            it('should perform unit testing', function(done) {
-                runner.run({
-                    language: 'objc',
-                    code: ' ',
-                    testFramework: 'unitkit',
-                    fixture: `
+    describe('UnitKit', function() {
+      it('should perform unit testing', function(done) {
+        runner.run({
+          language: 'objc',
+          code: ' ',
+          testFramework: 'unitkit',
+          fixture: `
                         @implementation TestSuite
 
                         + (void)testAClassMethod
@@ -314,23 +314,23 @@ describe( 'objc runner', function(){
 
                         @end
                     `
-                }, function(buffer) {
+        }, function(buffer) {
                     //console.log(buffer);
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
-                    expect(buffer.stdout).to.contain('<IT::>testAClassMethod');
-                    expect(buffer.stdout).to.contain('<IT::>testIfPass');
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    expect(buffer.stdout).to.not.contain('<FAILED::>');
-                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-                    done();
-                });
-            });
-            it('should handling failures', function(done) {
-                runner.run({
-                    language: 'objc',
-                    code: ' ',
-                    testFramework: 'unitkit',
-                    fixture: `
+          expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
+          expect(buffer.stdout).to.contain('<IT::>testAClassMethod');
+          expect(buffer.stdout).to.contain('<IT::>testIfPass');
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          expect(buffer.stdout).to.not.contain('<FAILED::>');
+          expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+          done();
+        });
+      });
+      it('should handling failures', function(done) {
+        runner.run({
+          language: 'objc',
+          code: ' ',
+          testFramework: 'unitkit',
+          fixture: `
                         @implementation TestSuite
 
                         - (void) testsFailures
@@ -357,26 +357,26 @@ describe( 'objc runner', function(){
 
                         @end
                     `
-                }, function(buffer) {
+        }, function(buffer) {
                     //console.log(buffer);
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
-                    expect(buffer.stdout).to.contain('<IT::>testsFailures');
-                    expect(buffer.stdout).to.not.contain('<PASSED::>');
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-                    done();
-                });
-            });
-            it('should unit test with code', function(done) {
-                runner.run({
-                    language: 'objc',
-                    testFramework: 'unitkit',
-                    code: `
+          expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
+          expect(buffer.stdout).to.contain('<IT::>testsFailures');
+          expect(buffer.stdout).to.not.contain('<PASSED::>');
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+          done();
+        });
+      });
+      it('should unit test with code', function(done) {
+        runner.run({
+          language: 'objc',
+          testFramework: 'unitkit',
+          code: `
                         #import <Foundation/Foundation.h>
 
                         NSString* Foo (NSString *str){return str;}
                     `,
-                    fixture: `
+          fixture: `
                         @implementation TestSuite
 
                         - (void) testsFoo
@@ -387,21 +387,21 @@ describe( 'objc runner', function(){
 
                         @end
                     `
-                }, function(buffer) {
+        }, function(buffer) {
                     //console.log(buffer);
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
-                    expect(buffer.stdout).to.contain('<IT::>testsFoo');
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    expect(buffer.stdout).to.not.contain('<FAILED::>');
-                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-                    done();
-                });
-            });
-            it('should handling exceptions', function(done) {
-                runner.run({
-                    language: 'objc',
-                    testFramework: 'unitkit',
-                    code: `
+          expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
+          expect(buffer.stdout).to.contain('<IT::>testsFoo');
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          expect(buffer.stdout).to.not.contain('<FAILED::>');
+          expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+          done();
+        });
+      });
+      it('should handling exceptions', function(done) {
+        runner.run({
+          language: 'objc',
+          testFramework: 'unitkit',
+          code: `
                         #import <Foundation/Foundation.h>
 
                         NSString* FooException (NSString *str){
@@ -409,7 +409,7 @@ describe( 'objc runner', function(){
                             return str;
                         }
                     `,
-                    fixture: `
+          fixture: `
                         @implementation TestSuite
 
                         - (void) testsFooException
@@ -419,62 +419,62 @@ describe( 'objc runner', function(){
 
                         @end
                     `
-                }, function(buffer) {
+        }, function(buffer) {
                     //console.log(buffer);
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
-                    expect(buffer.stdout).to.contain('<IT::>testsFooException');
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    expect(buffer.stdout).to.not.contain('<FAILED::>');
-                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-                    done();
-                });
-            });
+          expect(buffer.stdout).to.contain('<DESCRIBE::>TestSuite');
+          expect(buffer.stdout).to.contain('<IT::>testsFooException');
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          expect(buffer.stdout).to.not.contain('<FAILED::>');
+          expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+          done();
         });
+      });
+    });
 
-        describe('CW', function() {
-            it('should perform unit testing and test for failure (test equal())', function(done) {
-                runner.run({
-                    language: 'objc',
-                    code: 'NSString* Foo (NSString *str){return str;}',
-                    testFramework: 'cw',
-                    fixture: `
+    describe('CW', function() {
+      it('should perform unit testing and test for failure (test equal())', function(done) {
+        runner.run({
+          language: 'objc',
+          code: 'NSString* Foo (NSString *str){return str;}',
+          testFramework: 'cw',
+          fixture: `
                         describe(@"String match", ^() {
                             it(@"should not match", ^() {
                                 equal(@"Blah", Foo(@"Blah1"));
                             });
                         });
                     `
-                }, function(buffer) {
-                    console.log(buffer);
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>String match');
-                    expect(buffer.stdout).to.contain('<IT::>should not match');
-                    expect(buffer.stdout).to.contain('<FAILED::>Expected "Blah" (NSConstantString) but instead got "Blah1" (NSConstantString)');
-                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-                    done();
-                });
-            });
-            it('should perform unit testing and pass the test (test notEqual())', function(done) {
-                runner.run({
-                    language: 'objc',
-                    code: 'NSString* Foo (NSString *str){return str;}',
-                    testFramework: 'cw',
-                    fixture: [
-                        'describe(@"String not match", ^() {',
-                            'it(@"should pass", ^() {',
-                                'notEqual(@"Blah", Foo(@"Blah"));',
-                            '});',
-                        '});'
-                    ].join('\n')
-                }, function(buffer) {
-                    console.log(buffer);
-                    expect(buffer.stdout).to.contain('<FAILED::>Value is not supposed to equal "Blah" (NSConstantString)');
-                    expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
-                    expect(buffer.stdout).to.contain('<IT::>should pass');
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>String not match');
-                    expect(buffer.stderr).to.equal('');
-                    done();
-                });
-            });
+        }, function(buffer) {
+          console.log(buffer);
+          expect(buffer.stdout).to.contain('<DESCRIBE::>String match');
+          expect(buffer.stdout).to.contain('<IT::>should not match');
+          expect(buffer.stdout).to.contain('<FAILED::>Expected "Blah" (NSConstantString) but instead got "Blah1" (NSConstantString)');
+          expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+          done();
         });
+      });
+      it('should perform unit testing and pass the test (test notEqual())', function(done) {
+        runner.run({
+          language: 'objc',
+          code: 'NSString* Foo (NSString *str){return str;}',
+          testFramework: 'cw',
+          fixture: [
+            'describe(@"String not match", ^() {',
+            'it(@"should pass", ^() {',
+            'notEqual(@"Blah", Foo(@"Blah"));',
+            '});',
+            '});'
+          ].join('\n')
+        }, function(buffer) {
+          console.log(buffer);
+          expect(buffer.stdout).to.contain('<FAILED::>Value is not supposed to equal "Blah" (NSConstantString)');
+          expect(buffer.stdout).to.contain('<COMPLETEDIN::>');
+          expect(buffer.stdout).to.contain('<IT::>should pass');
+          expect(buffer.stdout).to.contain('<DESCRIBE::>String not match');
+          expect(buffer.stderr).to.equal('');
+          done();
+        });
+      });
     });
+  });
 });

--- a/test/runners/ocaml_spec.js
+++ b/test/runners/ocaml_spec.js
@@ -3,47 +3,47 @@ var runner = require('../runner');
 
 
 describe( 'ocaml runner', function(){
-    describe( '.run', function(){
-        runner.assertCodeExamples('ocaml');
+  describe( '.run', function(){
+    runner.assertCodeExamples('ocaml');
 
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'ocaml', code: 'print_string "42\n";;'}, function(buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'ocaml', code: 'print_string "42\n";;'}, function(buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
     });
+  });
 
-    describe('using oUnit for testing', function(){
-        it('should be able to run a basic test', function(done){
-            runner.run({
-                language: 'ocaml',
-                code: [
-                    'module Person = struct',
-                    '    type t = { name: string }',
-                    '    let greet (person: t) = "Hello, " ^ person.name ^ "!"',
-                    'end'
-                ].join('\n'),
-                fixture: [
-                    'module Tests = struct',
-                    '   open OUnit',
-                    '   let suite = ',
-                    '       [',
-                    '           "Person" >:::',
-                    '           [',
-                    '               ".greet" >:: (fun _ -> ',
-                    '                   let jack: Person.t = { Person.name = "Jack" } in ',
-                    '                   assert_equal "Hello, Jack!" (Person.greet jack)',
-                    '               )',
-                    '           ]',
-                    '       ]',
-                    'end'
-                ].join('\n')
-            }, function(buffer){
-                console.log(buffer);
-                expect(buffer.stdout).to.contain("<DESCRIBE::>Person\n<IT::>.greet\n<PASSED::>");
-                done();
-            })
-        });
-    })
+  describe('using oUnit for testing', function(){
+    it('should be able to run a basic test', function(done){
+      runner.run({
+        language: 'ocaml',
+        code: [
+          'module Person = struct',
+          '    type t = { name: string }',
+          '    let greet (person: t) = "Hello, " ^ person.name ^ "!"',
+          'end'
+        ].join('\n'),
+        fixture: [
+          'module Tests = struct',
+          '   open OUnit',
+          '   let suite = ',
+          '       [',
+          '           "Person" >:::',
+          '           [',
+          '               ".greet" >:: (fun _ -> ',
+          '                   let jack: Person.t = { Person.name = "Jack" } in ',
+          '                   assert_equal "Hello, Jack!" (Person.greet jack)',
+          '               )',
+          '           ]',
+          '       ]',
+          'end'
+        ].join('\n')
+      }, function(buffer){
+        console.log(buffer);
+        expect(buffer.stdout).to.contain("<DESCRIBE::>Person\n<IT::>.greet\n<PASSED::>");
+        done();
+      })
+    });
+  })
 });

--- a/test/runners/perl_spec.js
+++ b/test/runners/perl_spec.js
@@ -3,12 +3,12 @@ var runner = require('../runner');
 
 
 describe( 'perl runner', function(){
-    describe( '.run', function(){
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'perl', code: 'print 42'}, function(buffer) {
-                expect(buffer.stdout).to.equal('42');
-                done();
-            });
-        });
+  describe( '.run', function(){
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'perl', code: 'print 42'}, function(buffer) {
+        expect(buffer.stdout).to.equal('42');
+        done();
+      });
     });
+  });
 });

--- a/test/runners/php_spec.js
+++ b/test/runners/php_spec.js
@@ -15,9 +15,9 @@ describe( 'php runner', function(){
 
         it( 'should handle bad syntax', function(done){
             runner.run({
-            	language: 'php',
-            	solution: `fliggaflagam!!!`
-        	}, function(buffer) {
+                language: 'php',
+                solution: `fliggaflagam!!!`
+            }, function(buffer) {
                 expect(buffer.stderr).to.contain('syntax error');
                 done();
             });
@@ -25,9 +25,9 @@ describe( 'php runner', function(){
 
         it( 'should handle thrown exceptions', function(done){
             runner.run({
-            	language: 'php',
-            	solution: `throw new Exception('Rawr!');`
-        	}, function(buffer) {
+                language: 'php',
+                solution: `throw new Exception('Rawr!');`
+            }, function(buffer) {
                 expect(buffer.stderr).to.contain('Rawr!');
                 done();
             });
@@ -35,9 +35,9 @@ describe( 'php runner', function(){
 
         it( 'should handle undefined functions', function(done){
             runner.run({
-            	language: 'php',
-            	solution: `fliggaflagam();`
-        	}, function(buffer) {
+                language: 'php',
+                solution: `fliggaflagam();`
+            }, function(buffer) {
                 expect(buffer.stderr).to.contain('Uncaught Error');
                 done();
             });
@@ -45,379 +45,379 @@ describe( 'php runner', function(){
 
         it( 'should handle the latest and greatest of PHP 7', function(done){
             runner.run({
-            	language: 'php',
-            	solution: `
-								function sumOfInts(int ...$ints) { return array_sum($ints); }
-								echo sumOfInts(2, '3', 4.1);
-        		`
-        	}, function(buffer) {
-								console.log(buffer);
+                language: 'php',
+                solution: `
+                                function sumOfInts(int ...$ints) { return array_sum($ints); }
+                                echo sumOfInts(2, '3', 4.1);
+                `
+            }, function(buffer) {
+                                console.log(buffer);
                 expect(buffer.stdout).to.equal('9');
                 done();
             });
         });
 
         describe('cw-2', function() {
-        	it('should handle some basic tests', function(done) {
-		        runner.run({
-	                language: 'php',
-	                code: `
-				      function double($a) {
-				        return $a * 2;
-				      }
-	                `,
-	                fixture: `
-	                	$test->assert_equals(double(1, 2), 2);
-	                `,
-	                testFramework: 'cw-2'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<PASSED::>');
-	                done();
-	            });
-        	});
+            it('should handle some basic tests', function(done) {
+                runner.run({
+                    language: 'php',
+                    code: `
+                      function double($a) {
+                        return $a * 2;
+                      }
+                    `,
+                    fixture: `
+                        $test->assert_equals(double(1, 2), 2);
+                    `,
+                    testFramework: 'cw-2'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<PASSED::>');
+                    done();
+                });
+            });
 
-        	it('should be able to reference preloaded code', function(done) {
-		        runner.run({
-	                language: 'php',
-	                setup: `
-	                	class SomeClass
-						{
-						    const CONSTANT = 42;
-						}
-	                `,
-	                code: `
-					    function theConstant() {
-					        return SomeClass::CONSTANT;
-					    }
-	                `,
-	                fixture: `
-	                	$test->assert_equals(theConstant(), SomeClass::CONSTANT);
-	                `,
-	                testFramework: 'cw-2'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<PASSED::>');
-	                done();
-	            });
-        	});
+            it('should be able to reference preloaded code', function(done) {
+                runner.run({
+                    language: 'php',
+                    setup: `
+                        class SomeClass
+                        {
+                            const CONSTANT = 42;
+                        }
+                    `,
+                    code: `
+                        function theConstant() {
+                            return SomeClass::CONSTANT;
+                        }
+                    `,
+                    fixture: `
+                        $test->assert_equals(theConstant(), SomeClass::CONSTANT);
+                    `,
+                    testFramework: 'cw-2'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<PASSED::>');
+                    done();
+                });
+            });
 
-        	it('should handle failed tests', function(done) {
-		        runner.run({
-	                language: 'php',
-	                code: `
-				      function double($a) {
-				        return $a * 2;
-				      }
-	                `,
-	                fixture: `
-	                	$test->assert_equals(double(1), 6);
-	                `,
-	                testFramework: 'cw-2'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<FAILED::>');
-	                done();
-	            });
-        	});
+            it('should handle failed tests', function(done) {
+                runner.run({
+                    language: 'php',
+                    code: `
+                      function double($a) {
+                        return $a * 2;
+                      }
+                    `,
+                    fixture: `
+                        $test->assert_equals(double(1), 6);
+                    `,
+                    testFramework: 'cw-2'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<FAILED::>');
+                    done();
+                });
+            });
 
-        	it('should handle bad assertions', function(done) {
-		        runner.run({
-	                language: 'php',
-	                code: `
-						const CONSTANT = 42;
-	                `,
-	                fixture: `
-	                	$test->assert_equals(CONSTANT, 'apples');
-	                `,
-	                testFramework: 'cw-2'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<FAILED::>');
-	                done();
-	            });
-        	});
+            it('should handle bad assertions', function(done) {
+                runner.run({
+                    language: 'php',
+                    code: `
+                        const CONSTANT = 42;
+                    `,
+                    fixture: `
+                        $test->assert_equals(CONSTANT, 'apples');
+                    `,
+                    testFramework: 'cw-2'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<FAILED::>');
+                    done();
+                });
+            });
 
-	        it( 'should handle thrown exceptions', function(done){
-		        runner.run({
-	                language: 'php',
-	                code: `
-	                	$pizza = 'yummy';
-	                `,
-	                fixture: `
-	                	throw new Exception('Roffle!');
-	                `,
-	                testFramework: 'cw-2'
-	            },
-	            function(buffer) {
-	                expect(buffer.stderr).to.contain('Roffle!');
-	                done();
-	            });
-	        });
+            it( 'should handle thrown exceptions', function(done){
+                runner.run({
+                    language: 'php',
+                    code: `
+                        $pizza = 'yummy';
+                    `,
+                    fixture: `
+                        throw new Exception('Roffle!');
+                    `,
+                    testFramework: 'cw-2'
+                },
+                function(buffer) {
+                    expect(buffer.stderr).to.contain('Roffle!');
+                    done();
+                });
+            });
         });
 
         describe('phpunit', function() {
-        	it('should handle some basic tests', function(done) {
-		        runner.run({
-	                language: 'php',
-	                code: `
-				      function double($a) {
-				        return $a * 2;
-				      }
-	                `,
-	                fixture: `
-			            class DoubleMethod extends TestCase
-			            {
-		                	public function testDouble() {
-		                		$this->assertEquals(double(1), 2);
-		                	}
-			            }
-	                `,
-	                testFramework: 'phpunit'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<PASSED::>');
-	                done();
-	            });
-        	});
-	        it('should handle multiple tests', function(done) {
-		        runner.run({
-	                language: 'php',
-	                code: `
-				      function double($a) {
-				        return $a * 2;
-				      }
-	                `,
-	                fixture: `
-			            class DoubleMethod extends TestCase
-			            {
-		                	public function testDouble() {
-		                		$this->assertEquals(double(1), 2);
-		                	}
-		                	public function testDouble2() {
+            it('should handle some basic tests', function(done) {
+                runner.run({
+                    language: 'php',
+                    code: `
+                      function double($a) {
+                        return $a * 2;
+                      }
+                    `,
+                    fixture: `
+                        class DoubleMethod extends TestCase
+                        {
+                            public function testDouble() {
+                                $this->assertEquals(double(1), 2);
+                            }
+                        }
+                    `,
+                    testFramework: 'phpunit'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<PASSED::>');
+                    done();
+                });
+            });
+            it('should handle multiple tests', function(done) {
+                runner.run({
+                    language: 'php',
+                    code: `
+                      function double($a) {
+                        return $a * 2;
+                      }
+                    `,
+                    fixture: `
+                        class DoubleMethod extends TestCase
+                        {
+                            public function testDouble() {
+                                $this->assertEquals(double(1), 2);
+                            }
+                            public function testDouble2() {
                                 $this->assertEquals(double(2), 4);
                             }
                             public function testDouble3() {
                                 $this->assertEquals(double(4), 8);
                             }
-			            }
-	                `,
-	                testFramework: 'phpunit'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('\n<IT::>testDouble\n');
-		            expect(buffer.stdout).to.contain('\n<IT::>testDouble2\n');
-		            expect(buffer.stdout).to.contain('\n<IT::>testDouble3\n');
-	                done();
-	            });
-        	});
+                        }
+                    `,
+                    testFramework: 'phpunit'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('\n<IT::>testDouble\n');
+                    expect(buffer.stdout).to.contain('\n<IT::>testDouble2\n');
+                    expect(buffer.stdout).to.contain('\n<IT::>testDouble3\n');
+                    done();
+                });
+            });
 
-	        it( 'should render console output', function(done){
-		        runner.run({
-	                language: 'php',
-	                code: `
-	                  function double($a) {
-	                    print("this was a triumph\n");
-	                    return $a * 2;
-	                  }
-	                `,
-	                fixture: `
-	                    class DoubleMethod extends TestCase
-	                    {
-	                        public function testDouble() {
-	                            $this->assertEquals(double(1), 2);
-	                        }
-	                    }
-	                `,
-	                testFramework: 'phpunit'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<PASSED::>');
-		            expect(buffer.stdout).to.contain('this was a triumph');
-	                done();
-	            });
-	        });
+            it( 'should render console output', function(done){
+                runner.run({
+                    language: 'php',
+                    code: `
+                      function double($a) {
+                        print("this was a triumph\n");
+                        return $a * 2;
+                      }
+                    `,
+                    fixture: `
+                        class DoubleMethod extends TestCase
+                        {
+                            public function testDouble() {
+                                $this->assertEquals(double(1), 2);
+                            }
+                        }
+                    `,
+                    testFramework: 'phpunit'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<PASSED::>');
+                    expect(buffer.stdout).to.contain('this was a triumph');
+                    done();
+                });
+            });
 
-	        it( 'should handle console output without linewraps', function(done){
-		        runner.run({
-	                language: 'php',
-	                code: `
-	                  function double($a) {
-	                    print("this was a triumph");
-	                    return $a * 2;
-	                  }
-	                `,
-	                fixture: `
-	                    class DoubleMethod extends TestCase
-	                    {
-	                        public function testDouble() {
-	                            print("I'm making a note here, huge success");
-	                            $this->assertEquals(double(1), 2);
-	                        }
-	                    }
-	                `,
-	                testFramework: 'phpunit'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('\n<PASSED::>');
-		            expect(buffer.stdout).to.contain('huge success');
-		            expect(buffer.stdout).to.contain('this was a triumph');
-	                done();
-	            });
-	        });
+            it( 'should handle console output without linewraps', function(done){
+                runner.run({
+                    language: 'php',
+                    code: `
+                      function double($a) {
+                        print("this was a triumph");
+                        return $a * 2;
+                      }
+                    `,
+                    fixture: `
+                        class DoubleMethod extends TestCase
+                        {
+                            public function testDouble() {
+                                print("I'm making a note here, huge success");
+                                $this->assertEquals(double(1), 2);
+                            }
+                        }
+                    `,
+                    testFramework: 'phpunit'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('\n<PASSED::>');
+                    expect(buffer.stdout).to.contain('huge success');
+                    expect(buffer.stdout).to.contain('this was a triumph');
+                    done();
+                });
+            });
 
-        	it('should be able to reference preloaded code', function(done) {
-		        runner.run({
-	                language: 'php',
-	                setup: `
-	                	class SomeClass
-						{
-						    const CONSTANT = 42;
-						}
-	                `,
-	                code: `
-					    function theConstant() {
-					        return SomeClass::CONSTANT;
-					    }
-	                `,
-	                fixture: `
-			            class TheConstantMethod extends TestCase
-			            {
-		                	public function testConstantMethod() {
-	                			$this->assertEquals(theConstant(), SomeClass::CONSTANT);
-		                	}
-			            }
-	                `,
-	                testFramework: 'phpunit'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<PASSED::>');
-	                done();
-	            });
-        	});
+            it('should be able to reference preloaded code', function(done) {
+                runner.run({
+                    language: 'php',
+                    setup: `
+                        class SomeClass
+                        {
+                            const CONSTANT = 42;
+                        }
+                    `,
+                    code: `
+                        function theConstant() {
+                            return SomeClass::CONSTANT;
+                        }
+                    `,
+                    fixture: `
+                        class TheConstantMethod extends TestCase
+                        {
+                            public function testConstantMethod() {
+                                $this->assertEquals(theConstant(), SomeClass::CONSTANT);
+                            }
+                        }
+                    `,
+                    testFramework: 'phpunit'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<PASSED::>');
+                    done();
+                });
+            });
 
-	        it('should handle failed tests', function(done) {
-		        runner.run({
-	                language: 'php',
-	                code: `
-				      function double($a) {
-				        return $a * 2;
-				      }
-	                `,
-	                fixture: `
-			            class TheConstantMethod extends TestCase
-			            {
-		                	public function testConstantMethod() {
-	                			$this->assertEquals(double(1), 6);
-		                	}
-			            }
-	                `,
-	                testFramework: 'phpunit'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<FAILED::>');
-		            expect(buffer.stdout).to.not.contain('<PASSED::>');
-	                done();
-	            });
-        	});
+            it('should handle failed tests', function(done) {
+                runner.run({
+                    language: 'php',
+                    code: `
+                      function double($a) {
+                        return $a * 2;
+                      }
+                    `,
+                    fixture: `
+                        class TheConstantMethod extends TestCase
+                        {
+                            public function testConstantMethod() {
+                                $this->assertEquals(double(1), 6);
+                            }
+                        }
+                    `,
+                    testFramework: 'phpunit'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<FAILED::>');
+                    expect(buffer.stdout).to.not.contain('<PASSED::>');
+                    done();
+                });
+            });
 
 
-	        it('should render output on failed tests', function(done) {
-		        runner.run({
-	                language: 'php',
-	                code: `
-				      function greet($s) {
-				        return 'hello, ' . $s;
-				      }
-	                `,
-	                fixture: `
-			            class GreetingTest extends TestCase
-			            {
-		                	public function testGreet() {
-	                			$this->assertEquals(greet('Joe'), 'Hello, Joe');
-		                	}
-			            }
-	                `,
-	                testFramework: 'phpunit'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<FAILED::>');
-		            expect(buffer.stdout).to.contain('hello, Joe');
-		            expect(buffer.stdout).to.contain('Hello, Joe');
-	                done();
-	            });
-        	});
+            it('should render output on failed tests', function(done) {
+                runner.run({
+                    language: 'php',
+                    code: `
+                      function greet($s) {
+                        return 'hello, ' . $s;
+                      }
+                    `,
+                    fixture: `
+                        class GreetingTest extends TestCase
+                        {
+                            public function testGreet() {
+                                $this->assertEquals(greet('Joe'), 'Hello, Joe');
+                            }
+                        }
+                    `,
+                    testFramework: 'phpunit'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<FAILED::>');
+                    expect(buffer.stdout).to.contain('hello, Joe');
+                    expect(buffer.stdout).to.contain('Hello, Joe');
+                    done();
+                });
+            });
 
-        	it('should handle bad assertions', function(done) {
-		        runner.run({
-	                language: 'php',
-	                code: `
-						const CONSTANT = 42;
-	                `,
-	                fixture: `
-			            class TheConstantMethod extends TestCase
-			            {
-		                	public function testConstantMethod() {
-	                			$this->assertEquals(CONSTANT, 'apples');
-		                	}
-			            }
-	                `,
-	                testFramework: 'phpunit'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<FAILED::>');
-		            expect(buffer.stdout).to.not.contain('<PASSED::>');
-	                done();
-	            });
-        	});
+            it('should handle bad assertions', function(done) {
+                runner.run({
+                    language: 'php',
+                    code: `
+                        const CONSTANT = 42;
+                    `,
+                    fixture: `
+                        class TheConstantMethod extends TestCase
+                        {
+                            public function testConstantMethod() {
+                                $this->assertEquals(CONSTANT, 'apples');
+                            }
+                        }
+                    `,
+                    testFramework: 'phpunit'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<FAILED::>');
+                    expect(buffer.stdout).to.not.contain('<PASSED::>');
+                    done();
+                });
+            });
 
-	        it( 'should handle thrown exceptions', function(done){
-		        runner.run({
-	                language: 'php',
-	                code: `
-	                	$pizza = 'yummy';
-	                `,
-	                fixture: `
-			            class TheConstantMethod extends TestCase
-			            {
-		                	public function testConstantMethod() {
-		                		throw new Exception('Waffles!');
-		                	}
-			            }
-	                `,
-	                testFramework: 'phpunit'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('Waffles!');
-	                done();
-	            });
-	        });
+            it( 'should handle thrown exceptions', function(done){
+                runner.run({
+                    language: 'php',
+                    code: `
+                        $pizza = 'yummy';
+                    `,
+                    fixture: `
+                        class TheConstantMethod extends TestCase
+                        {
+                            public function testConstantMethod() {
+                                throw new Exception('Waffles!');
+                            }
+                        }
+                    `,
+                    testFramework: 'phpunit'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('Waffles!');
+                    done();
+                });
+            });
 
-	        it('should fail on PHP errors', function(done) {
-		        runner.run({
-	                language: 'php',
-	                code: `
-						function double($a) {
-							return $a * 2;
-						}
-	                `,
-	                fixture: `
-			            class Double extends TestCase
-			            {
-		                	public function testBadDouble() {
-	                			$this->assertEquals(double(), 2);
-		                	}
-			            }
-	                `,
-	                testFramework: 'phpunit'
-	            },
-	            function(buffer) {
-	                expect(buffer.stdout).to.contain('<FAILED::>');
-		            expect(buffer.stdout).to.not.contain('<PASSED::>');
-	                done();
-	            });
-        	});
-    	});
+            it('should fail on PHP errors', function(done) {
+                runner.run({
+                    language: 'php',
+                    code: `
+                        function double($a) {
+                            return $a * 2;
+                        }
+                    `,
+                    fixture: `
+                        class Double extends TestCase
+                        {
+                            public function testBadDouble() {
+                                $this->assertEquals(double(), 2);
+                            }
+                        }
+                    `,
+                    testFramework: 'phpunit'
+                },
+                function(buffer) {
+                    expect(buffer.stdout).to.contain('<FAILED::>');
+                    expect(buffer.stdout).to.not.contain('<PASSED::>');
+                    done();
+                });
+            });
+        });
 
     });
 });

--- a/test/runners/php_spec.js
+++ b/test/runners/php_spec.js
@@ -3,169 +3,169 @@ var runner = require('../runner');
 
 
 describe( 'php runner', function(){
-    describe( '.run', function(){
-        runner.assertCodeExamples('php');
+  describe( '.run', function(){
+    runner.assertCodeExamples('php');
 
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'php', solution: 'echo 42;'}, function(buffer) {
-                expect(buffer.stdout).to.equal('42');
-                done();
-            });
-        });
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'php', solution: 'echo 42;'}, function(buffer) {
+        expect(buffer.stdout).to.equal('42');
+        done();
+      });
+    });
 
-        it( 'should handle bad syntax', function(done){
-            runner.run({
-                language: 'php',
-                solution: `fliggaflagam!!!`
-            }, function(buffer) {
-                expect(buffer.stderr).to.contain('syntax error');
-                done();
-            });
-        });
+    it( 'should handle bad syntax', function(done){
+      runner.run({
+        language: 'php',
+        solution: `fliggaflagam!!!`
+      }, function(buffer) {
+        expect(buffer.stderr).to.contain('syntax error');
+        done();
+      });
+    });
 
-        it( 'should handle thrown exceptions', function(done){
-            runner.run({
-                language: 'php',
-                solution: `throw new Exception('Rawr!');`
-            }, function(buffer) {
-                expect(buffer.stderr).to.contain('Rawr!');
-                done();
-            });
-        });
+    it( 'should handle thrown exceptions', function(done){
+      runner.run({
+        language: 'php',
+        solution: `throw new Exception('Rawr!');`
+      }, function(buffer) {
+        expect(buffer.stderr).to.contain('Rawr!');
+        done();
+      });
+    });
 
-        it( 'should handle undefined functions', function(done){
-            runner.run({
-                language: 'php',
-                solution: `fliggaflagam();`
-            }, function(buffer) {
-                expect(buffer.stderr).to.contain('Uncaught Error');
-                done();
-            });
-        });
+    it( 'should handle undefined functions', function(done){
+      runner.run({
+        language: 'php',
+        solution: `fliggaflagam();`
+      }, function(buffer) {
+        expect(buffer.stderr).to.contain('Uncaught Error');
+        done();
+      });
+    });
 
-        it( 'should handle the latest and greatest of PHP 7', function(done){
-            runner.run({
-                language: 'php',
-                solution: `
+    it( 'should handle the latest and greatest of PHP 7', function(done){
+      runner.run({
+        language: 'php',
+        solution: `
                                 function sumOfInts(int ...$ints) { return array_sum($ints); }
                                 echo sumOfInts(2, '3', 4.1);
                 `
-            }, function(buffer) {
-                                console.log(buffer);
-                expect(buffer.stdout).to.equal('9');
-                done();
-            });
-        });
+      }, function(buffer) {
+        console.log(buffer);
+        expect(buffer.stdout).to.equal('9');
+        done();
+      });
+    });
 
-        describe('cw-2', function() {
-            it('should handle some basic tests', function(done) {
-                runner.run({
-                    language: 'php',
-                    code: `
+    describe('cw-2', function() {
+      it('should handle some basic tests', function(done) {
+        runner.run({
+          language: 'php',
+          code: `
                       function double($a) {
                         return $a * 2;
                       }
                     `,
-                    fixture: `
+          fixture: `
                         $test->assert_equals(double(1, 2), 2);
                     `,
-                    testFramework: 'cw-2'
-                },
+          testFramework: 'cw-2'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<PASSED::>');
+                  done();
                 });
-            });
+      });
 
-            it('should be able to reference preloaded code', function(done) {
-                runner.run({
-                    language: 'php',
-                    setup: `
+      it('should be able to reference preloaded code', function(done) {
+        runner.run({
+          language: 'php',
+          setup: `
                         class SomeClass
                         {
                             const CONSTANT = 42;
                         }
                     `,
-                    code: `
+          code: `
                         function theConstant() {
                             return SomeClass::CONSTANT;
                         }
                     `,
-                    fixture: `
+          fixture: `
                         $test->assert_equals(theConstant(), SomeClass::CONSTANT);
                     `,
-                    testFramework: 'cw-2'
-                },
+          testFramework: 'cw-2'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<PASSED::>');
+                  done();
                 });
-            });
+      });
 
-            it('should handle failed tests', function(done) {
-                runner.run({
-                    language: 'php',
-                    code: `
+      it('should handle failed tests', function(done) {
+        runner.run({
+          language: 'php',
+          code: `
                       function double($a) {
                         return $a * 2;
                       }
                     `,
-                    fixture: `
+          fixture: `
                         $test->assert_equals(double(1), 6);
                     `,
-                    testFramework: 'cw-2'
-                },
+          testFramework: 'cw-2'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<FAILED::>');
+                  done();
                 });
-            });
+      });
 
-            it('should handle bad assertions', function(done) {
-                runner.run({
-                    language: 'php',
-                    code: `
+      it('should handle bad assertions', function(done) {
+        runner.run({
+          language: 'php',
+          code: `
                         const CONSTANT = 42;
                     `,
-                    fixture: `
+          fixture: `
                         $test->assert_equals(CONSTANT, 'apples');
                     `,
-                    testFramework: 'cw-2'
-                },
+          testFramework: 'cw-2'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<FAILED::>');
+                  done();
                 });
-            });
+      });
 
-            it( 'should handle thrown exceptions', function(done){
-                runner.run({
-                    language: 'php',
-                    code: `
+      it( 'should handle thrown exceptions', function(done){
+        runner.run({
+          language: 'php',
+          code: `
                         $pizza = 'yummy';
                     `,
-                    fixture: `
+          fixture: `
                         throw new Exception('Roffle!');
                     `,
-                    testFramework: 'cw-2'
-                },
+          testFramework: 'cw-2'
+        },
                 function(buffer) {
-                    expect(buffer.stderr).to.contain('Roffle!');
-                    done();
+                  expect(buffer.stderr).to.contain('Roffle!');
+                  done();
                 });
-            });
-        });
+      });
+    });
 
-        describe('phpunit', function() {
-            it('should handle some basic tests', function(done) {
-                runner.run({
-                    language: 'php',
-                    code: `
+    describe('phpunit', function() {
+      it('should handle some basic tests', function(done) {
+        runner.run({
+          language: 'php',
+          code: `
                       function double($a) {
                         return $a * 2;
                       }
                     `,
-                    fixture: `
+          fixture: `
                         class DoubleMethod extends TestCase
                         {
                             public function testDouble() {
@@ -173,22 +173,22 @@ describe( 'php runner', function(){
                             }
                         }
                     `,
-                    testFramework: 'phpunit'
-                },
+          testFramework: 'phpunit'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<PASSED::>');
+                  done();
                 });
-            });
-            it('should handle multiple tests', function(done) {
-                runner.run({
-                    language: 'php',
-                    code: `
+      });
+      it('should handle multiple tests', function(done) {
+        runner.run({
+          language: 'php',
+          code: `
                       function double($a) {
                         return $a * 2;
                       }
                     `,
-                    fixture: `
+          fixture: `
                         class DoubleMethod extends TestCase
                         {
                             public function testDouble() {
@@ -202,26 +202,26 @@ describe( 'php runner', function(){
                             }
                         }
                     `,
-                    testFramework: 'phpunit'
-                },
+          testFramework: 'phpunit'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('\n<IT::>testDouble\n');
-                    expect(buffer.stdout).to.contain('\n<IT::>testDouble2\n');
-                    expect(buffer.stdout).to.contain('\n<IT::>testDouble3\n');
-                    done();
+                  expect(buffer.stdout).to.contain('\n<IT::>testDouble\n');
+                  expect(buffer.stdout).to.contain('\n<IT::>testDouble2\n');
+                  expect(buffer.stdout).to.contain('\n<IT::>testDouble3\n');
+                  done();
                 });
-            });
+      });
 
-            it( 'should render console output', function(done){
-                runner.run({
-                    language: 'php',
-                    code: `
+      it( 'should render console output', function(done){
+        runner.run({
+          language: 'php',
+          code: `
                       function double($a) {
                         print("this was a triumph\n");
                         return $a * 2;
                       }
                     `,
-                    fixture: `
+          fixture: `
                         class DoubleMethod extends TestCase
                         {
                             public function testDouble() {
@@ -229,25 +229,25 @@ describe( 'php runner', function(){
                             }
                         }
                     `,
-                    testFramework: 'phpunit'
-                },
+          testFramework: 'phpunit'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    expect(buffer.stdout).to.contain('this was a triumph');
-                    done();
+                  expect(buffer.stdout).to.contain('<PASSED::>');
+                  expect(buffer.stdout).to.contain('this was a triumph');
+                  done();
                 });
-            });
+      });
 
-            it( 'should handle console output without linewraps', function(done){
-                runner.run({
-                    language: 'php',
-                    code: `
+      it( 'should handle console output without linewraps', function(done){
+        runner.run({
+          language: 'php',
+          code: `
                       function double($a) {
                         print("this was a triumph");
                         return $a * 2;
                       }
                     `,
-                    fixture: `
+          fixture: `
                         class DoubleMethod extends TestCase
                         {
                             public function testDouble() {
@@ -256,31 +256,31 @@ describe( 'php runner', function(){
                             }
                         }
                     `,
-                    testFramework: 'phpunit'
-                },
+          testFramework: 'phpunit'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('\n<PASSED::>');
-                    expect(buffer.stdout).to.contain('huge success');
-                    expect(buffer.stdout).to.contain('this was a triumph');
-                    done();
+                  expect(buffer.stdout).to.contain('\n<PASSED::>');
+                  expect(buffer.stdout).to.contain('huge success');
+                  expect(buffer.stdout).to.contain('this was a triumph');
+                  done();
                 });
-            });
+      });
 
-            it('should be able to reference preloaded code', function(done) {
-                runner.run({
-                    language: 'php',
-                    setup: `
+      it('should be able to reference preloaded code', function(done) {
+        runner.run({
+          language: 'php',
+          setup: `
                         class SomeClass
                         {
                             const CONSTANT = 42;
                         }
                     `,
-                    code: `
+          code: `
                         function theConstant() {
                             return SomeClass::CONSTANT;
                         }
                     `,
-                    fixture: `
+          fixture: `
                         class TheConstantMethod extends TestCase
                         {
                             public function testConstantMethod() {
@@ -288,23 +288,23 @@ describe( 'php runner', function(){
                             }
                         }
                     `,
-                    testFramework: 'phpunit'
-                },
+          testFramework: 'phpunit'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<PASSED::>');
+                  done();
                 });
-            });
+      });
 
-            it('should handle failed tests', function(done) {
-                runner.run({
-                    language: 'php',
-                    code: `
+      it('should handle failed tests', function(done) {
+        runner.run({
+          language: 'php',
+          code: `
                       function double($a) {
                         return $a * 2;
                       }
                     `,
-                    fixture: `
+          fixture: `
                         class TheConstantMethod extends TestCase
                         {
                             public function testConstantMethod() {
@@ -312,25 +312,25 @@ describe( 'php runner', function(){
                             }
                         }
                     `,
-                    testFramework: 'phpunit'
-                },
+          testFramework: 'phpunit'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    expect(buffer.stdout).to.not.contain('<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<FAILED::>');
+                  expect(buffer.stdout).to.not.contain('<PASSED::>');
+                  done();
                 });
-            });
+      });
 
 
-            it('should render output on failed tests', function(done) {
-                runner.run({
-                    language: 'php',
-                    code: `
+      it('should render output on failed tests', function(done) {
+        runner.run({
+          language: 'php',
+          code: `
                       function greet($s) {
                         return 'hello, ' . $s;
                       }
                     `,
-                    fixture: `
+          fixture: `
                         class GreetingTest extends TestCase
                         {
                             public function testGreet() {
@@ -338,23 +338,23 @@ describe( 'php runner', function(){
                             }
                         }
                     `,
-                    testFramework: 'phpunit'
-                },
+          testFramework: 'phpunit'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    expect(buffer.stdout).to.contain('hello, Joe');
-                    expect(buffer.stdout).to.contain('Hello, Joe');
-                    done();
+                  expect(buffer.stdout).to.contain('<FAILED::>');
+                  expect(buffer.stdout).to.contain('hello, Joe');
+                  expect(buffer.stdout).to.contain('Hello, Joe');
+                  done();
                 });
-            });
+      });
 
-            it('should handle bad assertions', function(done) {
-                runner.run({
-                    language: 'php',
-                    code: `
+      it('should handle bad assertions', function(done) {
+        runner.run({
+          language: 'php',
+          code: `
                         const CONSTANT = 42;
                     `,
-                    fixture: `
+          fixture: `
                         class TheConstantMethod extends TestCase
                         {
                             public function testConstantMethod() {
@@ -362,22 +362,22 @@ describe( 'php runner', function(){
                             }
                         }
                     `,
-                    testFramework: 'phpunit'
-                },
+          testFramework: 'phpunit'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    expect(buffer.stdout).to.not.contain('<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<FAILED::>');
+                  expect(buffer.stdout).to.not.contain('<PASSED::>');
+                  done();
                 });
-            });
+      });
 
-            it( 'should handle thrown exceptions', function(done){
-                runner.run({
-                    language: 'php',
-                    code: `
+      it( 'should handle thrown exceptions', function(done){
+        runner.run({
+          language: 'php',
+          code: `
                         $pizza = 'yummy';
                     `,
-                    fixture: `
+          fixture: `
                         class TheConstantMethod extends TestCase
                         {
                             public function testConstantMethod() {
@@ -385,23 +385,23 @@ describe( 'php runner', function(){
                             }
                         }
                     `,
-                    testFramework: 'phpunit'
-                },
+          testFramework: 'phpunit'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('Waffles!');
-                    done();
+                  expect(buffer.stdout).to.contain('Waffles!');
+                  done();
                 });
-            });
+      });
 
-            it('should fail on PHP errors', function(done) {
-                runner.run({
-                    language: 'php',
-                    code: `
+      it('should fail on PHP errors', function(done) {
+        runner.run({
+          language: 'php',
+          code: `
                         function double($a) {
                             return $a * 2;
                         }
                     `,
-                    fixture: `
+          fixture: `
                         class Double extends TestCase
                         {
                             public function testBadDouble() {
@@ -409,15 +409,15 @@ describe( 'php runner', function(){
                             }
                         }
                     `,
-                    testFramework: 'phpunit'
-                },
+          testFramework: 'phpunit'
+        },
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    expect(buffer.stdout).to.not.contain('<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<FAILED::>');
+                  expect(buffer.stdout).to.not.contain('<PASSED::>');
+                  done();
                 });
-            });
-        });
-
+      });
     });
+
+  });
 });

--- a/test/runners/python_spec.js
+++ b/test/runners/python_spec.js
@@ -3,193 +3,193 @@ var runner = require('../runner');
 
 describe('python runner', function () {
     // These specs are compatible with both Python 2 and 3
-    ['2', '3', '3.6'].forEach(lv => {
-        describe('.run', function () {
-            runner.assertCodeExamples('python', lv);
+  ['2', '3', '3.6'].forEach(lv => {
+    describe('.run', function () {
+      runner.assertCodeExamples('python', lv);
 
-            it('should handle basic code evaluation', function (done) {
-                runner.run({
-                    language: 'python',
-                    languageVersion: lv,
-                    code: 'import sys; sys.stdout.write("42")'
-                }, function (buffer) {
-                    expect(buffer.stdout).to.equal('42');
-                    done();
-                });
-            });
-            it('stderr', function (done) {
-                runner.run({
-                    language: 'python',
-                    languageVersion: lv,
-                    code: 'import sys; sys.stderr.write("Error!  Codewars cannot and will not accept any more Fibonacci kata.")'
-                }, function (buffer) {
-                    expect(buffer.stderr).to.equal("Error!  Codewars cannot and will not accept any more Fibonacci kata.");
-                    done();
-                });
-            });
-            it('stderr', function (done) {
-                runner.run({
-                    language: 'python',
-                    languageVersion: lv,
-                    code: 'import sys; sys.stderr.write("florp"); sys.stdout.write("foop")'
-                }, function (buffer) {
-                    expect(buffer.stderr).to.equal("florp");
-                    expect(buffer.stdout).to.equal("foop");
-                    done();
-                });
-            });
+      it('should handle basic code evaluation', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'import sys; sys.stdout.write("42")'
+        }, function (buffer) {
+          expect(buffer.stdout).to.equal('42');
+          done();
         });
-        describe('cw-2', function () {
-            it('should handle a basic assertion', function (done) {
-                runner.run({
-                        language: 'python',
-                        languageVersion: lv,
-                        code: 'a = 1',
-                        fixture: 'test.expect(a == 1)',
-                        testFramework: 'cw-2'
-                    },
-                    function (buffer) {
-                        expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                        done();
-                    });
-            });
-            it('should handle a basic assert_equals', function (done) {
-                runner.run({
-                        language: 'python',
-                        languageVersion: lv,
-                        code: 'a = 1',
-                        fixture: 'test.assert_equals(a, 1)',
-                        testFramework: 'cw-2'
-                    },
-                    function (buffer) {
-                        expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                        done();
-                    });
-            });
-            it('should handle a basic setup', function (done) {
-                runner.run({
-                        language: 'python',
-                        languageVersion: lv,
-                        code: 'a = 1',
-                        setup: 'b = 2',
-                        fixture: 'test.assert_equals(b, 2)',
-                        testFramework: 'cw-2'
-                    },
-                    function (buffer) {
-                        expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                        done();
-                    });
-            });
-            it('should handle a failed assertion', function (done) {
-                runner.run({
-                        language: 'python',
-                        languageVersion: lv,
-                        code: 'a = 1',
-                        fixture: 'test.expect(a == 2)',
-                        testFramework: 'cw-2'
-                    },
-                    function (buffer) {
-                        expect(buffer.stdout).to.equal('<FAILED::>Value is not what was expected\n');
-                        done();
-                    });
-            });
-
-            it('should handle a failed assertion', function (done) {
-                runner.run({
-                        language: 'python',
-                        languageVersion: lv,
-                        code: 'a.fail()',
-                        testFramework: 'cw-2'},
-                    function (buffer) {
-                        expect(buffer.stderr).to.not.contain('File ');
-                        expect(buffer.stderr).to.not.contain(', line ');
-                        expect(buffer.stderr).to.not.contain('most recent call last');
-                        done();
-                    });
-            });
-
-            it('should support project mode', function(done) {
-                runner.run({
-                    language: 'python',
-                    languageVersion: lv,
-                    testFramework: 'cw-2',
-                    files: {
-                        'spec.py': 'Test.expect(True)'
-                    }
-                }, function (buffer) {
-                    expect(buffer.stdout).to.include('<PASSED::>');
-                    done();
-                });
-
-            });
+      });
+      it('stderr', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'import sys; sys.stderr.write("Error!  Codewars cannot and will not accept any more Fibonacci kata.")'
+        }, function (buffer) {
+          expect(buffer.stderr).to.equal("Error!  Codewars cannot and will not accept any more Fibonacci kata.");
+          done();
         });
-        describe('unittest', function () {
-            it('should handle a basic assertion', function (done) {
-                runner.run({
-                        language: 'python',
-                        languageVersion: lv,
-                        code: 'a = 1',
-                        fixture: [
-                            'class Test(unittest.TestCase):',
-                            '  def test_assert(self):',
-                            '    self.assertEqual(a, 1)'
-                        ].join('\n'),
-                        testFramework: 'unittest'},
-                    function (buffer) {
-                        expect(buffer.stdout).to.contain('\n<PASSED::>Test Passed\n');
-                        done();
-                    });
-            });
-            it('should include test names', function (done) {
-                runner.run({
-                        language: 'python',
-                        languageVersion: lv,
-                        code: 'a = 1',
-                        fixture: [
-                            'class Test(unittest.TestCase):',
-                            '  def test_assert(self):',
-                            '    self.assertEqual(a, 1)'
-                        ].join('\n'),
-                        testFramework: 'unittest'},
-                    function (buffer) {
-                        expect(buffer.stdout).to.contain('\n<IT::>test_assert');
-                        done();
-                    });
-            });
-            it('should handle a failed assetion', function (done) {
-                runner.run({
-                        language: 'python',
-                        languageVersion: lv,
-                        code: 'a = 1',
-                        fixture: [
-                            'class Test(unittest.TestCase):',
-                            '  def test_assert(self):',
-                            '    self.assertEqual(a, 2, "test failed")'
-                        ].join('\n'),
-                        testFramework: 'unittest'},
-                    function (buffer) {
-                        expect(buffer.stdout).to.contain('\n<FAILED::>');
-                        expect(buffer.stdout).to.contain('test failed');
-                        done();
-                    });
-            });
-            it('should handle a failed assetion', function (done) {
-                runner.run({
-                        language: 'python',
-                        code: 'a = 1',
-                        languageVersion: lv,
-                        fixture: [
-                            'class Test(unittest.TestCase):',
-                            '  def test_assert(self):',
-                            '    raise Exception("exceptions are my favorite, I always throw them")'
-                        ].join('\n'),
-                        testFramework: 'unittest'},
-                    function (buffer) {
-                        expect(buffer.stdout).to.contain('\n<ERROR::>Unhandled Exception: exceptions are my favorite, I always throw them\n');
-                        done();
-                    });
-            });
+      });
+      it('stderr', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'import sys; sys.stderr.write("florp"); sys.stdout.write("foop")'
+        }, function (buffer) {
+          expect(buffer.stderr).to.equal("florp");
+          expect(buffer.stdout).to.equal("foop");
+          done();
         });
+      });
     });
+    describe('cw-2', function () {
+      it('should handle a basic assertion', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'a = 1',
+          fixture: 'test.expect(a == 1)',
+          testFramework: 'cw-2'
+        },
+                    function (buffer) {
+                      expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+                      done();
+                    });
+      });
+      it('should handle a basic assert_equals', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'a = 1',
+          fixture: 'test.assert_equals(a, 1)',
+          testFramework: 'cw-2'
+        },
+                    function (buffer) {
+                      expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+                      done();
+                    });
+      });
+      it('should handle a basic setup', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'a = 1',
+          setup: 'b = 2',
+          fixture: 'test.assert_equals(b, 2)',
+          testFramework: 'cw-2'
+        },
+                    function (buffer) {
+                      expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+                      done();
+                    });
+      });
+      it('should handle a failed assertion', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'a = 1',
+          fixture: 'test.expect(a == 2)',
+          testFramework: 'cw-2'
+        },
+                    function (buffer) {
+                      expect(buffer.stdout).to.equal('<FAILED::>Value is not what was expected\n');
+                      done();
+                    });
+      });
+
+      it('should handle a failed assertion', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'a.fail()',
+          testFramework: 'cw-2'},
+                    function (buffer) {
+                      expect(buffer.stderr).to.not.contain('File ');
+                      expect(buffer.stderr).to.not.contain(', line ');
+                      expect(buffer.stderr).to.not.contain('most recent call last');
+                      done();
+                    });
+      });
+
+      it('should support project mode', function(done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          testFramework: 'cw-2',
+          files: {
+            'spec.py': 'Test.expect(True)'
+          }
+        }, function (buffer) {
+          expect(buffer.stdout).to.include('<PASSED::>');
+          done();
+        });
+
+      });
+    });
+    describe('unittest', function () {
+      it('should handle a basic assertion', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'a = 1',
+          fixture: [
+            'class Test(unittest.TestCase):',
+            '  def test_assert(self):',
+            '    self.assertEqual(a, 1)'
+          ].join('\n'),
+          testFramework: 'unittest'},
+                    function (buffer) {
+                      expect(buffer.stdout).to.contain('\n<PASSED::>Test Passed\n');
+                      done();
+                    });
+      });
+      it('should include test names', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'a = 1',
+          fixture: [
+            'class Test(unittest.TestCase):',
+            '  def test_assert(self):',
+            '    self.assertEqual(a, 1)'
+          ].join('\n'),
+          testFramework: 'unittest'},
+                    function (buffer) {
+                      expect(buffer.stdout).to.contain('\n<IT::>test_assert');
+                      done();
+                    });
+      });
+      it('should handle a failed assetion', function (done) {
+        runner.run({
+          language: 'python',
+          languageVersion: lv,
+          code: 'a = 1',
+          fixture: [
+            'class Test(unittest.TestCase):',
+            '  def test_assert(self):',
+            '    self.assertEqual(a, 2, "test failed")'
+          ].join('\n'),
+          testFramework: 'unittest'},
+                    function (buffer) {
+                      expect(buffer.stdout).to.contain('\n<FAILED::>');
+                      expect(buffer.stdout).to.contain('test failed');
+                      done();
+                    });
+      });
+      it('should handle a failed assetion', function (done) {
+        runner.run({
+          language: 'python',
+          code: 'a = 1',
+          languageVersion: lv,
+          fixture: [
+            'class Test(unittest.TestCase):',
+            '  def test_assert(self):',
+            '    raise Exception("exceptions are my favorite, I always throw them")'
+          ].join('\n'),
+          testFramework: 'unittest'},
+                    function (buffer) {
+                      expect(buffer.stdout).to.contain('\n<ERROR::>Unhandled Exception: exceptions are my favorite, I always throw them\n');
+                      done();
+                    });
+      });
+    });
+  });
 
 });

--- a/test/runners/r_spec.js
+++ b/test/runners/r_spec.js
@@ -3,12 +3,12 @@ var runner = require('../runner');
 
 
 describe( 'r runner', function(){
-    describe( '.run', function(){
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'r', code: 'cat("What a pirate says?")'}, function(buffer) {
-                expect(buffer.stdout).to.equal('What a pirate says?');
-                done();
-            });
-        });
+  describe( '.run', function(){
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'r', code: 'cat("What a pirate says?")'}, function(buffer) {
+        expect(buffer.stdout).to.equal('What a pirate says?');
+        done();
+      });
     });
+  });
 });

--- a/test/runners/racket_spec.js
+++ b/test/runners/racket_spec.js
@@ -3,30 +3,30 @@ var runner = require('../runner');
 
 
 describe( 'racket runner', function(){
-    describe( '.run', function(){
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'racket', code: '(print 42)'}, function(buffer) {
-                expect(buffer.stdout).to.equal('42');
-                done();
-            });
-        });
+  describe( '.run', function(){
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'racket', code: '(print 42)'}, function(buffer) {
+        expect(buffer.stdout).to.equal('42');
+        done();
+      });
+    });
 
-        it('should handle setup code and imports', function (done) {
-            runner.run({
-                language: 'racket',
-                setup: [
-                    '#lang racket/base',
-                    '(provide twice)',
-                    '(define (twice x) (+ x x))'
-                ].join('\n'),
-                code: [
-                    "(print (twice 2))"
-                ].join('\n')
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal('4');
-                done();
-            });
-        });
+    it('should handle setup code and imports', function (done) {
+      runner.run({
+        language: 'racket',
+        setup: [
+          '#lang racket/base',
+          '(provide twice)',
+          '(define (twice x) (+ x x))'
+        ].join('\n'),
+        code: [
+          "(print (twice 2))"
+        ].join('\n')
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal('4');
+        done();
+      });
+    });
 
-   });
+  });
 });

--- a/test/runners/ruby_spec.js
+++ b/test/runners/ruby_spec.js
@@ -3,255 +3,255 @@ var runner = require('../runner');
 
 
 describe('ruby runner', function () {
-    describe('.run', function () {
+  describe('.run', function () {
         // runner.assertCodeExamples('ruby');
 
-        it('should handle basic code evaluation', function (done) {
-            runner.run({language: 'ruby', code: 'puts 42'}, function (buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
+    it('should handle basic code evaluation', function (done) {
+      runner.run({language: 'ruby', code: 'puts 42'}, function (buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
+    });
 
-        it('should support githubRepo downloading', function (done) {
-            runner.run({
-                language: 'ruby',
-                code: `
+    it('should support githubRepo downloading', function (done) {
+      runner.run({
+        language: 'ruby',
+        code: `
                     require "sample"
                     puts Sample.new.message
                 `,
-                githubRepo: 'jhoffner/test'
-            }, function (buffer) {
-                console.log(buffer.stdout)
-                expect(buffer.stdout).to.contain('sample\n');
-                done();
-            });
-        });
+        githubRepo: 'jhoffner/test'
+      }, function (buffer) {
+        console.log(buffer.stdout)
+        expect(buffer.stdout).to.contain('sample\n');
+        done();
+      });
+    });
 
-        it('should support gist downloading', function (done) {
-          runner.run({
-            language: 'ruby',
-            code: 'puts `ls`',
-            setup: '# @config: gist 3acc7b81436ffe4ad20800e242ccaff6',
-          }, function (buffer) {
+    it('should support gist downloading', function (done) {
+      runner.run({
+        language: 'ruby',
+        code: 'puts `ls`',
+        setup: '# @config: gist 3acc7b81436ffe4ad20800e242ccaff6',
+      }, function (buffer) {
+        console.log(buffer.stdout)
+        expect(buffer.stdout).to.contain('gist.js\n');
+        done();
+      });
+    });
+
+    it('should support config bash-file', function (done) {
+      runner.run({
+        language: 'ruby',
+        code: 'puts `ls`',
+        setup: `
+                    # @config: github-repo jhoffner/test
+                    # @config: bash-file start.sh
+                `,
+      }, function (buffer) {
+        expect(buffer.stdout).to.contain('test.txt\n');
+        done();
+      });
+    });
+
+    it('should support additional files', function (done) {
+      runner.run({
+        language: 'ruby',
+        code: 'puts `ls`',
+        files: {
+          'myconfig.rb': 'puts 123'
+        }
+      }, function (buffer) {
+        expect(buffer.stdout).to.contain('myconfig.rb');
+        done();
+      });
+    });
+
+    describe('cw-2', function () {
+      it('should handle a basic assertion', function (done) {
+        runner.run({language: 'ruby', code: 'a = 1', fixture: 'Test.expect a == 1', testFramework: 'cw-2'}, function (buffer) {
+          expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
+
+      it('should handle a basic description', function (done) {
+        runner.run({language: 'ruby', code: 'a = 1', fixture: 'describe("test") { Test.expect a == 1 }', testFramework: 'cw-2'}, function (buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>test\n<PASSED::>Test Passed\n<COMPLETEDIN::>');
+          expect(buffer.stdout).to.contain('ms');
+          done();
+        });
+      });
+
+      describe('error handling', function () {
+        it('should handle a mix of failures and successes', function (done) {
+          runner.run({language: 'ruby',
+            code: 'a = 1',
+            fixture: 'describe "test" do\n' +
+                            'it("test1") { Test.expect(false) }\n' +
+                            'it("test2") { Test.expect(true) }\n' +
+                            'end',
+            testFramework: 'cw-2'}, function (buffer) {
             console.log(buffer.stdout)
-            expect(buffer.stdout).to.contain('gist.js\n');
+            expect(buffer.stdout).to.contain('<FAILED::>Value is not what was expected');
+            expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+            done();
+          });
+        });
+        it('should gracefully handle custom errors', function (done) {
+          runner.run({language: 'ruby',
+            code: 'a = 1',
+            fixture: 'describe "test" do\n' +
+                            'it("test1") { raise "boom!" }\n' +
+                            'it("test2") { Test.expect(true)}\n' +
+                            'end',
+            testFramework: 'cw-2'}, function (buffer) {
+            expect(buffer.stdout).to.contain('<ERROR::>');
+            expect(buffer.stdout).to.contain('boom!');
+            expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+            done();
+          });
+        });
+        it('should gracefully handle reference errors', function (done) {
+          runner.run({language: 'ruby',
+            code: 'a = 1',
+            fixture: 'describe "test" do\n' +
+                            'it("test1") { a.idontexist() }\n' +
+                            'it("test2") { Test.expect(true)}\n' +
+                            'end',
+            testFramework: 'cw-2'}, function (buffer) {
+            expect(buffer.stdout).to.contain('<ERROR::>');
+            expect(buffer.stdout).to.contain('<:LF:>');
+            expect(buffer.stdout).to.contain('NoMethodError:');
+            expect(buffer.stdout).to.not.contain('from /cli-runner/');
+                        // expect(buffer.stdout).to.not.contain('-e:');
+                        // expect(buffer.stdout).to.not.contain('cw-2.rb');
+            expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
             done();
           });
         });
 
-        it('should support config bash-file', function (done) {
-            runner.run({
-                language: 'ruby',
-                code: 'puts `ls`',
-                setup: `
-                    # @config: github-repo jhoffner/test
-                    # @config: bash-file start.sh
-                `,
-            }, function (buffer) {
-                expect(buffer.stdout).to.contain('test.txt\n');
-                done();
-            });
-        });
-
-        it('should support additional files', function (done) {
-            runner.run({
-                language: 'ruby',
-                code: 'puts `ls`',
-                files: {
-                  'myconfig.rb': 'puts 123'
-                }
-            }, function (buffer) {
-                expect(buffer.stdout).to.contain('myconfig.rb');
-                done();
-            });
-        });
-
-        describe('cw-2', function () {
-            it('should handle a basic assertion', function (done) {
-                runner.run({language: 'ruby', code: 'a = 1', fixture: 'Test.expect a == 1', testFramework: 'cw-2'}, function (buffer) {
-                    expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                    done();
-                });
-            });
-
-            it('should handle a basic description', function (done) {
-                runner.run({language: 'ruby', code: 'a = 1', fixture: 'describe("test") { Test.expect a == 1 }', testFramework: 'cw-2'}, function (buffer) {
-                    expect(buffer.stdout).to.contain('<DESCRIBE::>test\n<PASSED::>Test Passed\n<COMPLETEDIN::>');
-                    expect(buffer.stdout).to.contain('ms');
-                    done();
-                });
-            });
-
-            describe('error handling', function () {
-                it('should handle a mix of failures and successes', function (done) {
-                    runner.run({language: 'ruby',
-                        code: 'a = 1',
-                        fixture: 'describe "test" do\n' +
-                            'it("test1") { Test.expect(false) }\n' +
-                            'it("test2") { Test.expect(true) }\n' +
-                            'end',
-                        testFramework: 'cw-2'}, function (buffer) {
-                        console.log(buffer.stdout)
-                        expect(buffer.stdout).to.contain('<FAILED::>Value is not what was expected');
-                        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                        done();
-                    });
-                });
-                it('should gracefully handle custom errors', function (done) {
-                    runner.run({language: 'ruby',
-                        code: 'a = 1',
-                        fixture: 'describe "test" do\n' +
-                            'it("test1") { raise "boom!" }\n' +
-                            'it("test2") { Test.expect(true)}\n' +
-                            'end',
-                        testFramework: 'cw-2'}, function (buffer) {
-                        expect(buffer.stdout).to.contain('<ERROR::>');
-                        expect(buffer.stdout).to.contain('boom!');
-                        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                        done();
-                    });
-                });
-                it('should gracefully handle reference errors', function (done) {
-                    runner.run({language: 'ruby',
-                        code: 'a = 1',
-                        fixture: 'describe "test" do\n' +
-                            'it("test1") { a.idontexist() }\n' +
-                            'it("test2") { Test.expect(true)}\n' +
-                            'end',
-                        testFramework: 'cw-2'}, function (buffer) {
-                        expect(buffer.stdout).to.contain('<ERROR::>');
-                        expect(buffer.stdout).to.contain('<:LF:>');
-                        expect(buffer.stdout).to.contain('NoMethodError:');
-                        expect(buffer.stdout).to.not.contain('from /cli-runner/');
-                        // expect(buffer.stdout).to.not.contain('-e:');
-                        // expect(buffer.stdout).to.not.contain('cw-2.rb');
-                        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
-                        done();
-                    });
-                });
-
-                it('should prevent short circuiting', function (done) {
-                    runner.run({language: 'ruby',
-                            code: [
-                                "def example",
-                                "   Test.expect(true);",
-                                "   raise 'early error'",
-                                "end"
-                            ].join("\n"),
-                            fixture: [
-                                'describe "test" do',
-                                '   it("test1") { example }',
-                                '   it("test2") { Test.expect(false)}',
-                                'end'
-                            ].join('\n'),
-                            testFramework: 'cw-2'}, function (buffer) {
-                            expect(buffer.stdout).to.contain('<ERROR::>');
-                            done();
-                        }
+        it('should prevent short circuiting', function (done) {
+          runner.run({language: 'ruby',
+            code: [
+              "def example",
+              "   Test.expect(true);",
+              "   raise 'early error'",
+              "end"
+            ].join("\n"),
+            fixture: [
+              'describe "test" do',
+              '   it("test1") { example }',
+              '   it("test2") { Test.expect(false)}',
+              'end'
+            ].join('\n'),
+            testFramework: 'cw-2'}, function (buffer) {
+            expect(buffer.stdout).to.contain('<ERROR::>');
+            done();
+          }
                     );
-                });
-            });
         });
-        describe('rspec', function () {
-            it('should handle a basic assertion', function (done) {
-                runner.run({language: 'ruby',
-                        code: '$a = 1',
-                        fixture: 'describe "test" do\n' +
+      });
+    });
+    describe('rspec', function () {
+      it('should handle a basic assertion', function (done) {
+        runner.run({language: 'ruby',
+          code: '$a = 1',
+          fixture: 'describe "test" do\n' +
                             'it("test2") { expect($a).to eq(1)}\n' +
                             'end',
-                        testFramework: 'rspec'}, function (buffer) {
-                        expect(buffer.stdout).to.equal('<DESCRIBE::>test\n<IT::>test2\n<PASSED::>Test Passed\n<COMPLETEDIN::>\n<COMPLETEDIN::>\n');
-                        done();
-                    }
+          testFramework: 'rspec'}, function (buffer) {
+          expect(buffer.stdout).to.equal('<DESCRIBE::>test\n<IT::>test2\n<PASSED::>Test Passed\n<COMPLETEDIN::>\n<COMPLETEDIN::>\n');
+          done();
+        }
                 );
-            });
-            it('should support let', function (done) {
-                runner.run({language: 'ruby',
-                        code: '$a = 1',
-                        fixture: ['describe "test" do',
-                            'let(:b) { $a }',
-                            'it("test2") { expect(b).to eq(1)}',
-                            'end'].join('\n'),
-                        testFramework: 'rspec'}, function (buffer) {
-                        expect(buffer.stdout).to.equal('<DESCRIBE::>test\n<IT::>test2\n<PASSED::>Test Passed\n<COMPLETEDIN::>\n<COMPLETEDIN::>\n');
-                        done();
-                    }
+      });
+      it('should support let', function (done) {
+        runner.run({language: 'ruby',
+          code: '$a = 1',
+          fixture: ['describe "test" do',
+            'let(:b) { $a }',
+            'it("test2") { expect(b).to eq(1)}',
+            'end'].join('\n'),
+          testFramework: 'rspec'}, function (buffer) {
+          expect(buffer.stdout).to.equal('<DESCRIBE::>test\n<IT::>test2\n<PASSED::>Test Passed\n<COMPLETEDIN::>\n<COMPLETEDIN::>\n');
+          done();
+        }
                 );
-            });
-            it('should handle a basic failed assertion', function (done) {
-                runner.run({language: 'ruby',
-                        code: '$a = 1',
-                        fixture: 'describe "test" do\n' +
+      });
+      it('should handle a basic failed assertion', function (done) {
+        runner.run({language: 'ruby',
+          code: '$a = 1',
+          fixture: 'describe "test" do\n' +
                             'it("test2") { expect($a).to eq(2)}\n' +
                             'end',
-                        testFramework: 'rspec'}, function (buffer) {
-                        expect(buffer.stdout).to.contain('<DESCRIBE::>test\n<IT::>test2');
-                        expect(buffer.stdout).to.contain('<FAILED::>');
-                        expect(buffer.stdout).to.not.contain('<PASSED::>');
-                        expect(buffer.stdout).to.not.contain('simplified backtrace');
-                        done();
-                    }
+          testFramework: 'rspec'}, function (buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>test\n<IT::>test2');
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          expect(buffer.stdout).to.not.contain('<PASSED::>');
+          expect(buffer.stdout).to.not.contain('simplified backtrace');
+          done();
+        }
                 );
-            });
-            it('should handle errored code', function (done) {
-                runner.run({language: 'ruby',
-                        code: 'a = 1',
-                        fixture: 'describe "test" do\n' +
+      });
+      it('should handle errored code', function (done) {
+        runner.run({language: 'ruby',
+          code: 'a = 1',
+          fixture: 'describe "test" do\n' +
                             'it("test1") { a.idontexist() }\n' +
                             'it("test2") { expect(true)}\n' +
                             'end',
-                        testFramework: 'rspec'}, function (buffer) {
-                        expect(buffer.stdout).to.contain('<DESCRIBE::>test');
-                        expect(buffer.stdout).to.contain('<IT::>test1');
-                        expect(buffer.stdout).to.contain('<IT::>test2');
-                        expect(buffer.stdout).to.contain('<ERROR::>');
-                        done();
-                    }
+          testFramework: 'rspec'}, function (buffer) {
+          expect(buffer.stdout).to.contain('<DESCRIBE::>test');
+          expect(buffer.stdout).to.contain('<IT::>test1');
+          expect(buffer.stdout).to.contain('<IT::>test2');
+          expect(buffer.stdout).to.contain('<ERROR::>');
+          done();
+        }
                 );
-            });
-            it('should prevent short circuiting', function (done) {
-                runner.run({language: 'ruby',
-                        code: [
-                            "def example",
-                            "   expect(true);",
-                            "   raise 'early error'",
-                            "end"
-                        ].join("\n"),
-                        fixture: [
-                            'describe "test" do',
-                            '   it("test1") { example }',
-                            '   it("test2") { expect(false)}',
-                            'end'
-                        ].join('\n'),
-                        testFramework: 'rspec'}, function (buffer) {
-                        expect(buffer.stdout).to.contain('<ERROR::>');
-                        done();
-                    }
+      });
+      it('should prevent short circuiting', function (done) {
+        runner.run({language: 'ruby',
+          code: [
+            "def example",
+            "   expect(true);",
+            "   raise 'early error'",
+            "end"
+          ].join("\n"),
+          fixture: [
+            'describe "test" do',
+            '   it("test1") { example }',
+            '   it("test2") { expect(false)}',
+            'end'
+          ].join('\n'),
+          testFramework: 'rspec'}, function (buffer) {
+          expect(buffer.stdout).to.contain('<ERROR::>');
+          done();
+        }
                 );
-            });
-        });
-        describe('potpourri', function () {
-            it('can run redis', function (done) {
-                runner.run({
-                    language: 'ruby',
-                    code: ['puts `ls`',
-                        'fork do',
-                        '    exec "redis-server"',
-                        'end',
-                        "require 'redis'",
-                        'r = Redis.new',
-                        "r.set('a', 'b')"
-                    ].join('\n'),
-                    fixture: "Test.assert_equals(r.get('a'), 'b')",
-                    testFramework: 'cw-2'
-                }, function (buffer) {
-                    console.log(buffer.stderr);
-                    expect(buffer.stdout).to.contain('<PASSED::>Test Passed: Value == \"b\"');
-                    done();
-                });
-            });
-        });
+      });
     });
+    describe('potpourri', function () {
+      it('can run redis', function (done) {
+        runner.run({
+          language: 'ruby',
+          code: ['puts `ls`',
+            'fork do',
+            '    exec "redis-server"',
+            'end',
+            "require 'redis'",
+            'r = Redis.new',
+            "r.set('a', 'b')"
+          ].join('\n'),
+          fixture: "Test.assert_equals(r.get('a'), 'b')",
+          testFramework: 'cw-2'
+        }, function (buffer) {
+          console.log(buffer.stderr);
+          expect(buffer.stdout).to.contain('<PASSED::>Test Passed: Value == \"b\"');
+          done();
+        });
+      });
+    });
+  });
 
 });

--- a/test/runners/scala_spec.js
+++ b/test/runners/scala_spec.js
@@ -2,47 +2,47 @@ var expect = require('chai').expect;
 var runner = require('../runner');
 
 describe('scala runner', function () {
-    describe('.run', function () {
-        it('should handle basic code evaluation', function (done) {
-            var code = [
-                'object HelloWorld {',
-          'def main(args: Array[String]) {',
-              'println("Hello, world!")',
-           '}',
-            '}'
-            ].join('\n');
+  describe('.run', function () {
+    it('should handle basic code evaluation', function (done) {
+      var code = [
+        'object HelloWorld {',
+        'def main(args: Array[String]) {',
+        'println("Hello, world!")',
+        '}',
+        '}'
+      ].join('\n');
 
-            runner.run({language: 'scala', code: code}, function (buffer) {
+      runner.run({language: 'scala', code: code}, function (buffer) {
         console.log(buffer);
-                expect(buffer.stdout).to.equal("Hello, world!\n");
-                done();
-            });
-        });
-        it('should handle setup code and imports', function (done) {
-            runner.run({
-                language: 'scala',
-                setup: [
-        'package problems',
-                  'object Lists {',
-                    'def last(list: List[Any]): Option[Any] = list match {',
-                        'case Nil      => None',
-                'case x :: Nil => Some(x)',
-                'case _ :: xs  => last(xs)',
-              '}',
-            '}'
-                ].join('\n'),
-                code: [
-            'import problems.Lists._',
-            'object Test extends App {',
-            '  println("Starting tests...")',
-            '  println(last(List(1,2,3,4,5)))',
-            '}'
-                ].join('\n')
-            }, function (buffer) {
-                expect(buffer.stdout).to.contain('Starting tests...');
-                expect(buffer.stdout).to.contain('5');
-                done();
-            });
-        });
+        expect(buffer.stdout).to.equal("Hello, world!\n");
+        done();
+      });
     });
+    it('should handle setup code and imports', function (done) {
+      runner.run({
+        language: 'scala',
+        setup: [
+          'package problems',
+          'object Lists {',
+          'def last(list: List[Any]): Option[Any] = list match {',
+          'case Nil      => None',
+          'case x :: Nil => Some(x)',
+          'case _ :: xs  => last(xs)',
+          '}',
+          '}'
+        ].join('\n'),
+        code: [
+          'import problems.Lists._',
+          'object Test extends App {',
+          '  println("Starting tests...")',
+          '  println(last(List(1,2,3,4,5)))',
+          '}'
+        ].join('\n')
+      }, function (buffer) {
+        expect(buffer.stdout).to.contain('Starting tests...');
+        expect(buffer.stdout).to.contain('5');
+        done();
+      });
+    });
+  });
 });

--- a/test/runners/scala_spec.js
+++ b/test/runners/scala_spec.js
@@ -6,14 +6,14 @@ describe('scala runner', function () {
         it('should handle basic code evaluation', function (done) {
             var code = [
                 'object HelloWorld {',
-		  'def main(args: Array[String]) {',
-			  'println("Hello, world!")',
-		   '}',
-	        '}'
+          'def main(args: Array[String]) {',
+              'println("Hello, world!")',
+           '}',
+            '}'
             ].join('\n');
 
             runner.run({language: 'scala', code: code}, function (buffer) {
-		console.log(buffer);
+        console.log(buffer);
                 expect(buffer.stdout).to.equal("Hello, world!\n");
                 done();
             });
@@ -22,21 +22,21 @@ describe('scala runner', function () {
             runner.run({
                 language: 'scala',
                 setup: [
-		'package problems',
+        'package problems',
                   'object Lists {',
                     'def last(list: List[Any]): Option[Any] = list match {',
                         'case Nil      => None',
-		        'case x :: Nil => Some(x)',
-		        'case _ :: xs  => last(xs)',
-		      '}',
-		    '}'
+                'case x :: Nil => Some(x)',
+                'case _ :: xs  => last(xs)',
+              '}',
+            '}'
                 ].join('\n'),
                 code: [
-		    'import problems.Lists._',
-		    'object Test extends App {',
-		    '  println("Starting tests...")',
-		    '  println(last(List(1,2,3,4,5)))',
-		    '}'
+            'import problems.Lists._',
+            'object Test extends App {',
+            '  println("Starting tests...")',
+            '  println(last(List(1,2,3,4,5)))',
+            '}'
                 ].join('\n')
             }, function (buffer) {
                 expect(buffer.stdout).to.contain('Starting tests...');

--- a/test/runners/shell_spec.js
+++ b/test/runners/shell_spec.js
@@ -3,19 +3,19 @@ var runner = require('../runner');
 
 
 describe( 'shell runner', function(){
-    describe( '.run', function(){
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'shell', code: 'echo 42'}, function(buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
-        describe('rspec', function() {
-            it( 'should support run_shell', function(done) {
-                runner.run({
-                    language: 'shell',
-                    code: 'echo $1',
-                    fixture: `
+  describe( '.run', function(){
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'shell', code: 'echo 42'}, function(buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
+    });
+    describe('rspec', function() {
+      it( 'should support run_shell', function(done) {
+        runner.run({
+          language: 'shell',
+          code: 'echo $1',
+          fixture: `
                       describe "solution" do
                         it "should return 42" do
                            result = run_shell args: [42]
@@ -23,12 +23,12 @@ describe( 'shell runner', function(){
                         end
                       end
                     `
-                }, function(buffer) {
-                    console.log(buffer.stdout)
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
-                });
-            });
+        }, function(buffer) {
+          console.log(buffer.stdout)
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          done();
         });
+      });
     });
+  });
 });

--- a/test/runners/sql_spec.js
+++ b/test/runners/sql_spec.js
@@ -31,79 +31,79 @@ puts "database = #{DATABASE}"
 `
 
 describe('sql runner', function () {
-    runner.assertCodeExamples('sql');
+  runner.assertCodeExamples('sql');
 
-    describe('.run', function () {
+  describe('.run', function () {
 
-        describe('solution only', function() {
-            it("should support sqlite", function(done) {
-                runner.run({
-                    language: 'sql',
-                    languageVersion: 'sqlite',
-                    setup: itemsSetup,
-                    code: query
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('"name":"c"');
-                    done();
-                });
-            });
-
-            it("should support postgres", function(done) {
-                runner.run({
-                    language: 'sql',
-                    languageVersion: 'postgres',
-                    setup: itemsSetup,
-                    code: query
-                }, function(buffer) {
-                    console.log(buffer.stdout);
-                    expect(buffer.stdout).to.contain('"name":"c"');
-                    done();
-                });
-            });
+    describe('solution only', function() {
+      it("should support sqlite", function(done) {
+        runner.run({
+          language: 'sql',
+          languageVersion: 'sqlite',
+          setup: itemsSetup,
+          code: query
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('"name":"c"');
+          done();
         });
+      });
 
-        describe("rspec", function() {
-            it("should support sqlite", function(done) {
-                runner.run({
-                    language: 'sql',
-                    languageVersion: 'sqlite',
-                    setup: itemsSetup,
-                    code: query,
-                    fixture: itemsFixture
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('PASSED');
-                    done();
-                });
-            });
-
-            it("should support projectMode", function(done) {
-                runner.run({
-                    language: 'sql',
-                    languageVersion: 'sqlite',
-                    files: {
-                        'spec.rb': `require './setup.rb'\n${itemsFixture}`,
-                        'setup.rb': `require "/runner/frameworks/ruby/sql"\n${itemsSetup}`,
-                        'solution.sql': query
-                    }
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('PASSED');
-                    done();
-                });
-            });
-
-            it("should support postgres", function(done) {
-                runner.run({
-                    language: 'sql',
-                    languageVersion: 'postgres',
-                    setup: itemsSetup,
-                    code: query,
-                    fixture: itemsFixture
-                }, function(buffer) {
-                    expect(buffer.stdout).to.contain('PASSED');
-                    expect(buffer.stdout).to.contain('database = spec');
-                    done();
-                });
-            });
+      it("should support postgres", function(done) {
+        runner.run({
+          language: 'sql',
+          languageVersion: 'postgres',
+          setup: itemsSetup,
+          code: query
+        }, function(buffer) {
+          console.log(buffer.stdout);
+          expect(buffer.stdout).to.contain('"name":"c"');
+          done();
         });
+      });
     });
+
+    describe("rspec", function() {
+      it("should support sqlite", function(done) {
+        runner.run({
+          language: 'sql',
+          languageVersion: 'sqlite',
+          setup: itemsSetup,
+          code: query,
+          fixture: itemsFixture
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('PASSED');
+          done();
+        });
+      });
+
+      it("should support projectMode", function(done) {
+        runner.run({
+          language: 'sql',
+          languageVersion: 'sqlite',
+          files: {
+            'spec.rb': `require './setup.rb'\n${itemsFixture}`,
+            'setup.rb': `require "/runner/frameworks/ruby/sql"\n${itemsSetup}`,
+            'solution.sql': query
+          }
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('PASSED');
+          done();
+        });
+      });
+
+      it("should support postgres", function(done) {
+        runner.run({
+          language: 'sql',
+          languageVersion: 'postgres',
+          setup: itemsSetup,
+          code: query,
+          fixture: itemsFixture
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('PASSED');
+          expect(buffer.stdout).to.contain('database = spec');
+          done();
+        });
+      });
+    });
+  });
 });

--- a/test/runners/swift_spec.js
+++ b/test/runners/swift_spec.js
@@ -2,141 +2,141 @@ var expect = require('chai').expect;
 var runner = require('../runner');
 
 describe( 'swift runner', function(){
-    describe( '.run', function(){
-        runner.assertCodeExamples('swift');
+  describe( '.run', function(){
+    runner.assertCodeExamples('swift');
 
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'swift', code: 'print(42)'}, function(buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
-        it('should handle setup code', function (done) {
-            runner.run({
-                language: 'swift',
-                languageVersion: '3',
-                setup: "func foo() -> Int { return 999; }",
-                code: "print(foo())"
-            }, function (buffer) {
-                expect(buffer.stdout).to.equal("999\n");
-                done();
-            });
-        });
-        it('should handle line output when there is setup code', function (done) {
-            runner.run({
-                language: 'swift',
-                languageVersion: '3',
-                setup: "func foo() -> Int { \nreturn 999; \n}",
-                code: "print(foo(1))"
-            }, function (buffer) {
-                console.log(buffer.stderr);
-                expect(buffer.stderr).to.contain("(solution:1:11)");
-                done();
-            });
-        });
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'swift', code: 'print(42)'}, function(buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
     });
-    describe('cw-2', function () {
-            it('should handle a basic assertion', function (done) {
-                var code = 'let a = 1;'
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: code,
-                        fixture: 'Test.expect(a == 1)',
-                        testFramework: 'cw-2'
-                    },
+    it('should handle setup code', function (done) {
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        setup: "func foo() -> Int { return 999; }",
+        code: "print(foo())"
+      }, function (buffer) {
+        expect(buffer.stdout).to.equal("999\n");
+        done();
+      });
+    });
+    it('should handle line output when there is setup code', function (done) {
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        setup: "func foo() -> Int { \nreturn 999; \n}",
+        code: "print(foo(1))"
+      }, function (buffer) {
+        console.log(buffer.stderr);
+        expect(buffer.stderr).to.contain("(solution:1:11)");
+        done();
+      });
+    });
+  });
+  describe('cw-2', function () {
+    it('should handle a basic assertion', function (done) {
+      var code = 'let a = 1;'
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: code,
+        fixture: 'Test.expect(a == 1)',
+        testFramework: 'cw-2'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                        done();
+                      expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+                      done();
                     });
-            });
-            it('should handle a basic assert_equals', function (done) {
-                var code = 'let a = 1;'
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: code,
-                        fixture: 'Test.assert_equals(a, 1)',
-                        testFramework: 'cw-2'
-                    },
+    });
+    it('should handle a basic assert_equals', function (done) {
+      var code = 'let a = 1;'
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: code,
+        fixture: 'Test.assert_equals(a, 1)',
+        testFramework: 'cw-2'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                        done();
+                      expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+                      done();
                     });
-            });
-            it('should handle a basic assert_equals with arrays', function (done) {
-                var code = 'let a = [1, 2, 3]; let b = [1, 2, 3]'
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: code,
-                        fixture: 'Test.assert_equals(a, b)',
-                        testFramework: 'cw-2'
-                    },
+    });
+    it('should handle a basic assert_equals with arrays', function (done) {
+      var code = 'let a = [1, 2, 3]; let b = [1, 2, 3]'
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: code,
+        fixture: 'Test.assert_equals(a, b)',
+        testFramework: 'cw-2'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                        done();
+                      expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+                      done();
                     });
-            });
-            it('should handle a basic assert_equals with array slices', function (done) {
-                var code = 'let a = [1, 2, 3]; let b = [1, 2, 3]'
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: code,
-                        fixture: 'Test.assert_equals(a[0...1], b[0...1])',
-                        testFramework: 'cw-2'
-                    },
+    });
+    it('should handle a basic assert_equals with array slices', function (done) {
+      var code = 'let a = [1, 2, 3]; let b = [1, 2, 3]'
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: code,
+        fixture: 'Test.assert_equals(a[0...1], b[0...1])',
+        testFramework: 'cw-2'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                        done();
+                      expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+                      done();
                     });
-            });
-            it('should handle a basic setup', function (done) {
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: 'let a = 1',
-                        setup: 'let b = 2',
-                        fixture: 'Test.assert_equals(a + b, 3)',
-                        testFramework: 'cw-2'
-                    },
+    });
+    it('should handle a basic setup', function (done) {
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: 'let a = 1',
+        setup: 'let b = 2',
+        fixture: 'Test.assert_equals(a + b, 3)',
+        testFramework: 'cw-2'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                        done();
+                      expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+                      done();
                     });
-            });
-            it('should handle a failed assertion with default message', function (done) {
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: 'let a = 1',
-                        fixture: 'Test.expect(a == 2)',
-                        testFramework: 'cw-2'
-                    },
+    });
+    it('should handle a failed assertion with default message', function (done) {
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: 'let a = 1',
+        fixture: 'Test.expect(a == 2)',
+        testFramework: 'cw-2'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.equal('<FAILED::>Value is not what was expected\n');
-                        done();
+                      expect(buffer.stdout).to.equal('<FAILED::>Value is not what was expected\n');
+                      done();
                     });
-            });
-            it('should handle a failed assertion with custom message', function (done) {
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: 'let a = 1',
-                        fixture: 'Test.expect(a == 2, "a should be equal to 2")',
-                        testFramework: 'cw-2'
-                    },
+    });
+    it('should handle a failed assertion with custom message', function (done) {
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: 'let a = 1',
+        fixture: 'Test.expect(a == 2, "a should be equal to 2")',
+        testFramework: 'cw-2'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.equal('<FAILED::>a should be equal to 2\n');
-                        done();
+                      expect(buffer.stdout).to.equal('<FAILED::>a should be equal to 2\n');
+                      done();
                     });
-            });
-            it('should handle an expect_throws assertion', function (done) {
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: `
+    });
+    it('should handle an expect_throws assertion', function (done) {
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: `
                             enum MyError : Error {
                                 case RuntimeError(String)
                             }
@@ -149,67 +149,67 @@ describe( 'swift runner', function(){
                                 }
                             }
                         `,
-                        fixture: 'Test.expect_throws(try errorThrower(0))',
-                        testFramework: 'cw-2'
-                    },
+        fixture: 'Test.expect_throws(try errorThrower(0))',
+        testFramework: 'cw-2'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
-                        done();
+                      expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+                      done();
                     });
-            });
-            it('should handle a fatal error', function (done) {
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: 'fataError()',
-                        testFramework: 'cw-2'},
-                    function (buffer) {
-                        expect(buffer.stderr).to.not.contain(' file ');
-                        expect(buffer.stderr).to.not.contain(', line ');
-                        expect(buffer.stderr).to.not.contain('Current stack trace:');
-                        done();
-                    });
-            });
-            it('should handle describe', function (done) {
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: 'let a = 1',
-                        fixture: 'Test.describe("should handle edge cases")',
-                        testFramework: 'cw-2'},
-                    function (buffer) {
-                        expect(buffer.stdout).to.equal('<DESCRIBE::>should handle edge cases\n');
-                        done();
-                    });
-            });
-            it('should handle it', function (done) {
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: 'let a = 1',
-                        fixture: 'Test.it("should handle for nil input")',
-                        testFramework: 'cw-2'},
-                    function (buffer) {
-                        expect(buffer.stdout).to.equal('<IT::>should handle for nil input\n');
-                        done();
-                    });
-            });
-
     });
-    describe('xctest', function () {
-            it('should handle a single assertion', function (done) {
-                var code = `
+    it('should handle a fatal error', function (done) {
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: 'fataError()',
+        testFramework: 'cw-2'},
+                    function (buffer) {
+                      expect(buffer.stderr).to.not.contain(' file ');
+                      expect(buffer.stderr).to.not.contain(', line ');
+                      expect(buffer.stderr).to.not.contain('Current stack trace:');
+                      done();
+                    });
+    });
+    it('should handle describe', function (done) {
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: 'let a = 1',
+        fixture: 'Test.describe("should handle edge cases")',
+        testFramework: 'cw-2'},
+                    function (buffer) {
+                      expect(buffer.stdout).to.equal('<DESCRIBE::>should handle edge cases\n');
+                      done();
+                    });
+    });
+    it('should handle it', function (done) {
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: 'let a = 1',
+        fixture: 'Test.it("should handle for nil input")',
+        testFramework: 'cw-2'},
+                    function (buffer) {
+                      expect(buffer.stdout).to.equal('<IT::>should handle for nil input\n');
+                      done();
+                    });
+    });
+
+  });
+  describe('xctest', function () {
+    it('should handle a single assertion', function (done) {
+      var code = `
                     class Calculator {
                         func add(a:Int, b:Int) -> Int {
                             return a + b
                         }
                     }
                 `
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: code,
-                        fixture: `
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: code,
+        fixture: `
                             class CalculatorTest: XCTestCase {
                               var calc : Calculator!
     
@@ -231,18 +231,18 @@ describe( 'swift runner', function(){
                                 testCase(CalculatorTest.allTests)
                             ])
                         `,
-                        testFramework: 'xctest'
-                    },
+        testFramework: 'xctest'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.contain('<DESCRIBE::>CalculatorTest')
-                        expect(buffer.stdout).to.contain('<IT::>testAddCheck')
-                        expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
-                        expect(buffer.stdout).to.contain('<COMPLETEDIN::>')
-                        done();
+                      expect(buffer.stdout).to.contain('<DESCRIBE::>CalculatorTest')
+                      expect(buffer.stdout).to.contain('<IT::>testAddCheck')
+                      expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
+                      expect(buffer.stdout).to.contain('<COMPLETEDIN::>')
+                      done();
                     });
-            });
-            it('should replace newlines in error messages with <:LF:>', function (done) {
-                var code = `
+    });
+    it('should replace newlines in error messages with <:LF:>', function (done) {
+      var code = `
                     class Calculator {
                         func add(a:Int, b:Int) -> Int {
                             // Force an error
@@ -250,11 +250,11 @@ describe( 'swift runner', function(){
                         }
                     }
                 `
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: code,
-                        fixture: `
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: code,
+        fixture: `
                             class CalculatorTest: XCTestCase {
                               static var allTests = [
                                     ("testAddCheck", testAddCheck),
@@ -270,16 +270,16 @@ describe( 'swift runner', function(){
                                 testCase(CalculatorTest.allTests)
                             ])
                         `,
-                        testFramework: 'xctest'
-                    },
+        testFramework: 'xctest'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.contain('<FAILED::>testAddCheck')
-                        expect(buffer.stdout).to.contain('<ERROR::>testAddCheck : XCTAssertEqual failed: ("-1") is not equal to ("3") - calc.add(1, 2) <:LF:> should be 3\n')
-                        done();
+                      expect(buffer.stdout).to.contain('<FAILED::>testAddCheck')
+                      expect(buffer.stdout).to.contain('<ERROR::>testAddCheck : XCTAssertEqual failed: ("-1") is not equal to ("3") - calc.add(1, 2) <:LF:> should be 3\n')
+                      done();
                     });
-            });
-            it('should handle multiple assertions', function (done) {
-                var code = `
+    });
+    it('should handle multiple assertions', function (done) {
+      var code = `
                     class Calculator {
                         func add(a:Int, b:Int) -> Int {
                             return a + b
@@ -295,11 +295,11 @@ describe( 'swift runner', function(){
                         }
                     }
                 `
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: code,
-                        fixture: `
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: code,
+        fixture: `
                             class CalculatorTest: XCTestCase {
                               var calc : Calculator!
     
@@ -331,22 +331,22 @@ describe( 'swift runner', function(){
                                 testCase(CalculatorTest.allTests)
                             ])
                         `,
-                        testFramework: 'xctest'
-                    },
+        testFramework: 'xctest'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.contain('<DESCRIBE::>CalculatorTest')
-                        expect(buffer.stdout).to.contain('<IT::>testAddCheck')
-                        expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
-                        expect(buffer.stdout).to.contain('<COMPLETEDIN::>')
-                        expect(buffer.stdout).to.contain('<IT::>testSubCheck')
-                        expect(buffer.stdout).to.contain('<ERROR::>testSubCheck')
-                        expect(buffer.stdout).to.contain('<FAILED::>testSubCheck')
-                        expect(buffer.stdout).to.contain('<IT::>testMulCheck')
-                        done();
+                      expect(buffer.stdout).to.contain('<DESCRIBE::>CalculatorTest')
+                      expect(buffer.stdout).to.contain('<IT::>testAddCheck')
+                      expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
+                      expect(buffer.stdout).to.contain('<COMPLETEDIN::>')
+                      expect(buffer.stdout).to.contain('<IT::>testSubCheck')
+                      expect(buffer.stdout).to.contain('<ERROR::>testSubCheck')
+                      expect(buffer.stdout).to.contain('<FAILED::>testSubCheck')
+                      expect(buffer.stdout).to.contain('<IT::>testMulCheck')
+                      done();
                     });
-            });
-            it('should display test results for multiple assertions in the same test method', function (done) {
-                var code = `
+    });
+    it('should display test results for multiple assertions in the same test method', function (done) {
+      var code = `
                     class Calculator {
                         func add(a:Int, b:Int) -> Int {
                             return a + b
@@ -362,11 +362,11 @@ describe( 'swift runner', function(){
                         }
                     }
                 `
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: code,
-                        fixture: `
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: code,
+        fixture: `
                             class CalculatorTest: XCTestCase {
     
                               static var allTests = [
@@ -384,30 +384,30 @@ describe( 'swift runner', function(){
                                 testCase(CalculatorTest.allTests)
                             ])
                         `,
-                        testFramework: 'xctest'
-                    },
+        testFramework: 'xctest'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.contain('<DESCRIBE::>CalculatorTest')
-                        expect(buffer.stdout).to.contain('<IT::>testCalculator')
-                        expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
-                        expect(buffer.stdout).to.contain('<FAILED::>XCTAssertEqual failed:')
-                        expect(buffer.stdout).to.contain('<COMPLETEDIN::>')
-                        done();
+                      expect(buffer.stdout).to.contain('<DESCRIBE::>CalculatorTest')
+                      expect(buffer.stdout).to.contain('<IT::>testCalculator')
+                      expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
+                      expect(buffer.stdout).to.contain('<FAILED::>XCTAssertEqual failed:')
+                      expect(buffer.stdout).to.contain('<COMPLETEDIN::>')
+                      done();
                     });
-            });
-            it('should handle strings', function (done) {
-                var code = `
+    });
+    it('should handle strings', function (done) {
+      var code = `
                     class Greetings {
                         func sayHello() -> String {
                             return "hello, codewars!"
                         }
                     }
                 `
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: code,
-                        fixture: `
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: code,
+        fixture: `
                             class GreetingsTest: XCTestCase {
                               var greetings : Greetings!
     
@@ -430,18 +430,18 @@ describe( 'swift runner', function(){
                                 testCase(GreetingsTest.allTests)
                             ])
                         `,
-                        testFramework: 'xctest'
-                    },
+        testFramework: 'xctest'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.contain('<DESCRIBE::>GreetingsTest')
-                        expect(buffer.stdout).to.contain('<IT::>testSayHello')
-                        expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
-                        expect(buffer.stdout).to.contain('<COMPLETEDIN::>')
-                        done();
+                      expect(buffer.stdout).to.contain('<DESCRIBE::>GreetingsTest')
+                      expect(buffer.stdout).to.contain('<IT::>testSayHello')
+                      expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
+                      expect(buffer.stdout).to.contain('<COMPLETEDIN::>')
+                      done();
                     });
-            });
-            it('should handle multiple test cases', function (done) {
-                var code = `
+    });
+    it('should handle multiple test cases', function (done) {
+      var code = `
                     class Calculator {
                         func add(a:Int, b:Int) -> Int {
                             return a + b
@@ -460,11 +460,11 @@ describe( 'swift runner', function(){
                         }
                     }
                 `
-                runner.run({
-                        language: 'swift',
-                        languageVersion: '3',
-                        code: code,
-                        fixture: `
+      runner.run({
+        language: 'swift',
+        languageVersion: '3',
+        code: code,
+        fixture: `
                             class CalculatorTest: XCTestCase {
                               static var allTests = [("testAddCheck", testAddCheck)]
     
@@ -488,17 +488,17 @@ describe( 'swift runner', function(){
                                 testCase(PersonTest.allTests),
                             ])
                         `,
-                        testFramework: 'xctest'
-                    },
+        testFramework: 'xctest'
+      },
                     function (buffer) {
-                        expect(buffer.stdout).to.contain('<DESCRIBE::>CalculatorTest')
-                        expect(buffer.stdout).to.contain('<IT::>testAddCheck')
-                        expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
-                        expect(buffer.stdout).to.contain('<DESCRIBE::>PersonTest')
-                        expect(buffer.stdout).to.contain('<IT::>testGreet')
-                        expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
-                        done();
+                      expect(buffer.stdout).to.contain('<DESCRIBE::>CalculatorTest')
+                      expect(buffer.stdout).to.contain('<IT::>testAddCheck')
+                      expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
+                      expect(buffer.stdout).to.contain('<DESCRIBE::>PersonTest')
+                      expect(buffer.stdout).to.contain('<IT::>testGreet')
+                      expect(buffer.stdout).to.contain('<PASSED::>Test Passed')
+                      done();
                     });
-            });
     });
+  });
 });

--- a/test/runners/typescript_spec.js
+++ b/test/runners/typescript_spec.js
@@ -3,28 +3,28 @@ var runner = require('../runner');
 
 
 describe( 'typescript runner', function(){
-    runner.assertCodeExamples('typescript');
+  runner.assertCodeExamples('typescript');
 
-    describe( '.run', function(){
-        it( 'should handle basic code evaluation', function(done){
-            runner.run({language: 'typescript', code: 'console.log(42)'}, function(buffer) {
-                expect(buffer.stdout).to.equal('42\n');
-                done();
-            });
-        });
+  describe( '.run', function(){
+    it( 'should handle basic code evaluation', function(done){
+      runner.run({language: 'typescript', code: 'console.log(42)'}, function(buffer) {
+        expect(buffer.stdout).to.equal('42\n');
+        done();
+      });
     });
+  });
 
-    describe('mocha bdd', function() {
-        it( 'should handle outputting objects', function(done){
-            runner.run({
-                    language: 'typescript',
-                    code: `
+  describe('mocha bdd', function() {
+    it( 'should handle outputting objects', function(done){
+      runner.run({
+        language: 'typescript',
+        code: `
                         export interface B {
                             b:number
                         };
                         export var a:B = {b: 3};
                     `,
-                    fixture: `
+        fixture: `
                         /// <reference path="/runner/typings/mocha/index.d.ts" />
                         /// <reference path="/runner/typings/chai/index.d.ts" />
                         import solution = require('./solution');
@@ -34,17 +34,17 @@ describe( 'typescript runner', function(){
                                 assert.equal(3, solution.a.b);
                             })
                         });`,
-                    testFramework: 'mocha_bdd'},
+        testFramework: 'mocha_bdd'},
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<PASSED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<PASSED::>');
+                  done();
                 });
-        });
-        it( 'should handle failures', function(done){
-            runner.run({
-                    language: 'typescript',
-                    code: 'export var a = {b: 2};',
-                    fixture: `
+    });
+    it( 'should handle failures', function(done){
+      runner.run({
+        language: 'typescript',
+        code: 'export var a = {b: 2};',
+        fixture: `
                       /// <reference path="/runner/typings/mocha/index.d.ts" />
                       /// <reference path="/runner/typings/chai/index.d.ts" />
                       import solution = require("./solution");
@@ -56,17 +56,17 @@ describe( 'typescript runner', function(){
                         })
                       })
                     });`,
-                    testFramework: 'mocha_bdd'},
+        testFramework: 'mocha_bdd'},
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<FAILED::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<FAILED::>');
+                  done();
                 });
-        });
-        it( 'should handle errors', function(done){
-            runner.run({
-                    language: 'typescript',
-                    code: 'export var a = {b: 2};',
-                    fixture: `
+    });
+    it( 'should handle errors', function(done){
+      runner.run({
+        language: 'typescript',
+        code: 'export var a = {b: 2};',
+        fixture: `
                       /// <reference path="/runner/typings/mocha/index.d.ts" />
                       /// <reference path="/runner/typings/chai/index.d.ts" />
                       import solution = require("./solution");
@@ -79,11 +79,11 @@ describe( 'typescript runner', function(){
                         })
                       });
                     `,
-                    testFramework: 'mocha_bdd'},
+        testFramework: 'mocha_bdd'},
                 function(buffer) {
-                    expect(buffer.stdout).to.contain('<ERROR::>');
-                    done();
+                  expect(buffer.stdout).to.contain('<ERROR::>');
+                  done();
                 });
-        });
     });
+  });
 });


### PR DESCRIPTION
Fixed indentation using `eslint` disabling other rules.

```
eslint '**/*.js' \
  --rule 'semi: [off]' \
  --rule 'no-unused-vars: [off]' \
  --rule 'no-empty: [off]' \
  --rule 'no-extra-boolean-cast: [off]' \
  --rule 'no-regex-spaces: [off]' \
  --rule 'no-undef: [off]' \
  --rule 'no-extra-semi: [off]' \
  --rule 'valid-typeof: [off]'
```


![image](https://cloud.githubusercontent.com/assets/639336/24338327/5b5fa898-1259-11e7-8967-f294e166d08a.png)

https://github.com/Codewars/codewars-runner-cli/compare/master...kazk:fix/indentation?w=1