### PR TITLE
Support for julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - TEST_IMG=ruby
     - TEST_IMG=alt
     - TEST_IMG=rust
-#    - TEST_IMG=julia
+    - TEST_IMG=julia
     - TEST_IMG=systems
     - TEST_IMG=dart
     - TEST_IMG=crystal

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HOSTNAME=codewars
 
 # Building erlang images have been suspended (frozen) until they are able to be repaired
-CONTAINERS=node dotnet jvm java python ruby alt rust systems dart crystal ocaml swift haskell objc go lua esolangs chapel
+CONTAINERS=node dotnet jvm java python ruby alt rust julia systems dart crystal ocaml swift haskell objc go lua esolangs chapel
 
 ALL_CONTAINERS=${CONTAINERS} base
 

--- a/docker/julia.docker
+++ b/docker/julia.docker
@@ -11,12 +11,12 @@ RUN apt-get update \
 ENV USER codewarrior
 ENV HOME /home/codewarrior
 ENV JULIA_PATH /usr/local/julia
-ENV JULIA_VERSION 0.4.6
+ENV JULIA_VERSION 0.6.0
 
 RUN mkdir $JULIA_PATH \
   && apt-get update && apt-get install -y curl \
-  && curl -sSL "https://julialang.s3.amazonaws.com/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" -o julia.tar.gz \
-  && curl -sSL "https://julialang.s3.amazonaws.com/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz.asc" -o julia.tar.gz.asc \
+  && curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" -o julia.tar.gz \
+  && curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz.asc" -o julia.tar.gz.asc \
   && export GNUPGHOME="$(mktemp -d)" \
 # http://julialang.org/juliareleases.asc
 # Julia (Binary signing key) <buildbot@julialang.org>

--- a/documentation/environments/julia.md
+++ b/documentation/environments/julia.md
@@ -1,3 +1,3 @@
 ## Language Versions
 
-Julia 0.4.6 are supported.
+Julia 0.6.0 are supported.

--- a/lib/runners/julia.js
+++ b/lib/runners/julia.js
@@ -30,7 +30,10 @@ module.exports.run = function run(opts, cb) {
 
       runCode({
         name: 'julia',
-        args: ['-ie', runCmd]
+        args: ['-q', solutionFile],
+        options: {
+          cwd: juliaCodeDir,
+        }
       });
     }
   });

