### PR TITLE
[Lua] Add "Preloaded" code support

### DIFF
--- a/docker/lua.docker
+++ b/docker/lua.docker
@@ -24,9 +24,6 @@ RUN mkdir -p /runner && cp -a /tmp/node_modules /runner
 COPY . /runner
 WORKDIR /runner
 
-COPY frameworks/lua /home/codewarrior/lua
-RUN chown -R codewarrior:codewarrior /home/codewarrior/lua
-
 USER codewarrior
 ENV USER=codewarrior HOME=/home/codewarrior
 

--- a/frameworks/lua/codewars.lua
+++ b/frameworks/lua/codewars.lua
@@ -6,45 +6,45 @@ return function(options)
   end
 
   local function onDescribeStart(element, parent)
-    print('<DESCRIBE::>' .. element.name)
+    print('\n<DESCRIBE::>' .. element.name)
     return nil, true
   end
   local function onDescribeEnd(element, parent)
-    local s = '<COMPLETEDIN::>%.4f'
+    local s = '\n<COMPLETEDIN::>%.4f'
     print(s:format(1000*element.duration))
     return nil, true
   end
 
   local function onTestStart(element, parent)
-    print('<IT::>' .. element.name)
+    print('\n<IT::>' .. element.name)
     return nil, true
   end
   local function onTestEnd(element, parent, status, trace)
     if status == 'success' then
-      print('<PASSED::>Test Passed')
+      print('\n<PASSED::>Test Passed')
     end
-    local s = '<COMPLETEDIN::>%.4f'
+    local s = '\n<COMPLETEDIN::>%.4f'
     print(s:format(1000*element.duration))
     return nil, true
   end
 
   local function onTestFailure(element, parent, message, debug)
-    print('<FAILED::>Test Failed')
+    print('\n<FAILED::>Test Failed')
     -- remove '/home/codewarrior/lua/fixture.lua:\d+: ' from message
-    print('<LOG:ESC:>' .. escape(message:sub(message:find(' ') + 1)))
+    print('\n<LOG:ESC:>' .. escape(message:sub(message:find(' ') + 1)))
     return nil, true
   end
 
   local function onTestError(element, parent, message, debug)
-    print('<ERROR::>Test Error')
-    print('<LOG:ESC:Traceback>' .. escape(message))
+    print('\n<ERROR::>Test Error')
+    print('\n<LOG:ESC:Traceback>' .. escape(message))
     return nil, true
   end
 
   local function onError(element, parent, message, debug)
     if element.descriptor ~= 'it' then
-      print('<ERROR::>Error')
-      print('<LOG:ESC:>' .. escape(message))
+      print('\n<ERROR::>Error')
+      print('\n<LOG:ESC:>' .. escape(message))
     end
     return nil, true
   end

--- a/lib/runners/lua.js
+++ b/lib/runners/lua.js
@@ -1,24 +1,28 @@
-var shovel = require('../shovel'),
-    writeFileSync = require('../util').writeFileSync;
+"use strict";
+
+const shovel = require('../shovel');
+const writeFileSync = require('../util').writeFileSync;
 
 module.exports.run = function run(opts, cb) {
-  const dir = '/home/codewarrior/lua';
   shovel.start(opts, cb, {
-    solutionOnly: function(runCode) {
+    solutionOnly(runCode) {
       runCode({
         name: 'lua',
-        args: [writeFileSync(dir, 'solution.lua', opts.solution, true)]
+        args: [writeFileSync(opts.dir, 'solution.lua', opts.solution, true)],
+        options: {cwd: opts.dir}
       });
     },
-    testIntegration: function(runCode) {
-      writeFileSync(dir, 'solution.lua', opts.solution, true);
+
+    testIntegration(runCode) {
+      writeFileSync(opts.dir, 'solution.lua', opts.solution, true);
+      if (opts.setup) writeFileSync(opts.dir, 'setup.lua', opts.setup, true);
       runCode({
         name: 'busted',
         args: [
-          writeFileSync(dir, 'fixture.lua', opts.fixture, true),
-          `--output=codewars.lua`,
+          writeFileSync(opts.dir, 'fixture.lua', opts.fixture, true),
+          '--output=/runner/frameworks/lua/codewars.lua'
         ],
-        options: {cwd: dir}
+        options: {cwd: opts.dir}
       });
     }
   });

--- a/test/runners/lua_spec.js
+++ b/test/runners/lua_spec.js
@@ -204,6 +204,43 @@ end)
       done();
     });
   });
