### PR TITLE
Add Test.assert(Not)ApproxEquals for floating point values

### DIFF
--- a/frameworks/javascript/cw-2.js
+++ b/frameworks/javascript/cw-2.js
@@ -356,6 +356,12 @@ try {
         Test.expect(false, msg, options);
       }
     },
+    assertFuzzyEquals: function (actual, expected, msg = "") {
+      Test.expect(expected === 0 ? Math.abs(actual) <= 1e-9 : Math.abs((expected - actual) / expected) <= 1e-9, msg === "" ? "Actual value " + actual + " is not sufficiently close to expected value " + expected + " (accepted relative error: 1e-9)" : msg);
+    },
+    assertNotFuzzyEquals: function (actual, expected, msg = "") {
+      Test.expect(expected === 0 ? Math.abs(actual) > 1e-9 : Math.abs((expected - actual) / expected) > 1e-9, msg === "" ? "Actual value " + actual + " too close to expected value " + expected + " (rejected relative error: 1e-9)" : msg);
+    },
     assertContains: function(actual, expected, msg, options) {
       if (actual.indexOf(expected) >= 0) {
         options = options || {};

--- a/frameworks/javascript/cw-2.js
+++ b/frameworks/javascript/cw-2.js
@@ -356,11 +356,27 @@ try {
         Test.expect(false, msg, options);
       }
     },
-    assertFuzzyEquals: function (actual, expected, msg = "") {
-      Test.expect(expected === 0 ? Math.abs(actual) <= 1e-9 : Math.abs((expected - actual) / expected) <= 1e-9, msg === "" ? "Actual value " + actual + " is not sufficiently close to expected value " + expected + " (accepted relative error: 1e-9)" : msg);
+    assertApproxEquals: function (actual, expected, msg, options) {
+      // Compares two floating point values and checks whether they are approximately equal to each other
+      options = options || {};
+      msg = Test.display.message('Expected actual value ' + actual + ' to approximately equal expected value ' + expected + ' (accepted relative error: 1e-9)', msg);
+      if (expected === 0) {
+        Test.expect(Math.abs(actual) <= 1e-9, msg, options);
+      }
+      else {
+        Test.expect(Math.abs((expected - actual) / expected) <= 1e-9, msg, options);
+      }
     },
-    assertNotFuzzyEquals: function (actual, expected, msg = "") {
-      Test.expect(expected === 0 ? Math.abs(actual) > 1e-9 : Math.abs((expected - actual) / expected) > 1e-9, msg === "" ? "Actual value " + actual + " too close to expected value " + expected + " (rejected relative error: 1e-9)" : msg);
+    assertNotApproxEquals: function (actual, unexpected, msg, options) {
+      // Compares two floating point values and checks whether they are sufficiently different from each other
+      options = options || {};
+      msg = Test.display.message('Actual value ' + actual + ' should not approximately equal unexpected value ' + unexpected + ' (rejected relative error: 1e-9)', msg);
+      if (unexpected === 0) {
+        Test.expect(Math.abs(actual) > 1e-9, msg, options);
+      }
+      else {
+        Test.expect(Math.abs((unexpected - actual) / unexpected) > 1e-9, msg, options);
+      }
     },
     assertContains: function(actual, expected, msg, options) {
       if (actual.indexOf(expected) >= 0) {

--- a/test/runners/javascript_spec.js
+++ b/test/runners/javascript_spec.js
@@ -705,6 +705,88 @@ describe('javascript runner', function() {
       });
     });
 
+    describe('Test.assertApproxEquals', function () {
+      it("should allow for minor floating point errors and compare them as equal", function(done) {
+        runner.run({language: 'javascript', code: 'var a = 2.00000000004', fixture: 'Test.assertApproxEquals(a, 2);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
+      it("should allow for minor floating point errors and compare them as equal (2)", function(done) {
+        runner.run({language: 'javascript', code: 'var a = 1.99999999996', fixture: 'Test.assertApproxEquals(a, 2);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
+      it("should handle 0 properly and not throw DivisionByZeroError", function(done) {
+        runner.run({language: 'javascript', code: 'var a = 0.00000000009', fixture: 'Test.assertApproxEquals(a, 0);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
+      it("should handle 0 properly and not throw DivisionByZeroError (2)", function(done) {
+        runner.run({language: 'javascript', code: 'var a = -0.00000000009', fixture: 'Test.assertApproxEquals(a, 0);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
+      it("should fail tests where the relative error is greater than 1e-9", function(done) {
+        runner.run({language: 'javascript', code: 'var a = 3.004', fixture: 'Test.assertApproxEquals(a, 3);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          expect(buffer.stdout).to.contain('\n');
+          done();
+        });
+      });
+      it("should fail tests where the relative error is greater than 1e-9 (2)", function(done) {
+        runner.run({language: 'javascript', code: 'var a = 2.996', fixture: 'Test.assertApproxEquals(a, 3);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          expect(buffer.stdout).to.contain('\n');
+          done();
+        });
+      });
+    });
+
+    describe('Test.assertNotApproxEquals', function() {
+      it('should pass tests where the two values are outside the rejected relative error', function(done) {
+        runner.run({language: 'javascript', code: 'var a = 2.004', fixture: 'Test.assertNotApproxEquals(a, 2);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
+      it('should pass tests where the two values are outside the rejected relative error (2)', function(done) {
+        runner.run({language: 'javascript', code: 'var a = 1.996', fixture: 'Test.assertNotApproxEquals(a, 2);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
+      it('should handle 0 properly and not throw DivisionByZeroError', function(done) {
+        runner.run({language: 'javascript', code: 'var a = -0.009', fixture: 'Test.assertNotApproxEquals(a, 0);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
+      it('should handle 0 properly and not throw DivisionByZeroError (2)', function(done) {
+        runner.run({language: 'javascript', code: 'var a = 0.009', fixture: 'Test.assertNotApproxEquals(a, 0);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.equal('<PASSED::>Test Passed\n');
+          done();
+        });
+      });
+      it('should fail a test where the two floats are within the rejected relative error', function(done) {
+        runner.run({language: 'javascript', code: 'var a = 3.00000000004', fixture: 'Test.assertNotApproxEquals(a, 3);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          expect(buffer.stdout).to.contain('\n');
+          done();
+        });
+      });
+      it('should fail a test where the two floats are within the rejected relative error (2)', function(done) {
+        runner.run({language: 'javascript', code: 'var a = 2.99999999996', fixture: 'Test.assertNotApproxEquals(a, 3);', testFramework: 'cw-2'}, function(buffer) {
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          expect(buffer.stdout).to.contain('\n');
+          done();
+        });
+      });
+    });
+
 
     //----------------------------------------------------------------------------------------
     // Karma BDD


### PR DESCRIPTION
> Includes:
>
> - 2 new assertions `Test.assert(Not)ApproxEquals` which follow the general format presented in `cw-2.js`. Compatible with Node v0.10.0
> - Tests in `javascript_spec.js` to confirm that this assertion works as expected

Authored by @DonaldKellett.