--- a/lib/runners/julia.js
+++ b/lib/runners/julia.js
@@ -12,7 +12,7 @@ module.exports.run = function run(opts, cb) {
       if (opts.setup) codeWriteSync('julia', opts.setup, juliaCodeDir);
       runCode({
         name: 'julia',
-        args: ['-P', ['push!(LOAD_PATH, "', juliaCodeDir, '", "frameworks/julia")'].join(""),
+        args: ['', ['push!(LOAD_PATH, "', juliaCodeDir, '", "frameworks/julia")'].join(""),
           '-e', opts.solution]
       });
     },

--- a/lib/runners/julia.js
+++ b/lib/runners/julia.js
@@ -9,11 +9,16 @@ module.exports.run = function run(opts, cb) {
   var juliaCodeDir = temp.mkdirSync('julia');
   shovel.start(opts, cb, {
     solutionOnly: function(runCode) {
+      codeWriteSync('julia', opts.code, juliaCodeDir, 'solution1.jl', true);
       if (opts.setup) codeWriteSync('julia', opts.setup, juliaCodeDir);
+
+      let runCmd1 = `
+              include("${juliaCodeDir}/solution1.jl")
+            `;
+
       runCode({
         name: 'julia',
-        args: [' ', ['push!(LOAD_PATH, "', juliaCodeDir, '", "frameworks/julia")'].join(""),
-          '-e', opts.solution]
+        args: ['-ie', runCmd1]
       });
     },
     testIntegration: function(runCode) {
@@ -30,10 +35,7 @@ module.exports.run = function run(opts, cb) {
 
       runCode({
         name: 'julia',
-        args: ['-q', solutionFile],
-        options: {
-          cwd: juliaCodeDir,
-        }
+        args: ['-ie', runCmd]
       });
     }
   });

--- a/lib/runners/julia.js
+++ b/lib/runners/julia.js
@@ -12,7 +12,7 @@ module.exports.run = function run(opts, cb) {
       if (opts.setup) codeWriteSync('julia', opts.setup, juliaCodeDir);
       runCode({
         name: 'julia',
-        args: ['-P', ['push!(LOAD_PATH, "', juliaCodeDir, '", "frameworks/julia")'].join(""),
+        args: [' ', ['push!(LOAD_PATH, "', juliaCodeDir, '", "frameworks/julia")'].join(""),
           '-e', opts.solution]
       });
     },

--- a/lib/runners/julia.js
+++ b/lib/runners/julia.js
@@ -12,7 +12,7 @@ module.exports.run = function run(opts, cb) {
       if (opts.setup) codeWriteSync('julia', opts.setup, juliaCodeDir);
       runCode({
         name: 'julia',
-        args: ['', ['push!(LOAD_PATH, "', juliaCodeDir, '", "frameworks/julia")'].join(""),
+        args: ['-P', ['push!(LOAD_PATH, "', juliaCodeDir, '", "frameworks/julia")'].join(""),
           '-e', opts.solution]
       });
     },

--- a/test/runners/julia_spec.js
+++ b/test/runners/julia_spec.js
@@ -4,7 +4,7 @@ var runner = require('../runner');
 describe('julia runner', function() {
   // These specs are compatible with both Julia 0.4.6
   describe('.run', function() {
-    /*it('should handle basic code evaluation', function(done) {
+    it('should handle basic code evaluation', function(done) {
       runner.run({
         language: 'julia',
         code: 'print("42")'
@@ -12,7 +12,7 @@ describe('julia runner', function() {
         expect(buffer.stdout).to.equal('42');
         done();
       });
-    });*/
+    });
 
     it('should handle a basic assertion', function(done) {
       runner.run({

--- a/test/runners/julia_spec.js
+++ b/test/runners/julia_spec.js
@@ -4,7 +4,7 @@ var runner = require('../runner');
 describe('julia runner', function() {
   // These specs are compatible with both Julia 0.4.6
   describe('.run', function() {
-    it('should handle basic code evaluation', function(done) {
+    /*it('should handle basic code evaluation', function(done) {
       runner.run({
         language: 'julia',
         code: 'print("42")'
@@ -12,7 +12,7 @@ describe('julia runner', function() {
         expect(buffer.stdout).to.equal('42');
         done();
       });
-    });
+    });*/
 
     it('should handle a basic assertion', function(done) {
       runner.run({
@@ -23,7 +23,7 @@ describe('julia runner', function() {
         `,
         testFramework: 'Test'
       }, function(buffer) {
-        expect(buffer.stdout).to.equal('("<PASSED::>Test Passed","<:LF:>\\n")');
+        expect(buffer.stdout).to.equal('("<PASSED::>Test Passed", "<:LF:>\\n")');
         done();
       });
     });
@@ -35,7 +35,7 @@ describe('julia runner', function() {
         fixture: 'facts(()->(@fact  a => 1) ,"test")',
         testFramework: 'Test'
       }, function(buffer) {
-        expect(buffer.stdout).to.contain('<DESCRIBE::>test<:LF:>\n("<PASSED::>Test Passed","<:LF:>\\n")');
+        expect(buffer.stdout).to.contain('<DESCRIBE::>test<:LF:>\n("<PASSED::>Test Passed", "<:LF:>\\n")');
         done();
       });
     });


### PR DESCRIPTION
- updated julia.docker (v.0.6.0)
- updated  julia_spec.js
- updated julia.yml
- updated Test.jl 
#### issue

```julia
it('should handle basic code evaluation', function(done) {
      runner.run({
        language: 'julia',
        code: 'print("42")'
      }, function(buffer) {
        expect(buffer.stdout).to.equal('42');
        done();
      });
    });
```
generates the following error when run the file julia_spec.js:

```julia
  1 failing

  1) julia runner .run should handle basic code evaluation:

      Uncaught AssertionError: expected '' to equal '42'
      + expected - actual

      +42

      at test/runners/julia_spec.js:12:34
      at lib/shovel.js:28:5
      at complete (lib/shovel.js:281:5)
      at ChildProcess.<anonymous> (lib/shovel.js:252:5)
      at maybeClose (internal/child_process.js:877:16)
      at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
```
