### PR TITLE
Improve Travis build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: node_js
 node_js:
   - "6"
 
+before_install:
+  - sudo apt-get update && sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
+  - docker --version
 install:
   - npm install -g eslint@3.19.0
 
@@ -39,4 +42,9 @@ env:
 
 script:
   - eslint '**/*.js'
-  - make $TEST_IMG
+  - cp docker/${TEST_IMG}.docker ./Dockerfile
+  - if docker pull codewars/${TEST_IMG}-runner; then
+      docker build --cache-from codewars/${TEST_IMG}-runner -t codewars/${TEST_IMG}-runner .;
+    else
+      docker build -t codewars/${TEST_IMG}-runner .;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: node_js
 node_js:
   - "6"
 
-before_install:
-  - sudo apt-get update && sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
-  - docker --version
 install:
   - npm install -g eslint@3.19.0
 


### PR DESCRIPTION
This improves Travis build time by using `--cache-from`.

`python-runner` [22 min 18 sec](https://travis-ci.org/Codewars/codewars-runner-cli/jobs/229500520) to [2 min 51 sec](https://travis-ci.org/Codewars/codewars-runner-cli/jobs/229584747)
![image](https://cloud.githubusercontent.com/assets/639336/25777433/11ac76d2-3292-11e7-9db8-61efa8bea95b.png)
![image](https://cloud.githubusercontent.com/assets/639336/25778164/ef66f03e-32aa-11e7-940d-f3d52d032311.png)
`haskell-runner` [27 min 41 sec](https://travis-ci.org/Codewars/codewars-runner-cli/jobs/229500534) to [2 min 54 sec](https://travis-ci.org/Codewars/codewars-runner-cli/jobs/229584756)
![image](https://cloud.githubusercontent.com/assets/639336/25778202/574395a8-32ac-11e7-9468-e0b7d2cb770e.png)
![image](https://cloud.githubusercontent.com/assets/639336/25778204/64e83a4c-32ac-11e7-884a-6207a42dbd8e.png)


Duration [44 min 59 sec](https://travis-ci.org/Codewars/codewars-runner-cli/builds/229500514) to [23 min 53 sec](https://travis-ci.org/Codewars/codewars-runner-cli/builds/229584743)
![image](https://cloud.githubusercontent.com/assets/639336/25778174/3d53fd1e-32ab-11e7-9ccb-cddf7635da30.png)
![image](https://cloud.githubusercontent.com/assets/639336/25778176/457accc0-32ab-11e7-9319-e6a2d73d85f8.png)

This can be further improved by refactoring Dockerfile to only copy necessary files (removing `COPY . /runner`) which minimizes the number of affected images.
Also, some images are failing to pull with `manifest don't match image configuration` and completely rebuilt.

Slow images and possible reasons:
- `ruby-runner` took [14 min 45 sec](https://travis-ci.org/Codewars/codewars-runner-cli/jobs/229584748). `docker pull` failed.
- `jvm-runner` took [8 min 4 sec](https://travis-ci.org/Codewars/codewars-runner-cli/jobs/229584746). `docker pull` failed.
- `node-runner` took [11 min](https://travis-ci.org/Codewars/codewars-runner-cli/jobs/229584744). `npm install`.
- `ocaml-runner` took [8 min 26 sec](https://travis-ci.org/Codewars/codewars-runner-cli/jobs/229584755). time consuming step after cache invalidated `npm install`.
- `objc-runner` took [10 min 38 sec](https://travis-ci.org/Codewars/codewars-runner-cli/jobs/229584757). pulled image had less usable cache.

Most of them finishes under 3 min now :)