### PR TITLE
Add BF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
     - TEST_IMG=objc
     - TEST_IMG=go
     - TEST_IMG=lua
+    - TEST_IMG=esolangs
 
 script:
   - eslint '**/*.js'

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 HOSTNAME=codewars
 
 # Building erlang images have been suspended (frozen) until they are able to be repaired
-CONTAINERS=node dotnet jvm python ruby alt rust julia systems dart crystal ocaml swift haskell objc go lua
+CONTAINERS=node dotnet jvm python ruby alt rust julia systems dart crystal ocaml swift haskell objc go lua esolangs
 
 # recent containers should be updated when adding or modifying a language, so that
 # the travis build process will test it. The process cant test all languages
 # without timing out so this is required to get passed that issue.
-RECENT_CONTAINERS=node
+RECENT_CONTAINERS=esolangs
 
 ALL_CONTAINERS=${CONTAINERS} base
 

--- a/docker/esolangs.docker
+++ b/docker/esolangs.docker
@@ -1,0 +1,28 @@
+# Pull base image.
+FROM codewars/base-runner
+
+# Install "bf" Fast Brainf**k Interpreter
+RUN apt-get update && apt-get install -y --no-install-recommends bf
+
+# add the package json first to a tmp directory and build, copy over so that we don't rebuild every time
+ADD package.json /tmp/package.json
+RUN cd /tmp && npm install --production
+RUN mkdir -p /runner && cp -a /tmp/node_modules /runner
+
+# ADD cli-runner and install node deps
+ADD . /runner
+
+RUN ln -s /home/codewarrior /workspace
+
+# Set environment variables
+ENV HOME /home/codewarrior
+USER codewarrior
+ENV USER codewarrior
+
+# Switch to /runner directory and run BF Test Suite to make sure it works
+WORKDIR /runner
+RUN mocha -t 10000 test/runners/bf_spec.js
+
+#timeout is a fallback in case an error with node
+#prevents it from exiting properly
+ENTRYPOINT ["timeout", "15", "node"]

