### PR TITLE
Make Travis Check ESLint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: required
 
-language: javascript
+language: node_js
+node_js:
+  - "6"
+
+# skip `npm install` <https://docs.travis-ci.com/user/customizing-the-build#Skipping-the-Installation-Step>
+install: true
 
 services:
   - docker
@@ -9,5 +14,8 @@ after_success:
   - docker ps -a
   - docker images -a
 
+before_script:
+  - npm install -g eslint
 script:
+  - eslint '**/*.js'
   - make recent


### PR DESCRIPTION
`make recent` is executed even if `eslint '**/*.js'` reports errors, but the build will result in failure.
I thought this is less annoying, but if failing quick is preferred, `eslint '**/*.js' && make recent` should do that.

Closes #340 once all other ESLint PRs are merged and this build succeeds.