+
+  it('should support opts.setup', function(done) {
+    runner.run({
+      language: 'lua',
+      setup: `
+local setup = {}
+function setup.add(a, b)
+  return a + b
+end
+setup.answer = 42
+return setup
+`,
+      solution: `
+local setup = require 'setup'
+return {
+  add = setup.add,
+  ans = setup.answer
+}
+`,
+      fixture: `
+local kata = require 'solution'
+describe("add", function()
+  it("should add numbers", function()
+    assert.are.same(2, kata.add(1, 1))
+  end)
+  it("should have 42", function()
+    assert.are.same(42, kata.ans)
+  end)
+end)
+`
+    }, function(buffer) {
+      expect(buffer.stdout).to.contain('<PASSED::>');
+      done();
+    });
+  });
+
+
 });
 
 describe('Examples', function() {

--- a/test/runners/lua_spec.js
+++ b/test/runners/lua_spec.js
@@ -5,7 +5,10 @@ var runner = require('../runner');
 describe('lua runner', function() {
   describe('.run', function() {
     it('should handle basic code evaluation', function(done) {
-      runner.run({language: 'lua', code: 'print(42)'}, function(buffer) {
+      runner.run({
+        language: 'lua',
+        code: 'print(42)'
+      }, function(buffer) {
         expect(buffer.stdout).to.equal('42\n');
         done();
       });
@@ -18,21 +21,21 @@ describe('busted', function() {
   it('should handle basic code assertion', function(done) {
     runner.run({
       language: 'lua',
-      solution: `
-local kata = {}
-function kata.add(a, b)
-  return a + b
-end
-return kata
-`,
-      fixture: `
-local kata = require 'solution'
-describe("add", function()
-  it("should add numbers", function()
-    assert.are.same(2, kata.add(1, 1))
-  end)
-end)
-`
+      solution: [
+        `local kata = {}`,
+        `function kata.add(a, b)`,
+        `  return a + b`,
+        `end`,
+        `return kata`,
+      ].join('\n'),
+      fixture: [
+        `local kata = require 'solution'`,
+        `describe("add", function()`,
+        `  it("should add numbers", function()`,
+        `    assert.are.same(2, kata.add(1, 1))`,
+        `  end)`,
+        `end)`,
+      ].join('\n')
     }, function(buffer) {
       expect(buffer.stdout).to.contain('<PASSED::>');
       done();
@@ -42,21 +45,21 @@ end)
   it('should handle basic code assertion failure', function(done) {
     runner.run({
       language: 'lua',
-      solution: `
-local kata = {}
-function kata.add(a, b)
-  return a - b
-end
-return kata
-`,
-      fixture: `
-local kata = require 'solution'
-describe("add", function()
-  it("should add numbers", function()
-    assert.are.same(2, kata.add(1, 1))
-  end)
-end)
-`
+      solution: [
+        `local kata = {}`,
+        `function kata.add(a, b)`,
+        `  return a - b`,
+        `end`,
+        `return kata`,
+      ].join('\n'),
+      fixture: [
+        `local kata = require 'solution'`,
+        `describe("add", function()`,
+        `  it("should add numbers", function()`,
+        `    assert.are.same(2, kata.add(1, 1))`,
+        `  end)`,
+        `end)`,
+      ].join('\n')
     }, function(buffer) {
       expect(buffer.stdout).to.contain('<FAILED::>');
       done();
@@ -66,24 +69,24 @@ end)
   it('should handle mixed success and failure', function(done) {
     runner.run({
       language: 'lua',
-      solution: `
-local kata = {}
-function kata.add(a, b)
-  return a - b
-end
-return kata
-`,
-      fixture: `
-local kata = require 'solution'
-describe("add", function()
-  it("should add numbers", function()
-    assert.are.same(0, kata.add(0, 0))
-  end)
-  it("should add numbers", function()
-    assert.are.same(2, kata.add(1, 1))
-  end)
-end)
-`
+      solution: [
+        `local kata = {}`,
+        `function kata.add(a, b)`,
+        `  return a - b`,
+        `end`,
+        `return kata`,
+      ].join('\n'),
+      fixture: [
+        `local kata = require 'solution'`,
+        `describe("add", function()`,
+        `  it("should add numbers", function()`,
+        `    assert.are.same(0, kata.add(0, 0))`,
+        `  end)`,
+        `  it("should add numbers", function()`,
+        `    assert.are.same(2, kata.add(1, 1))`,
+        `  end)`,
+        `end)`,
+      ].join('\n')
     }, function(buffer) {
       expect(buffer.stdout).to.contain('<PASSED::>');
       expect(buffer.stdout).to.contain('<FAILED::>');
@@ -94,25 +97,25 @@ end)
   it('should handle error', function(done) {
     runner.run({
       language: 'lua',
-      solution: `
-local kata = {}
-function kata.add(a, b)
-  error("Error")
-  return a - b
-end
-return kata
-`,
-      fixture: `
-local kata = require 'solution'
-describe("add", function()
-  it("should add numbers", function()
-    assert.equal(2, kata.add(1, 1))
-  end)
-end)
-`
+      solution: [
+        `local kata = {}`,
+        `function kata.add(a, b)`,
+        `  error("Error")`,
+        `  return a - b`,
+        `end`,
+        `return kata`,
+      ].join('\n'),
+      fixture: [
+        `local kata = require 'solution'`,
+        `describe("add", function()`,
+        `  it("should add numbers", function()`,
+        `    assert.equal(2, kata.add(1, 1))`,
+        `  end)`,
+        `end)`,
+      ].join('\n')
     }, function(buffer) {
       expect(buffer.stdout).to.contain('<ERROR::>');
-      expect(buffer.stdout).to.contain('./solution.lua:4: Error');
+      expect(buffer.stdout).to.contain('./solution.lua:3: Error');
       done();
     });
   });
@@ -120,45 +123,45 @@ end)
   it('should output nested describes', function(done) {
     runner.run({
       language: 'lua',
-      solution: `
-local kata = {}
-function kata.add(a, b)
-  return a + b
-end
-return kata
-`,
-      fixture: `
--- from busted website
-describe("Busted unit testing framework", function()
-  describe("should be awesome", function()
-    it("should be easy to use", function()
-      assert.truthy("Yup.")
-    end)
-
-    it("should have lots of features", function()
-      assert.are.same({ table = "great"}, { table = "great" })
-      assert.are_not.equal({ table = "great"}, { table = "great"})
-      assert.truthy("this is a string")
-      assert.True(1 == 1)
-      assert.is_true(1 == 1)
-      assert.falsy(nil)
-      assert.has_error(function() error("Wat") end, "Wat")
-    end)
-
-    it("should provide some shortcuts to common functions", function()
-      assert.are.unique({{ thing = 1 }, { thing = 2 }, { thing = 3 }})
-    end)
-
-    it("should have mocks and spies for functional tests", function()
-      local kata = require 'solution'
-      spy.on(kata, "add")
-      kata.add(1, 1)
-      assert.spy(kata.add).called()
-      assert.spy(kata.add).called_with(1, 1)
-    end)
-  end)
-end)
-`
+      solution: [
+        `local kata = {}`,
+        `function kata.add(a, b)`,
+        `  return a + b`,
+        `end`,
+        `return kata`,
+      ].join('\n'),
+      fixture: [
+        `-- from busted website`,
+        `describe("Busted unit testing framework", function()`,
+        `  describe("should be awesome", function()`,
+        `    it("should be easy to use", function()`,
+        `      assert.truthy("Yup.")`,
+        `    end)`,
+        ``,
+        `    it("should have lots of features", function()`,
+        `      assert.are.same({ table = "great"}, { table = "great" })`,
+        `      assert.are_not.equal({ table = "great"}, { table = "great"})`,
+        `      assert.truthy("this is a string")`,
+        `      assert.True(1 == 1)`,
+        `      assert.is_true(1 == 1)`,
+        `      assert.falsy(nil)`,
+        `      assert.has_error(function() error("Wat") end, "Wat")`,
+        `    end)`,
+        ``,
+        `    it("should provide some shortcuts to common functions", function()`,
+        `      assert.are.unique({{ thing = 1 }, { thing = 2 }, { thing = 3 }})`,
+        `    end)`,
+        ``,
+        `    it("should have mocks and spies for functional tests", function()`,
+        `      local kata = require 'solution'`,
+        `      spy.on(kata, "add")`,
+        `      kata.add(1, 1)`,
+        `      assert.spy(kata.add).called()`,
+        `      assert.spy(kata.add).called_with(1, 1)`,
+        `    end)`,
+        `  end)`,
+        `end)`,
+      ].join('\n')
     }, function(buffer) {
       const nested = [
         '<DESCRIBE::>',
@@ -178,25 +181,25 @@ end)
   it('should allow solution to log', function(done) {
     runner.run({
       language: 'lua',
-      solution: `
-local kata = {}
-function kata.add(a, b)
-  print(a)
-  print(b)
-  return a + b
-end
-return kata
-`,
-      fixture: `
-require 'busted.runner'()
-local kata = require 'solution'
-
-describe("add", function()
-  it("should add numbers", function()
-    assert.are.same(3, kata.add(1, 2))
-  end)
-end)
-`
+      solution: [
+        `local kata = {}`,
+        `function kata.add(a, b)`,
+        `  print(a)`,
+        `  print(b)`,
+        `  return a + b`,
+        `end`,
+        `return kata`,
+      ].join('\n'),
+      fixture: [
+        `require 'busted.runner'()`,
+        `local kata = require 'solution'`,
+        ``,
+        `describe("add", function()`,
+        `  it("should add numbers", function()`,
+        `    assert.are.same(3, kata.add(1, 2))`,
+        `  end)`,
+        `end)`,
+      ].join('\n')
     }, function(buffer) {
       expect(buffer.stdout).to.contain('<PASSED::>');
       expect(buffer.stdout).to.contain('1');
@@ -208,39 +211,37 @@ end)
   it('should support opts.setup', function(done) {
     runner.run({
       language: 'lua',
-      setup: `
-local setup = {}
-function setup.add(a, b)
-  return a + b
-end
-setup.answer = 42
-return setup
-`,
-      solution: `
-local setup = require 'setup'
-return {
-  add = setup.add,
-  ans = setup.answer
-}
-`,
-      fixture: `
-local kata = require 'solution'
-describe("add", function()
-  it("should add numbers", function()
-    assert.are.same(2, kata.add(1, 1))
-  end)
-  it("should have 42", function()
-    assert.are.same(42, kata.ans)
-  end)
-end)
-`
+      setup: [
+        `local setup = {}`,
+        `function setup.add(a, b)`,
+        `  return a + b`,
+        `end`,
+        `setup.answer = 42`,
+        `return setup`,
+      ].join('\n'),
+      solution: [
+        `local setup = require 'setup'`,
+        `return {`,
+        `  add = setup.add,`,
+        `  ans = setup.answer`,
+        `}`,
+      ].join('\n'),
+      fixture: [
+        `local kata = require 'solution'`,
+        `describe("add", function()`,
+        `  it("should add numbers", function()`,
+        `    assert.are.same(2, kata.add(1, 1))`,
+        `  end)`,
+        `  it("should have 42", function()`,
+        `    assert.are.same(42, kata.ans)`,
+        `  end)`,
+        `end)`,
+      ].join('\n')
     }, function(buffer) {
       expect(buffer.stdout).to.contain('<PASSED::>');
       done();
     });
   });
-
-
 });
 
 describe('Examples', function() {

--- a/test/runners/lua_spec.js
+++ b/test/runners/lua_spec.js
@@ -242,6 +242,35 @@ describe('busted', function() {
       done();
     });
   });
+
+  it('should have output format commands on independent lines', function(done) {
+    runner.run({
+      language: 'lua',
+      solution: [
+        `local kata = {}`,
+        `function kata.add(a, b)`,
+        `  io.write(a)`,
+        `  io.write(b)`,
+        `  return a + b`,
+        `end`,
+        `return kata`,
+      ].join('\n'),
+      fixture: [
+        `require 'busted.runner'()`,
+        `local kata = require 'solution'`,
+        ``,
+        `describe("add", function()`,
+        `  it("should add numbers", function()`,
+        `    assert.are.same(3, kata.add(1, 2))`,
+        `  end)`,
+        `end)`,
+      ].join('\n')
+    }, function(buffer) {
+      expect(buffer.stdout).to.contain('12');
+      expect(buffer.stdout).to.contain('\n<PASSED::>');
+      done();
+    });
+  });
 });
 
 describe('Examples', function() {


### PR DESCRIPTION
This adds support for `opts.setup` and `opts.dir`.
The code is written to a file named `setup.lua` in `opts.dir` and can be used by `require 'setup'`.

This also fixes the LF issue.