### PR TITLE
[TypeScript] Make targets configurable

### DIFF
--- a/lib/runners/typescript.js
+++ b/lib/runners/typescript.js
@@ -11,7 +11,7 @@ module.exports.run = function run(opts, cb) {
       // TODO: Support Setup Code
 
       var solutionFile = util.codeWriteSync('typescript', opts.solution, dir, 'solution.ts', true);
-      exec('tsc ' + solutionFile + ' --module commonjs', function(error, stdout, stderr) {
+      exec(_tsc(opts) + ' ' + solutionFile, function(error, stdout, stderr) {
         if (error) return fail(error, stdout, stderr);
         runCode({name: 'node', args: [solutionFile.replace('.ts', '.js')]});
       });
@@ -52,13 +52,12 @@ module.exports.run = function run(opts, cb) {
     var code = opts.setup ? `${opts.setup}\n${opts.solution}` : opts.solution;
 
     var codeFile = util.codeWriteSync('typescript', code, null, 'solution.ts', true);
-
-    exec('tsc --module commonjs ' + codeFile, function(error, stdout, stderr) {
+    const cmd = _tsc(opts);
+    exec(cmd + ' ' + codeFile, function(error, stdout, stderr) {
       if (error) return fail(error, stdout, stderr);
 
       var specFile = util.codeWriteSync('typescript', opts.fixture, null, 'spec.ts', true);
-
-      exec('tsc --module commonjs ' + specFile, function(error, stdout, stderr) {
+      exec(cmd + ' ' + specFile, function(error, stdout, stderr) {
         if (error) return fail(error, stdout, stderr);
         specFile = specFile.replace('.ts', '.js');
         runCode({name: 'mocha', 'args': ['-t', opts.timeout || 7000, '-u', interfaceType, '-R', 'mocha-reporter', specFile]});
@@ -149,3 +148,12 @@ module.exports.run = function run(opts, cb) {
   }
 
 };
+
+function _tsc(opts) {
+  const m = (opts.languageVersion || '2.4/ES3').match(/ES(?:[356]|201[5-7]|Next)$/);
+  return [
+    'tsc',
+    '--module', 'commonjs',
+    '--target', m === null ? 'ES3' : m[0],
+  ].join(' ');
+}

--- a/test/runners/typescript_spec.js
+++ b/test/runners/typescript_spec.js
@@ -446,4 +446,80 @@ describe('typescript runner', function() {
       });
     });
   });
+
+  describe('targets', function() {
+    it('should support running with ES6 target', function(done) {
+      runner.run({
+        language: 'typescript',
+        languageVersion: '2.4/ES6',
+        solution: [
+          `class Cube {`,
+          `  private _n: number;`,
+          `  constructor(n) {`,
+          `    this._n = n;`,
+          `  }`,
+          `  get volume(): number { return Math.pow(this._n, 3); }`,
+          `}`,
+          ``,
+          `const c = new Cube(2);`,
+          `console.log(c.volume);`,
+        ].join('\n'),
+      }, function(buffer) {
+        expect(buffer.stdout).to.equal('8\n');
+        done();
+      });
+    });
+
+    it('should default to ES3', function(done) {
+      runner.run({
+        language: 'typescript',
+        solution: [
+          `class Cube {`,
+          `  private _n: number;`,
+          `  constructor(n) {`,
+          `    this._n = n;`,
+          `  }`,
+          `  get volume(): number { return Math.pow(this._n, 3); }`,
+          `}`,
+          ``,
+          `const c = new Cube(2);`,
+          `console.log(c.volume);`,
+        ].join('\n'),
+      }, function(buffer) {
+        expect(buffer.stdout).contains('Accessors are only available when targeting ECMAScript 5 and higher.');
+        done();
+      });
+    });
+
+    it('should support testing with ES6 target', function(done) {
+      runner.run({
+        language: 'typescript',
+        languageVersion: '2.4/ES6',
+        testFramework: 'mocha_bdd',
+        solution: [
+          `export class Cube {`,
+          `  private _n: number;`,
+          `  constructor(n) {`,
+          `    this._n = n;`,
+          `  }`,
+          `  get volume(): number { return Math.pow(this._n, 3); }`,
+          `}`,
+        ].join('\n'),
+        fixture: [
+          `/// <reference path="/runner/typings/mocha/index.d.ts" />`,
+          `/// <reference path="/runner/typings/chai/index.d.ts" />`,
+          `import {Cube} from "./solution";`,
+          `import {assert} from "chai";`,
+          `describe("Cube", function() {`,
+          `  it("should have volume getter", function() {`,
+          `    assert.equal(new Cube(2).volume, 8);`,
+          `  });`,
+          `});`,
+        ].join('\n'),
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<PASSED::>Passed');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Make `tsc` `--target` configurable through `opts.languageVersion`, e.g., `2.4/ES6`, for simple execution and testing with mocha.
I decided not to touch Karma's configuration for now since it's set to ES5 explicitly.

Closes #418
Closes #380