### PR TITLE
[RFC][WIP] Improved Python POC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 HOSTNAME=codewars
 
 # Building erlang images have been suspended (frozen) until they are able to be repaired
-CONTAINERS=node dotnet jvm python ruby alt rust julia systems dart crystal ocaml swift haskell objc go lua
+CONTAINERS=node dotnet jvm python ruby alt rust julia systems dart crystal ocaml swift haskell objc go lua python-poc
 
 # recent containers should be updated when adding or modifying a language, so that
 # the travis build process will test it. The process cant test all languages
 # without timing out so this is required to get passed that issue.
-RECENT_CONTAINERS=node
+RECENT_CONTAINERS=python-poc
 
 ALL_CONTAINERS=${CONTAINERS} base
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,16 @@ services:
     entrypoint: ''
     command: bash
 
+  python-poc-runner:
+    image: codewars/python-poc-runner
+    volumes:
+      - ./lib:/runner/lib
+      - ./examples:/runner/examples
+      - ./frameworks:/runner/frameworks
+      - ./test:/runner/test
+    entrypoint: ''
+    command: bash
+
   func-runner:
     image: codewars/func-runner
     volumes:
@@ -664,5 +674,13 @@ services:
       - ./examples:/runner/examples
       - ./frameworks:/runner/frameworks
       - ./test:/runner/test
-    entrypoint: ''
     entrypoint: 'mocha -t 5000 test/runners/go_spec.js'
+
+  python-poc_test:
+    image: codewars/python-poc-runner
+    volumes:
+      - ./lib:/runner/lib
+      - ./examples:/runner/examples
+      - ./frameworks:/runner/frameworks
+      - ./test:/runner/test
+    entrypoint: 'mocha -t 5000 test/runners/python_poc_spec.js'

--- a/docker/python-poc.docker
+++ b/docker/python-poc.docker
@@ -1,0 +1,24 @@
+FROM codewars/base-runner
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    checkinstall \
+    python3 \
+    python3-pip
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ADD package.json /tmp/package.json
+RUN cd /tmp && npm install --production
+RUN mkdir -p /runner && cp -a /tmp/node_modules /runner
+
+RUN ln -s /home/codewarrior /workspace
+
+COPY . /runner
+
+WORKDIR /runner
+USER codewarrior
+ENV USER=codewarrior HOME=/home/codewarrior
+RUN mocha -t 5000 test/runners/python_poc_spec.js
+
+ENTRYPOINT ["timeout", "15", "node"]

--- a/frameworks/python-poc/codewars.py
+++ b/frameworks/python-poc/codewars.py
@@ -1,0 +1,71 @@
+import unittest
+import traceback
+from time import perf_counter
+
+class CodewarsTestRunner(object):
+    def __init__(self): pass
+    def run(self, test):
+        r = CodewarsTestResult()
+        s = perf_counter()
+        print("\n<DESCRIBE::>Tests")
+        try:
+            test(r)
+        finally:
+            pass
+        print("\n<COMPLETEDIN::>{:.4f}".format(1000*(perf_counter() - s)))
+        return r
+
+__unittest = True
+class CodewarsTestResult(unittest.TestResult):
+    def __init__(self):
+        super().__init__()
+        self.start = 0.0
+
+    def startTest(self, test):
+        print("\n<IT::>" + test._testMethodName)
+        super().startTest(test)
+        self.start = perf_counter()
+
+    def stopTest(self, test):
+        print("\n<COMPLETEDIN::>{:.4f}".format(1000*(perf_counter() - self.start)))
+        super().stopTest(test)
+
+    def addSuccess(self, test):
+        print("\n<PASSED::>Test Passed")
+        super().addSuccess(test)
+
+    def addError(self, test, err):
+        print("\n<ERROR::>Unhandled Exception")
+        print("\n<LOG:ESC:Error>" + esc(''.join(traceback.format_exception_only(err[0], err[1]))))
+        print("\n<LOG:ESC:Traceback>" + esc(self._exc_info_to_string(err, test)))
+        super().addError(test, err)
+
+    def addFailure(self, test, err):
+        print("\n<FAILED::>Test Failed")
+        print("\n<LOG:ESC:Failure>" + esc(''.join(traceback.format_exception_only(err[0], err[1]))))
+        super().addFailure(test, err)
+
+    # from unittest/result.py
+    def _exc_info_to_string(self, err, test):
+        exctype, value, tb = err
+        # Skip test runner traceback levels
+        while tb and self._is_relevant_tb_level(tb):
+            tb = tb.tb_next
+        if exctype is test.failureException:
+            length = self._count_relevant_tb_levels(tb) # Skip assert*() traceback levels
+        else:
+            length = None
+        return ''.join(traceback.format_tb(tb, limit=length))
+
+    def _is_relevant_tb_level(self, tb):
+        return '__unittest' in tb.tb_frame.f_globals
+
+    def _count_relevant_tb_levels(self, tb):
+        length = 0
+        while tb and not self._is_relevant_tb_level(tb):
+            length += 1
+            tb = tb.tb_next
+        return length
+
+def esc(s):
+    return s.replace("\n", "<:LF:>")