--- a/documentation/environments/esolangs.md
+++ b/documentation/environments/esolangs.md
@@ -1,0 +1,64 @@
+# Environment
+
+Code is executed within a Dockerized Ubuntu 14.04 container.
+
+## Language
+
+[brainf**k](http://esolangs.org/wiki/Brainfuck) (known as simply BF in this codebase)
+
+## Interpreter
+
+### BF
+
+*["bf" fast Brainf**k Interpreter](http://manpages.ubuntu.com/manpages/trusty/man1/bf.1.html)*
+
+Care has been taken to follow the standard implementation guidelines as outlined by [The Epistle to the Implementors](http://www.hevanet.com/cristofd/brainfuck/epistle.html) whenever possible.  Specifically:
+
+- The newline `\n` and carriage return `\r` are treated like any other character by this interpreter in terms of both input and output; there is no special behavior configured in this case
+- For the program input, when EOF is reached, note that a value of `-1` is stored in the cell under the pointer, which is considered a standard implementation, albeit not the most popular one.  Keep that in mind when writing your BF programs as programs that assume otherwise is likely to cause an infinite loop.
+- Hacks are not enabled: `#` and `!` are treated like any other non-command character.
+- The memory tape has been configured to contain exactly `30000` 8-bit cells as per the original implementation of Brainf\*\*k by Urban Müller (and therefore is **not** unbounded) and does not exhibit toroidal behavior - an out-of-bounds memory pointer is reported as an error
+- Cell wrapping (`0 - 1 -> 255`, `255 + 1 -> 0`) is enabled as per the standard implementation
+
+## Testing Framework
+
+### BF
+
+The [JavaScript CW-2 custom testing framework](https://www.codewars.com/docs/js-slash-coffeescript-test-reference) is used for testing brainf\*\*k code.  To execute the BF code with the desired input, simply make a call to the `runBF` function which optionally accepts 1 argument - the program input as a string.  For example, if you want the output of your CAT program with the input `"Codewars"`, simply do `runBF("Codewars")` in which case the string `"Codewars"` is returned provided your CAT program is correct.  If no input is required, simply call `runBF` without any arguments.
+
+A basic example of testing a Hello World program:
+
+```javascript
+Test.describe("Your BF Hello World Program", function () {
+  Test.it("should return the string \"Hello World!\"", function () {
+    Test.assertEquals(runBF(), "Hello World!");
+  });
+});
+```
+
+And a basic example of testing a program that multiplies two numbers together:
+
+```javascript
+Test.describe("Your BF Multiply Program", function () {
+  Test.it("should work for some fixed tests", function () {
+    Test.assertEquals(runBF(String.fromCharCode(3, 5)), String.fromCharCode(15));
+    Test.assertEquals(runBF(String.fromCharCode(9, 8)), "H"); // "H" has character code 72
+    Test.assertEquals(runBF(" \n"), "@"); // Cell wrapping at work - (10 * 32) % 256 === 64
+  });
+  Test.it("should work for some random tests", function () {
+    for (var i = 0; i < 100; i++) {
+      var a = ~~(Math.random() * 128); // Random number from 0 to 127 (both inclusive)
+      var b = ~~(Math.random() * 128);
+      Test.assertEquals(runBF(String.fromCharCode(a, b)), String.fromCharCode((a * b) % 256)); // allowing for cell wrapping when product exceeds 255
+    }
+  });
+});
+```
+
+*NOTE: Although the JavaScript CW-2 Framework contains many different methods, only the following should be needed in most cases to test BF output:*
+
+1. `Test.describe`
+2. `Test.it`
+3. `Test.assert(Not)Equals`
+
+`Test.expect` may also be used in special circumstances but it is recommended to avoid it unless absolutely necessary.

--- a/examples/bf.yml
+++ b/examples/bf.yml
@@ -1,0 +1,77 @@
+cw-2:
+  bug fixes:
+    initial: |-
+      ++++++++++[>+++++++>++++++++++>+++++++++++>+++>+++++++++<<<<<->++.>+.>--.+++.>++.>---.<<.+++.------.<-.>>+
+    answer: |-
+      ++++++++++[>+++++++>++++++++++>+++++++++++>+++>+++++++++<<<<<-]>++.>+.>--..+++.>++.>---.<<.+++.------.<-.>>+.
+    fixture: |-
+      Test.describe("Your Hello World Program", function () {
+        Test.it("should return the string \"Hello World!\"", function () {
+          Test.assertEquals(runBF(), "Hello World!");
+        });
+      });
+  algorithms:
+    initial: |-
+      [
+        TODO: Write a BF program that accepts exactly 2 characters as input,
+        multiplies the ASCII character codes of the two characters and returns
+        the corresponding character
+
+        E.g.
+        Input: byte(9), byte(8)
+        Output: byte(72) - prints out "H"
+      ]
+    answer: |-
+      [
+        TODO: Write a BF program that accepts exactly 2 characters as input,
+        multiplies the ASCII character codes of the two characters and returns
+        the corresponding character
+
+        E.g.
+        Input: byte(9), byte(8)
+        Output: byte(72) - prints out "H"
+      ]
+      ,>,<      Read two bytes of input (byte(a) and byte(b)) from the input stream
+      [         while a is greater than 0
+        -       Decrement a
+        >       Move pointer to b
+        [       while b is greater than 0
+          -     Decrement b
+          >+>+  Move to cells 3 and 4 and increment both cells
+          <<    Go back to cell 2
+        ]       end while
+        >>      Move to cell 4
+        [       while cell 4 greater than 0
+          -     Decrement cell 4
+          <<    Move to cell 2
+          +     Increment cell 2
+          >>    Return to cell 4
+        ]       end while
+        <<<     Return to cell 1
+      ]         end while
+      >>        Goto cell 3 (a * b)
+      .         Output Result
+    fixture: |-
+      Test.describe("Your Multiply Program", function () {
+        Test.it("should work for the example provided in the loop comment", function () {
+          Test.assertEquals(runBF(String.fromCharCode(9, 8)), "H");
+        });
+        Test.it("should work for some fixed tests", function () {
+          Test.assertEquals(runBF(String.fromCharCode(0, 0)), String.fromCharCode(0));
+          Test.assertEquals(runBF(String.fromCharCode(17, 0)), String.fromCharCode(0));
+          Test.assertEquals(runBF(String.fromCharCode(1, 1)), String.fromCharCode(1));
+          Test.assertEquals(runBF(String.fromCharCode(2, 4)), String.fromCharCode(8));
+          Test.assertEquals(runBF(String.fromCharCode(3, 5)), String.fromCharCode(15));
+          Test.assertEquals(runBF(String.fromCharCode(5, 3)), String.fromCharCode(15));
+          Test.assertEquals(runBF(String.fromCharCode(5, 9)), String.fromCharCode(45));
+          Test.assertEquals(runBF(String.fromCharCode(15, 12)), String.fromCharCode(180));
+          Test.assertEquals(runBF(String.fromCharCode(15, 15)), String.fromCharCode(225));
+        });
+        Test.it("should work for some random tests", function () {
+          for (var i = 0; i < 100; i++) {
+            var a = Math.floor(Math.random() * 16); // Random integer from 0 to 15 (inclusive)
+            var b = Math.floor(Math.random() * 16);
+            Test.assertEquals(runBF(String.fromCharCode(a, b)), String.fromCharCode(a * b));
+          }
+        });
+      });

--- a/frameworks/bf/run-bf.js
+++ b/frameworks/bf/run-bf.js
@@ -1,7 +1,7 @@
 var execSync = require('child_process').execSync;
 module.exports = function runBF(input) {
   if (input) {
-    return String.fromCharCode(...execSync('bf /workspace/solution.txt', {input}));
+    return String.fromCharCode(...execSync('bf -c29999 /workspace/solution.txt', {input}));
   }
-  return String.fromCharCode(...execSync('bf /workspace/solution.txt'));
+  return String.fromCharCode(...execSync('bf -c29999 /workspace/solution.txt'));
 };

--- a/frameworks/bf/run-bf.js
+++ b/frameworks/bf/run-bf.js
@@ -1,0 +1,7 @@
+var execSync = require('child_process').execSync;
+module.exports = function runBF(input) {
+  if (input) {
+    return String.fromCharCode(...execSync('bf /workspace/solution.txt', {input}));
+  }
+  return String.fromCharCode(...execSync('bf /workspace/solution.txt'));
+};

--- a/lib/runners/bf.js
+++ b/lib/runners/bf.js
@@ -7,7 +7,7 @@ module.exports.run = function run(opts, cb) {
       var solutionFile = util.writeFileSync('/home/codewarrior', 'code.b', opts.solution, true);
       runCode({
         name: 'bf',
-        args: [solutionFile]
+        args: ['-c29999', solutionFile]
       });
     },
     testIntegration: function(runCode, fail) {

--- a/lib/runners/bf.js
+++ b/lib/runners/bf.js
@@ -1,0 +1,21 @@
+var shovel = require('../shovel'),
+    util = require('../util');
+
+module.exports.run = function run(opts, cb) {
+  shovel.start(opts, cb, {
+    solutionOnly: function(runCode) {
+      var solutionFile = util.writeFileSync('/home/codewarrior', 'code.b', opts.solution, true);
+      runCode({
+        name: 'bf',
+        args: [solutionFile]
+      });
+    },
+    testIntegration: function(runCode, fail) {
+      switch (opts.testFramework) {
+        // TODO: Add Test Framework options as they become available
+        default:
+          throw 'Test framework is not supported';
+      }
+    }
+  });
+};

--- a/lib/runners/bf.js
+++ b/lib/runners/bf.js
@@ -12,7 +12,20 @@ module.exports.run = function run(opts, cb) {
     },
     testIntegration: function(runCode, fail) {
       switch (opts.testFramework) {
-        // TODO: Add Test Framework options as they become available
+        case 'cw-2':
+          var fixture = `
+require('/runner/frameworks/javascript/cw-2');
+const runBF = require('/runner/frameworks/bf/run-bf.js');
+${opts.fixture};
+`;
+          runCode({
+            name: 'node',
+            args: ['-e', fixture, '--no-deprecation'],
+            options: {
+              cwd: opts.dir
+            }
+          });
+          break;
         default:
           throw 'Test framework is not supported';
       }

--- a/test/runners/bf_spec.js
+++ b/test/runners/bf_spec.js
@@ -10,41 +10,41 @@ describe("BF Runner", function() {
       });
     });
     it('should ignore anything not in "+-.,<>[]" as comments', function(done) {
-      runner.run({language: 'bf', code: "++++++++++ Initialize cell #0 to 10\
-[\
-  \"while\" loop begins\
-  >+++ Go to cell #1 and add 3\
-  >+++++++ Go to cell #2 and add 7\
-  >+++++++++ Go to cell #3 and add 9\
-  >++++++++++ Go to cell #4 and add 10\
-  >+++++++++++ Go to cell #5 and add 11\
-  <<<<<- Return to cell #0 and decrement its value\
-  \"while\" loop ends\
-]\
-[\
-  Now cell #0 has value 0,\
-  cell #1 has value 70,\
-  cell #2 has value 100,\
-  cell #3 has value 110,\
-  and cell #4 has value 30:\
-  0 | 70 | 100 | 110 | 30 | 0 | ...\
-  Note that this is what is known as a \"comment loop\".\
-  In a comment loop, all special characters in Brainfuck are ignored\
-  PROVIDED THAT: the value of the current cell is 0\
-  AND: all opening and closing square brackets \"[]\" are balanced\
-]\
->>++. Print \"H\"\
->>+. Print \"e\"\
->--. Print \"l\"\
-. Print \"l\"\
-+++. Print \"o\"\
-<<<<++. Print \" \" (spacebar character)\
->>---. Print \"W\"\
->>. Print \"o\"\
-+++. Print \"r\"\
-------. Print \"l\"\
-<-. Print \"d\"\
-<<<+. Print \"!\""}, function(buffer) {
+      runner.run({language: 'bf', code: `++++++++++ Initialize cell #0 to 10
+[
+  "while" loop begins
+  >+++ Go to cell #1 and add 3
+  >+++++++ Go to cell #2 and add 7
+  >+++++++++ Go to cell #3 and add 9
+  >++++++++++ Go to cell #4 and add 10
+  >+++++++++++ Go to cell #5 and add 11
+  <<<<<- Return to cell #0 and decrement its value
+  "while" loop ends
+]
+[
+  Now cell #0 has value 0,
+  cell #1 has value 70,
+  cell #2 has value 100,
+  cell #3 has value 110,
+  and cell #4 has value 30:
+  0 | 70 | 100 | 110 | 30 | 0 | ...
+  Note that this is what is known as a "comment loop".
+  In a comment loop, all special characters in Brainfuck are ignored
+  PROVIDED THAT: the value of the current cell is 0
+  AND: all opening and closing square brackets "[]" are balanced
+]
+>>++. Print "H"
+>>+. Print "e"
+>--. Print "l"
+. Print "l"
++++. Print "o"
+<<<<++. Print " " (spacebar character)
+>>---. Print "W"
+>>. Print "o"
++++. Print "r"
+------. Print "l"
+<-. Print "d"
+<<<+. Print "!"`}, function(buffer) {
         expect(buffer.stdout).to.equal("Hello World!");
         done();
       });
@@ -58,6 +58,174 @@ describe("BF Runner", function() {
     it("should handle a relatively complex program without any issues", function(done) {
       runner.run({language: 'bf', code: '+++++++++++>+>>>>++++++++++++++++++++++++++++++++++++++++++++>++++++++++++++++++++++++++++++++<<<<<<[>[>>>>>>+>+<<<<<<<-]>>>>>>>[<<<<<<<+>>>>>>>-]<[>++++++++++[-<-[>>+>+<<<-]>>>[<<<+>>>-]+<[>[-]<[-]]>[<<[>>>+<<<-]>>[-]]<<]>>>[>>+>+<<<-]>>>[<<<+>>>-]+<[>[-]<[-]]>[<<+>>[-]]<<<<<<<]>>>>>[++++++++++++++++++++++++++++++++++++++++++++++++.[-]]++++++++++<[->-<]>++++++++++++++++++++++++++++++++++++++++++++++++.[-]<<<<<<<<<<<<[>>>+>+<<<<-]>>>>[<<<<+>>>>-]<-[>>.>.<<<[-]]<<[>>+>+<<<-]>>>[<<<+>>>-]<<[<+>-]>[<+>-]<<<-]'}, function(buffer) {
         expect(buffer.stdout).to.equal("1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89");
+        done();
+      });
+    });
+  });
+  describe('Test Integration', function() {
+    it('should handle "Hello World" program with no input provided', function(done) {
+      runner.run({
+        language: 'bf',
+        code: '++++++++++[>+++>+++++++>+++++++++>++++++++++>+++++++++++<<<<<-]>>++.>>+.>--..+++.<<<<++.>>---.>>.+++.------.<-.<<<+.',
+        fixture: 'Test.assertEquals(runBF(), "Hello World!");',
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<PASSED::>');
+        expect(buffer.stdout).to.not.contain('<FAILED::>');
+        expect(buffer.stdout).to.not.contain('<ERROR::>');
+        expect(buffer.stdout).to.contain('Hello World!');
+        done();
+      });
+    });
+    it('should handle basic input and pass it to the BF program when provided', function(done) {
+      runner.run({
+        language: 'bf',
+        code: ',>,<[->[->>+<<]>>[-<+<+>>]<<<]>>.',
+        fixture: `Test.assertEquals(runBF(String.fromCharCode(9, 8)), "H");
+Test.assertEquals(runBF(String.fromCharCode(3, 5)), String.fromCharCode(15));
+Test.assertEquals(runBF(String.fromCharCode(15, 12)), String.fromCharCode(180));
+Test.assertEquals(runBF(String.fromCharCode(1, 1)), String.fromCharCode(1));`,
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<PASSED::>');
+        expect(buffer.stdout).to.not.contain('<FAILED::>');
+        expect(buffer.stdout).to.not.contain('<ERROR::>');
+        done();
+      });
+    });
+    it('should have 8-bit cells that wrap as per the standard implementation', function(done) {
+      runner.run({
+        language: 'bf',
+        code: ',>,<[->[->>+<<]>>[-<+<+>>]<<<]>>.',
+        fixture: `Test.assertEquals(runBF(String.fromCharCode(32, 10)), String.fromCharCode(64));
+Test.assertEquals(runBF(String.fromCharCode(48, 49)), String.fromCharCode(48));
+Test.assertEquals(runBF(String.fromCharCode(127, 45)), String.fromCharCode(83));`,
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<PASSED::>');
+        expect(buffer.stdout).to.not.contain('<FAILED::>');
+        expect(buffer.stdout).to.not.contain('<ERROR::>');
+        done();
+      });
+    });
+    it('should set the cell under the pointer to -1 when EOF is reached which is 1 of the 3 possible standard implementations as described in http://www.hevanet.com/cristofd/brainfuck/epistle.html', function(done) {
+      runner.run({
+        language: 'bf',
+        code: ',+[-.,+]',
+        fixture: `Test.assertEquals(runBF("Codewars"), "Codewars");
+Test.assertEquals(runBF("@jhoffner"), "@jhoffner");
+Test.assertEquals(runBF("@kazk"), "@kazk");
+Test.assertEquals(runBF("@donaldsebleung"), "@donaldsebleung");
+Test.assertEquals(runBF("Brainf**k"), "Brainf**k");
+Test.assertEquals(runBF("BF"), "BF");`,
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<PASSED::>');
+        expect(buffer.stdout).to.not.contain('<FAILED::>');
+        expect(buffer.stdout).to.not.contain('<ERROR::>');
+        done();
+      });
+    });
+    it('should provide a useful error message for invalid BF code', function(done) {
+      runner.run({
+        language: 'bf',
+        code: '++++++++++[>+++>+++++++>+++++++++>++++[++++++>+++++++++++<<<<<-]>>++.>>+.>--..+++.<<<<++.>>---.>>.+++.------.<-.<<<+.',
+        fixture: 'Test.assertEquals(runBF(), "Hello World!");',
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stderr).to.contain('Error');
+        done();
+      });
+    });
+    it('should provide a useful error message for invalid BF code (2)', function(done) {
+      runner.run({
+        language: 'bf',
+        code: '++++++++++[>+++>+++++++>+++++++++>++++++]++++>++++++]+++++<<<<<-]>>++.>>+.>--..+++.<<<<++.>>---.>>.+++.------.<-.<<<+.',
+        fixture: 'Test.assertEquals(runBF(), "Hello World!");',
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stderr).to.contain('Error');
+        done();
+      });
+    });
+    it('should provide a useful error meesage for invalid BF code (3)', function(done) {
+      runner.run({
+        language: 'bf',
+        code: ',>[[,<[->[->>+<<]>>[-<+<+[>>]<<<]>>[.[[',
+        fixture: `Test.assertEquals(runBF(String.fromCharCode(9, 8)), "H");
+Test.assertEquals(runBF(String.fromCharCode(3, 5)), String.fromCharCode(15));
+Test.assertEquals(runBF(String.fromCharCode(15, 12)), String.fromCharCode(180));`,
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stderr).to.contain('Error');
+        done();
+      });
+    });
+    it('should provide a useful error meesage for invalid BF code (4)', function(done) {
+      runner.run({
+        language: 'bf',
+        code: ',>,<[->[-]>>+<<]]>]>[-<]]]]]+<+>]>]]<<<]]>>].]',
+        fixture: `Test.assertEquals(runBF(String.fromCharCode(9, 8)), "H");
+Test.assertEquals(runBF(String.fromCharCode(3, 5)), String.fromCharCode(15));
+Test.assertEquals(runBF(String.fromCharCode(15, 12)), String.fromCharCode(180));`,
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stderr).to.contain('Error');
+        done();
+      });
+    });
+    it('should handle a basic failed test properly', function(done) {
+      runner.run({
+        language: 'bf',
+        code: '++++++++++[>++++++++++>+++++++++++>+++>++++++++++++<<<<-]>++++.---.>--..+++.>++.>-.<<.+++.------.<-.',
+        fixture: `Test.assertEquals(runBF(), "Hello World!");`,
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stdout).to.not.contain('<PASSED::>');
+        expect(buffer.stdout).to.contain('<FAILED::>');
+        expect(buffer.stdout).to.not.contain('<ERROR::>');
+        done();
+      });
+    });
+    it('should handle a mixture of passed and failed tests', function(done) {
+      runner.run({
+        language: 'bf',
+        code: '+++++++++++++++.',
+        fixture: `Test.assertEquals(runBF(String.fromCharCode(3, 5)), String.fromCharCode(15));
+Test.assertEquals(runBF(String.fromCharCode(9, 8)), "H");
+Test.assertEquals(runBF(String.fromCharCode(5, 3)), String.fromCharCode(15));
+Test.assertEquals(runBF(String.fromCharCode(32, 10)), String.fromCharCode(64));`,
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<PASSED::>');
+        expect(buffer.stdout).to.contain('<FAILED::>');
+        expect(buffer.stdout).to.not.contain('<ERROR::>');
+        done();
+      });
+    });
+    it('should handle errors properly when spec methods are being used (JavaScript CW-2 Framework Specific Test)', function(done) {
+      runner.run({
+        language: 'bf',
+        code: '++++++++++[>+++>+++++++>+++++++++>++++++]++++>++++++]+++++<<<<<-]>>++.>>+.>--..+++.<<<<++.>>---.>>.+++.------.<-.<<<+.',
+        fixture: `Test.describe("Your BF Hello World Program", function() {
+  var program = require('fs').readFileSync('/home/codewarrior/solution.txt', 'utf8');
+  Test.it('should return the string "Hello World!"', function() {
+    Test.assertEquals(runBF(), "Hello World!");
+  });
+  Test.it("should be shorter than 110 characters", function() {
+    Test.expect(program.length < 110, "Your BF program must be shorter than 110 characters");
+  });
+  Test.it("should not contain any comments (i.e. non-command characters)", function() {
+    Test.expect(!/[^+\\-.,\\[\\]<>]/.test(program), "Your program should not contain comments");
+  });
+});`,
+        testFramework: 'cw-2'
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<DESCRIBE::>');
+        expect(buffer.stdout).to.contain('<IT::>');
+        expect(buffer.stdout).to.contain('<PASSED::>');
+        expect(buffer.stdout).to.contain('<FAILED::>');
+        expect(buffer.stdout).to.contain('<ERROR::>');
         done();
       });
     });

--- a/test/runners/bf_spec.js
+++ b/test/runners/bf_spec.js
@@ -1,0 +1,65 @@
+var expect = require('chai').expect;
+var runner = require('../runner');
+
+describe("BF Runner", function() {
+  describe("Basic Run", function() {
+    it('should handle basic code evaluation', function(done) {
+      runner.run({language: 'bf', code: '++++++++++[>+++>+++++++>+++++++++>++++++++++>+++++++++++<<<<<-]>>++.>>+.>--..+++.<<<<++.>>---.>>.+++.------.<-.<<<+.'}, function(buffer) {
+        expect(buffer.stdout).to.equal("Hello World!");
+        done();
+      });
+    });
+    it('should ignore anything not in "+-.,<>[]" as comments', function(done) {
+      runner.run({language: 'bf', code: "++++++++++ Initialize cell #0 to 10\
+[\
+  \"while\" loop begins\
+  >+++ Go to cell #1 and add 3\
+  >+++++++ Go to cell #2 and add 7\
+  >+++++++++ Go to cell #3 and add 9\
+  >++++++++++ Go to cell #4 and add 10\
+  >+++++++++++ Go to cell #5 and add 11\
+  <<<<<- Return to cell #0 and decrement its value\
+  \"while\" loop ends\
+]\
+[\
+  Now cell #0 has value 0,\
+  cell #1 has value 70,\
+  cell #2 has value 100,\
+  cell #3 has value 110,\
+  and cell #4 has value 30:\
+  0 | 70 | 100 | 110 | 30 | 0 | ...\
+  Note that this is what is known as a \"comment loop\".\
+  In a comment loop, all special characters in Brainfuck are ignored\
+  PROVIDED THAT: the value of the current cell is 0\
+  AND: all opening and closing square brackets \"[]\" are balanced\
+]\
+>>++. Print \"H\"\
+>>+. Print \"e\"\
+>--. Print \"l\"\
+. Print \"l\"\
++++. Print \"o\"\
+<<<<++. Print \" \" (spacebar character)\
+>>---. Print \"W\"\
+>>. Print \"o\"\
++++. Print \"r\"\
+------. Print \"l\"\
+<-. Print \"d\"\
+<<<+. Print \"!\""}, function(buffer) {
+        expect(buffer.stdout).to.equal("Hello World!");
+        done();
+      });
+    });
+    it("should handle nested loops properly", function(done) {
+      runner.run({language: 'bf', code: '++++++++>+++++++++<[->[->>+<<]>>[-<+<+>>]<<<]>>.'}, function(buffer) {
+        expect(buffer.stdout).to.equal("H");
+        done();
+      });
+    });
+    it("should handle a relatively complex program without any issues", function(done) {
+      runner.run({language: 'bf', code: '+++++++++++>+>>>>++++++++++++++++++++++++++++++++++++++++++++>++++++++++++++++++++++++++++++++<<<<<<[>[>>>>>>+>+<<<<<<<-]>>>>>>>[<<<<<<<+>>>>>>>-]<[>++++++++++[-<-[>>+>+<<<-]>>>[<<<+>>>-]+<[>[-]<[-]]>[<<[>>>+<<<-]>>[-]]<<]>>>[>>+>+<<<-]>>>[<<<+>>>-]+<[>[-]<[-]]>[<<+>>[-]]<<<<<<<]>>>>>[++++++++++++++++++++++++++++++++++++++++++++++++.[-]]++++++++++<[->-<]>++++++++++++++++++++++++++++++++++++++++++++++++.[-]<<<<<<<<<<<<[>>>+>+<<<<-]>>>>[<<<<+>>>>-]<-[>>.>.<<<[-]]<<[>>+>+<<<-]>>>[<<<+>>>-]<<[<+>-]>[<+>-]<<<-]'}, function(buffer) {
+        expect(buffer.stdout).to.equal("1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89");
+        done();
+      });
+    });
+  });
+});

--- a/test/runners/bf_spec.js
+++ b/test/runners/bf_spec.js
@@ -3,6 +3,7 @@ var runner = require('../runner');
 
 describe("BF Runner", function() {
   describe("Basic Run", function() {
+    runner.assertCodeExamples('bf');
     it('should handle basic code evaluation', function(done) {
       runner.run({language: 'bf', code: '++++++++++[>+++>+++++++>+++++++++>++++++++++>+++++++++++<<<<<-]>>++.>>+.>--..+++.<<<<++.>>---.>>.+++.------.<-.<<<+.'}, function(buffer) {
         expect(buffer.stdout).to.equal("Hello World!");


### PR DESCRIPTION
This is just #405 cleaned up.

![image](https://user-images.githubusercontent.com/639336/27005770-43bcade6-4dda-11e7-916b-b2ce2be7f291.png)

---

kazk commented on [May 6](https://github.com/Codewars/codewars-runner-cli/pull/405#issuecomment-299654449)

> @DonaldKellett 
> 
> Great job with the documentation :+1:
> 
> For the tests "should provide a useful error message for invalid BF code", messages are from `bf` and just written to `stderr`? It's hard to see from the Travis output but the test case is `expect(buffer.stderr).to.contain('Error')`.
> 
> I was thinking that in case of invalid code, `bf` will have non-zero exit code causing `execSync` to throw. This seems to happen in "should handle errors properly when spec methods are being used" test.
> 
> @jhoffner, this looks like a test framework bug to me.
> If the test case is inside `describe/it`, `Test.handleError` is used. If not, it's handled by `uncaughtException` on `process` which just ignores if the test is synchronous.
> 
> ```javascript
> process.on('uncaughtException', function(err) {
>   if (async) {
>     Test.handleError(err);
>     if (asyncDone) asyncDone();
>   }
> });
> ```


jhoffner commented on [May 6](https://github.com/Codewars/codewars-runner-cli/pull/405#issuecomment-299658659)

> @DonaldKellett first glance at this it looks really good. Great job! I need to run out for a bit but when I get back I'll dig in deeper. Thanks @kazk for all of the support in this.
> 
> One thing to note, I wonder if this should just be installed on the node image. @kazk otherwise once we start splitting out the runners based off of your new modular design, we will need to share cw-2.js somewhere shared.


DonaldKellett commented on [May 6](https://github.com/Codewars/codewars-runner-cli/pull/405#issuecomment-299678547)

> Thanks for the compliments 😄
>
>> For the tests "should provide a useful error message for invalid BF code", messages are from `bf` and just written to `stderr`? It's hard to see from the Travis output but the test case is `expect(buffer.stderr).to.contain('Error')`.
>
> @kazk I thought that would have been suitable because the error messages provided by bf are pretty comprehensive IMO, but should I do something like a `try/catch` block instead and throw my own error? Or should `runBF` swallow the error and just console.log a message containing `<ERROR::>` instead?
>
>> One thing to note, I wonder if this should just be installed on the node image.
>
> @jhoffner Should I proceed with this now or should I wait until a decision is reached?


kazk commented on [May 6](https://github.com/Codewars/codewars-runner-cli/pull/405#issuecomment-299681924)

> @DonaldKellett
>
>> should I do something like a `try/catch` block instead and throw my own error? Or should `runBF` swallow the error and just `console.log` a message containing `<ERROR::>` instead?
>
> No, I think it's test framework's bug because the thrown error is ignored. You don't need to do anything until it's confirmed and fixed. Let's wait for @jhoffner's review.
> For using node-runner or not, I'd say we keep this as is for now. There're still some things that I'd like to consider and discuss before deciding.