### PR TITLE
[Haskell] Disable warning on Tab usage

### DIFF
--- a/lib/runners/haskell.js
+++ b/lib/runners/haskell.js
@@ -11,6 +11,7 @@ module.exports.run = function run(opts, cb) {
       runCode({
         name: 'runhaskell',
         args: [
+          '--', '-fno-warn-tabs',
           '-i' + ['frameworks/haskell', haskellCodeDir].join(':'),
           codeWriteSync('haskell', opts.solution, haskellCodeDir, "Main.hs")
         ]
@@ -27,7 +28,11 @@ module.exports.run = function run(opts, cb) {
 
       runCode({
         name: 'runhaskell',
-        args: ['-i' + ['frameworks/haskell', haskellCodeDir].join(':'), fixtureFileName],
+        args: [
+          '--', '-fno-warn-tabs',
+          '-i' + ['frameworks/haskell', haskellCodeDir].join(':'),
+          fixtureFileName,
+        ],
         options: {env: process.env}
       });
     }

--- a/test/runners/haskell_spec.js
+++ b/test/runners/haskell_spec.js
@@ -536,6 +536,29 @@ describe('haskell runner', function() {
         done();
       });
     });
+
+    it('should not warn when tabs are used (Codewars/codewars.com#700)', function(done) {
+      runner.run({
+        language: 'haskell',
+        code: 'module Foo where',
+        fixture: [
+          'module Basic.Test where',
+          'import Test.Hspec',
+          'main :: IO ()',
+          'main = hspec $ do',
+          '\tdescribe "Prelude.head" $ do',
+          '\t\tit "returns the first element of a list" $ do',
+          '\t\t\thead [23 ..] `shouldBe` (23 :: Int)'
+        ].join('\n')
+      }, function(buffer) {
+        console.log(buffer);
+        expect(buffer.stderr).to.equal('');
+        expect(buffer.stdout).to.contain('<DESCRIBE::>Prelude.head');
+        expect(buffer.stdout).to.contain('<IT::>returns the first element of a list');
+        expect(buffer.stdout).to.contain('<PASSED::>Test Passed');
+        done();
+      });
+    });
   });
   describe('haskell', function() {
     it('can handle SQLite interaction', function(done) {


### PR DESCRIPTION
#271 broke existing kata that contained Tabs (https://github.com/Codewars/codewars.com/issues/700) because "-fwarn-tabs warning flag is turned on by default" since [GHC 7.10.1](https://downloads.haskell.org/~ghc/7.10.1/docs/html/users_guide/release-7-10-1.html#idp5793824).

This disables the warning. Maybe remove this later if existing kata can be migrated.

Closes https://github.com/Codewars/codewars.com/issues/700