--- a/lib/runners/python-poc.js
+++ b/lib/runners/python-poc.js
@@ -1,0 +1,61 @@
+const shovel = require('../shovel');
+const util = require('../util');
+
+module.exports.run = function run(opts, cb) {
+  shovel.start(opts, cb, {
+    // python3 code.py
+    // .
+    // |-- code.py
+    // `-- setup.py
+    // file name can be configured by having a comment in first line
+    solutionOnly(runCode) {
+      if (opts.setup) {
+        const m = opts.setup.match(/^#\s*name:\s*([a-z]+)/);
+        util.writeFileSync(opts.dir, `${m === null ? 'setup' : m[1]}.py`, opts.setup, true);
+      }
+      runCode({
+        name: 'python3',
+        args: [util.writeFileSync(opts.dir, `code.py`, opts.code, true)]
+      });
+    },
+
+    // python3 test
+    // .
+    // |-- setup.py
+    // |-- solution.py
+    // `-- test
+    //     |-- __init__.py
+    //     |-- __main__.py
+    //     `-- test_solution.py
+    // inspired by http://stackoverflow.com/a/27630375
+    testIntegration(runCode) {
+      if (opts.setup) {
+        const m = opts.setup.match(/^#\s*name:\s*([a-z]+)/);
+        util.writeFileSync(opts.dir, `${m === null ? 'setup' : m[1]}.py`, opts.setup, true);
+      }
+      util.writeFileSync(opts.dir, 'solution.py', opts.solution, true);
+      util.writeFileSync(opts.dir+'/test', 'test_solution.py', opts.fixture, true);
+      util.writeFileSync(opts.dir+'/test', '__init__.py', '', true);
+      util.writeFileSync(opts.dir+'/test', '__main__.py', [
+        'import unittest',
+        'from codewars import CodewarsTestRunner',
+        '',
+        'def load_tests(loader, tests, pattern):',
+        '    return loader.discover(".")',
+        '',
+        'unittest.main(testRunner=CodewarsTestRunner())',
+        '',
+      ].join('\n'), true);
+      runCode({
+        name: 'python3',
+        args: ['test'],
+        options: {
+          cwd: opts.dir,
+          env: Object.assign({}, process.env, {
+            PYTHONPATH: `/runner/frameworks/python-poc:${process.env.PYTHONPATH}`
+          })
+        }
+      });
+    }
+  });
+};

--- a/test/runners/python_poc_spec.js
+++ b/test/runners/python_poc_spec.js
@@ -1,0 +1,161 @@
+const expect = require('chai').expect;
+const runner = require('../runner');
+const exec = require('child_process').exec;
+
+describe('.run', function() {
+  afterEach(function cleanup(done) {
+    exec([
+      'rm -rf',
+      '/home/codewarrior/*.py',
+      '/home/codewarrior/__pycache__',
+      '/home/codewarrior/test',
+    ].join(' '), function(err) {
+      if (err) return done(err);
+      return done();
+    });
+  });
+
+  it('should handle basic code evaluation', function(done) {
+    runner.run({
+      language: 'python-poc',
+      code: 'print(42)'
+    }, function(buffer) {
+      expect(buffer.stdout).to.equal('42\n');
+      done();
+    });
+  });
+
+  it('should handle setup file', function(done) {
+    runner.run({
+      language: 'python-poc',
+      setup: [
+        'def add(a, b): return a + b',
+      ].join('\n'),
+      code: [
+        'import setup',
+        'print(setup.add(21, 21))'
+      ].join('\n'),
+    }, function(buffer) {
+      expect(buffer.stdout).to.equal('42\n');
+      done();
+    });
+  });
+
+  it('should handle setup file', function(done) {
+    runner.run({
+      language: 'python-poc',
+      setup: [
+        '# name: foo',
+        'def add(a, b): return a + b',
+      ].join('\n'),
+      code: [
+        'import foo',
+        'print(foo.add(21, 21))'
+      ].join('\n'),
+    }, function(buffer) {
+      expect(buffer.stdout).to.equal('42\n');
+      done();
+    });
+  });
+
+
+  it('stderr', function(done) {
+    runner.run({
+      language: 'python-poc',
+      code: 'import sys; sys.stderr.write("Error!  Codewars cannot and will not accept any more Fibonacci kata.\\n")'
+    }, function(buffer) {
+      expect(buffer.stderr).to.equal("Error!  Codewars cannot and will not accept any more Fibonacci kata.\n");
+      done();
+    });
+  });
+
+  it('stderr', function(done) {
+    runner.run({
+      language: 'python-poc',
+      code: 'import sys; sys.stderr.write("florp\\n"); sys.stdout.write("foop\\n")'
+    }, function(buffer) {
+      expect(buffer.stderr).to.equal("florp\n");
+      expect(buffer.stdout).to.equal("foop\n");
+      done();
+    });
+  });
+});
+
+
+describe('unittest', function() {
+  afterEach(function cleanup(done) {
+    exec([
+      'rm -rf',
+      '/home/codewarrior/*.py',
+      '/home/codewarrior/__pycache__',
+      '/home/codewarrior/test',
+    ].join(' '), function(err) {
+      if (err) return done(err);
+      return done();
+    });
+  });
+
+  it('should handle a basic assertion', function(done) {
+    runner.run({
+      language: 'python-poc',
+      testFramework: 'unittest',
+      solution: [
+        'def add(a, b): return a + b'
+      ].join('\n'),
+      fixture: [
+        'import unittest',
+        'import solution',
+        'class TestAddition(unittest.TestCase):',
+        '  def test_add(self):',
+        '    self.assertEqual(solution.add(1, 1), 2)'
+      ].join('\n'),
+    }, function(buffer) {
+      expect(buffer.stdout).to.contain('\n<PASSED::>');
+      done();
+    });
+  });
+
+  it('should handle a failed assetion', function(done) {
+    runner.run({
+      language: 'python-poc',
+      testFramework: 'unittest',
+      solution: [
+        'def add(a, b): return a - b'
+      ].join('\n'),
+      fixture: [
+        'import unittest',
+        'import solution',
+        '',
+        'class TestAddition(unittest.TestCase):',
+        '  def test_add(self):',
+        '    self.assertEqual(solution.add(1, 1), 2)',
+        ''
+      ].join('\n'),
+    }, function(buffer) {
+      expect(buffer.stdout).to.contain('\n<FAILED::>');
+      done();
+    });
+  });
+
+  it('should handle error', function(done) {
+    runner.run({
+      language: 'python-poc',
+      testFramework: 'unittest',
+      solution: [
+        'def add(a, b): return a / b'
+      ].join('\n'),
+      fixture: [
+        'import unittest',
+        'import solution',
+        '',
+        'class TestAddition(unittest.TestCase):',
+        '  def test_add(self):',
+        '    self.assertEqual(solution.add(1, 0), 1)',
+        ''
+      ].join('\n'),
+    }, function(buffer) {
+      expect(buffer.stdout).to.contain('\n<ERROR::>');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Features

- No file concatenation
- Tracebacks with line numbers/file names
- Test integration using standard unittest
- Can be modified to have multiple test files
- Can be modified to test a package/project

---

```
Current                   Testing a package     Multiple test files
.                         .                     .
|-- setup.py              |-- kata              |-- kata
|-- solution.py           |   |-- __init__.py   |   |-- __init__.py
`-- test                  |   |-- setup.py      |   |-- setup.py
    |-- __init__.py       |   `-- solution.py   |   `-- solution.py
    |-- __main__.py       `-- test              `-- test
    `-- test_solution.py      |-- __init__.py       |-- __init__.py
                              |-- __main__.py       |-- __main__.py
                              `-- test_kata.py      |-- test_kata1.py
                                                    `-- test_kata2.py

All of these should be supported without much modification.
```

At first, I looked into running the test with `python -m unittest discover`, but I couldn't figure out a way to use `CodewarsTestResult` with this.
`test/__main__.py` uses `loader.discover('.')` to find all the tests in `test` package and runs them by calling `unittest.main()` with `testRunner=CodewarsTestRunner`.

---

### TODO

- Grouping tests
- Cleanup messages