### PR TITLE
Lock ESLint version to 3.19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - "6"
 
 install:
-  - npm install -g eslint
+  - npm install -g eslint@3.19.0
 
 services:
   - docker


### PR DESCRIPTION
ESLint 4.0.0 was released on 2017-06-11 and introduced breaking changes.
Use ESLint 3.19.0 for now.

- http://eslint.org/blog/2017/06/eslint-v4.0.0-released