### PR TITLE
Fixes Crystal by installing a specific version

### DIFF
--- a/docker/chapel.docker
+++ b/docker/chapel.docker
@@ -33,5 +33,5 @@ ADD . /runner
 WORKDIR /runner
 USER codewarrior
 
-RUN mocha -t 5000 test/runners/chapel_spec.js
+RUN mocha -t 10000 test/runners/chapel_spec.js
 ENTRYPOINT ["timeout", "15", "node"]

--- a/docker/crystal.docker
+++ b/docker/crystal.docker
@@ -2,8 +2,14 @@ FROM codewars/base-runner
 
 RUN apt-get update -qq
 RUN apt-get install apt-transport-https
-RUN curl https://dist.crystal-lang.org/apt/setup.sh | sudo bash
-RUN apt-get install -y crystal
+RUN set -ex \
+  && cd /tmp \
+  && wget -q -O crystal.tar.gz https://github.com/crystal-lang/crystal/releases/download/0.21.1/crystal-0.21.1-1-linux-x86_64.tar.gz \
+  && mkdir -p /opt/crystal \
+  && tar zxf crystal.tar.gz -C /opt/crystal --strip-components=1 \
+  && rm crystal.tar.gz \
+  && ln -s /opt/crystal/embedded/bin/shards /usr/local/bin/shards \
+  && ln -s /opt/crystal/bin/crystal /usr/local/bin/crystal
 
 # Setup env
 ENV USER codewarrior


### PR DESCRIPTION
- Thanks to kazk for getting the majority of the work done on this.
- I had to add `shards` to the path binaries to get it to build.
- The `crystal` inside `embedded/bin` is not the same, and could not run the code. Very weird.

I also went ahead and doubled Chapel's timeout within the Docker build, simply to avoid further headaches. This doesn't affect Chapel itself anywhere else, only during the build test. Hopefully 10s is enough.