### PR TITLE
[WIP][RFC] Add Kotlin support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ env:
     - TEST_IMG=r
     - TEST_IMG=erlang
     - TEST_IMG=elixir
+    - TEST_IMG=kotlin
 
 script:
   - eslint '**/*.js'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 HOSTNAME=codewars
 
-CONTAINERS=node dotnet jvm java python ruby alt rust julia systems dart crystal ocaml swift haskell objc go lua esolangs chapel nim r erlang elixir
+CONTAINERS=node dotnet jvm java python ruby alt rust julia systems dart crystal ocaml swift haskell objc go lua esolangs chapel nim r erlang elixir kotlin
 
 ALL_CONTAINERS=${CONTAINERS} base
 

--- a/docker/jvm.docker
+++ b/docker/jvm.docker
@@ -55,17 +55,15 @@ COPY lib/utils lib/utils
 COPY lib/runners/clojure.js lib/runners/
 COPY lib/runners/groovy.js lib/runners/
 COPY lib/runners/scala.js lib/runners/
-COPY lib/runners/kotlin.js lib/runners/
 COPY examples/clojure.yml examples/
 COPY test/runner.js test/
 COPY test/runners/clojure_spec.js test/runners/
 COPY test/runners/groovy_spec.js test/runners/
-COPY test/runners/kotlin_spec.js test/runners/
 COPY test/runners/scala_spec.js test/runners/
 
 USER codewarrior
 ENV USER=codewarrior HOME=/home/codewarrior
 ENV TIMEOUT 10000
-RUN mocha -t 10000 test/runners/{clojure,groovy,scala,kotlin}_spec.js
+RUN mocha -t 10000 test/runners/{clojure,groovy,scala}_spec.js
 
 ENTRYPOINT ["node"]

--- a/docker/kotlin.docker
+++ b/docker/kotlin.docker
@@ -1,0 +1,58 @@
+FROM codewars/base-runner
+
+# Install Oracle JDK 8
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends software-properties-common \
+ && add-apt-repository ppa:webupd8team/java \
+ && apt-get update \
+# http://askubuntu.com/a/190674
+ && echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections \
+ && echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections \
+ && apt-get install -y --no-install-recommends oracle-java8-installer
+
+# Install Gradle
+RUN apt-get update && apt-get install -y --no-install-recommends zip unzip
+ENV GRADLE_HOME=/usr/local/gradle \
+    GRADLE_VERSION=4.0 \
+    GRADLE_DOWNLOAD_SHA256=56bd2dde29ba2a93903c557da1745cafd72cdd8b6b0b83c05a40ed7896b79dfe
+RUN set -o errexit -o nounset \
+	&& echo "Downloading Gradle" \
+	&& wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+	\
+	&& echo "Checking download hash" \
+	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
+	\
+	&& echo "Installing Gradle" \
+	&& unzip gradle.zip \
+	&& rm gradle.zip \
+	&& mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
+	&& ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+
+RUN ln -s /home/codewarrior /workspace
+ENV NPM_CONFIG_LOGLEVEL warn
+
+WORKDIR /runner
+COPY package.json package.json
+RUN npm install --production
+
+COPY frameworks/kotlin frameworks/kotlin
+RUN chown -R codewarrior:codewarrior frameworks/kotlin
+
+USER codewarrior
+ENV USER=codewarrior HOME=/home/codewarrior
+
+RUN cd /runner/frameworks/kotlin \
+ && gradle --no-daemon test || true
+
+COPY *.js ./
+COPY lib/*.js lib/
+COPY lib/*.sh lib/
+COPY lib/utils lib/utils
+COPY lib/runners/kotlin.js lib/runners/
+COPY examples/kotlin.yml examples/
+COPY test/runner.js test/
+COPY test/runners/kotlin_spec.js test/runners/
+
+RUN mocha test/runners/kotlin_spec.js
+
+ENTRYPOINT ["node"]

--- a/examples/kotlin.yml
+++ b/examples/kotlin.yml
@@ -1,0 +1,69 @@
+junit:
+  algorithms:
+    initial: |-
+      package algos
+
+      fun twoOldestAges(xs: List<Int>): List<Int> {
+        return listOf(0, 0)
+      }
+
+    answer: |-
+      package algos
+
+      fun twoOldestAges(xs: List<Int>): List<Int> {
+        var a = 0
+        var b = 0
+        for (x in xs) {
+          if (x > b) {
+            a = b
+            b = x
+          } else if (x > a) {
+            a = x
+          }
+        }
+        return listOf(a, b)
+      }
+
+    fixture: |-
+      package algos
+
+      import kotlin.test.assertEquals
+      import org.junit.Test
+
+      class TestTwoOldestAges {
+        @Test
+        fun returnsTwoOldest1() {
+          assertEquals(listOf(45, 87), twoOldestAges(listOf(1,5,87,45,8,8)))
+        }
+        @Test
+        fun returnsTwoOldest2() {
+          assertEquals(listOf(18, 83), twoOldestAges(listOf(6,5,83,5,3,18)))
+        }
+      }
+
+  bug fixes:
+    initial: |-
+      package buggy
+
+      fun multiply(a: Int, b: Int): Int {
+        a * b
+      }
+    answer: |-
+      package buggy
+
+      fun multiply(a: Int, b: Int) = a * b
+
+    fixture: |-
+      package buggy
+
+      import kotlin.test.assertEquals
+      import org.junit.Test
+
+      class TestMultiply {
+        @Test
+        fun returnsProduct() {
+          assertEquals(1, multiply(1, 1), "1*1 == 1")
+        }
+      }
+
+

--- a/frameworks/kotlin/build.gradle
+++ b/frameworks/kotlin/build.gradle
@@ -1,0 +1,75 @@
+buildscript {
+  ext.kotlin_version = '1.1.3-2'
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+  }
+}
+
+apply plugin: 'kotlin'
+apply plugin: 'application'
+
+mainClassName = System.getenv('KOTLIN_MAIN_CLASS_NAME')
+defaultTasks 'run'
+
+repositories {
+  jcenter()
+}
+
+dependencies {
+  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  testCompile 'junit:junit:4.12'
+  testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+}
+
+compileKotlin {
+  kotlinOptions {
+  }
+}
+
+test {
+  reports {
+    html.enabled = false
+    junitXml.enabled = false
+  }
+
+  beforeSuite { desc ->
+    if (!desc.name.startsWith("Gradle Test ")) {
+      println("\n<DESCRIBE::>${desc.name}")
+    }
+  }
+  afterSuite { desc, result ->
+    if (!desc.name.startsWith("Gradle Test ")) {
+      println("\n<COMPLETEDIN::>${result.endTime - result.startTime}")
+    }
+  }
+  beforeTest { desc ->
+    println("\n<IT::>${desc.name}")
+  }
+  afterTest { desc, result ->
+    if (result.resultType == TestResult.ResultType.SUCCESS) {
+      println("\n<PASSED::>Test Passed")
+    } else if (result.resultType == TestResult.ResultType.FAILURE) {
+      def ex = result.exception
+      if (ex instanceof AssertionError) {
+        println("\n" + "<FAILED::>Test Failed\n\t${ex.message}".replaceAll("\n", "<:LF:>"))
+      } else {
+        println("\n" + "<ERROR::>Test Errored\n${ex.message}".replaceAll("\n", "<:LF:>"))
+        println("\n" + "<LOG::Stack Trace>${ex.stackTrace.join("\n").replaceAll("\n", "<:LF:>")}")
+      }
+    } else if (result.resultType == TestResult.ResultType.SKIPPED) {
+      println("\n<LOG::>Test Skipped")
+    }
+    println("\n<COMPLETEDIN::>${result.endTime - result.startTime}")
+  }
+
+  onOutput { desc, event ->
+    if (event.destination == TestOutputEvent.Destination.StdOut) {
+      print(event.message)
+    } else if (event.destination == TestOutputEvent.Destination.StdErr) {
+      System.err.print(event.message)
+    }
+  }
+}

--- a/frameworks/kotlin/src/main/kotlin/helloWorld.kt
+++ b/frameworks/kotlin/src/main/kotlin/helloWorld.kt
@@ -1,0 +1,14 @@
+package codewars
+
+// https://github.com/JetBrains/kotlin-examples/blob/master/gradle/hello-world/src/main/kotlin/demo/helloWorld.kt
+fun getGreeting(): String {
+    val words = mutableListOf<String>()
+    words.add("Hello,")
+    words.add("world!")
+
+    return words.joinToString(separator = " ")
+}
+
+fun main(args: Array<String>) {
+    println(getGreeting())
+}

--- a/frameworks/kotlin/src/test/kotlin/tests.kt
+++ b/frameworks/kotlin/src/test/kotlin/tests.kt
@@ -1,0 +1,11 @@
+package codewars
+
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class TestHelloWorld {
+    @Test
+    fun greetingTest() {
+        assertEquals("Hello, world!", getGreeting())
+    }
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,7 +15,8 @@ module.exports = {
     go: 15000,
     haskell: 15000,
     sql: 14000,
-    java: 20000
+    java: 20000,
+    kotlin: 20000,
   },
   moduleRegExs: {
     haskell: /module\s+([A-Z]([a-z|A-Z|0-9]|\.[A-Z])*)\W/,
@@ -23,7 +24,6 @@ module.exports = {
     erlang: /-module\(([a-z|A-Z][a-z|A-Z|0-9|_]*)\)/,
     elixir: /defmodule\s+([a-z|A-Z][.a-z|A-Z|0-9|_]*)\s+do/,
     scala: /(?:object|class)\s+([A-Z][a-z|A-Z|0-9|_]*)/,
-    kotlin: /(?:object|class)\s+([A-Z][a-z|A-Z|0-9|_]*)/,
     swift: /\n*\/\/\s*([a-z|A-Z|0-9|_|-]+)\.swift\s*\n/,
     objc: /\n*\/\/\s*([a-z|A-Z|0-9|_|-]+)\.m\s*\n/,
     objcHeader: /\n*\/\/\s*([a-z|A-Z|0-9|_|-]+)\.h\s*\n/

--- a/lib/runners/kotlin.js
+++ b/lib/runners/kotlin.js
@@ -1,39 +1,65 @@
-var shovel = require('../shovel'),
-    util = require('../util'),
-    path = require('path'),
-    temp = require('temp');
+"use strict";
 
-var KOTLIN_BASE_DIR = '/usr/local/lib/kotlin/kotlinc/bin/';
-var KOTLIN_DEFAULT_SOLUTION = 'Solution';
-var KOTLIN_DEFAULT_SETUP = 'Setup';
+const shovel = require('../shovel');
+const path = require('path');
+const fs = require('fs-extra');
 
 module.exports.run = function run(opts, cb) {
-  temp.track();
-  var dir = temp.mkdirSync('kotlin');
-
   shovel.start(opts, cb, {
-    solutionOnly: function(runCode, fail) {
-      var classDirectory = path.join(dir, 'classes'),
-          solutionFile = util.codeWriteSync('kotlin', opts.solution, dir, KOTLIN_DEFAULT_SOLUTION),
-          solutionClassName = path.basename(solutionFile, '.kt'),
-          args = [KOTLIN_BASE_DIR + 'kotlinc', '-d', classDirectory, solutionFile],
-          runArgs = ['-classpath', classDirectory, solutionClassName + 'Kt'];
-
-      if (opts.setup) {
-        var setupFile = util.codeWriteSync('kotlin', opts.setup, dir, KOTLIN_DEFAULT_SETUP);
-        args.push(setupFile);
-      }
-      util.mkdirParentSync(classDirectory);
-      util.exec(args.join(' '), function(error) {
-        if (error) return fail(error);
-        runCode({
-          'name': KOTLIN_BASE_DIR + 'kotlin',
-          'args': runArgs
-        });
+    solutionOnly(runCode) {
+      fs.outputFileSync(path.join(opts.dir, 'build.gradle'), fs.readFileSync('/runner/frameworks/kotlin/build.gradle'));
+      if (opts.setup)
+        fs.outputFileSync(path.join(opts.dir, 'src', 'main', 'kotlin', 'setup.kt'), opts.setup);
+      fs.outputFileSync(path.join(opts.dir, 'src', 'main', 'kotlin', 'main.kt'), opts.solution);
+      runCode({
+        name: 'gradle',
+        args: [
+          process.env.KOTLIN_GRADLE_DAEMON || '--no-daemon',
+          '--stacktrace',
+          '--no-search-upward',
+          '--project-cache-dir', '/runner/frameworks/kotlin',
+          '--quiet',
+          'run',
+        ],
+        options: {
+          cwd: opts.dir,
+          env: Object.assign({}, process.env, {
+            KOTLIN_MAIN_CLASS_NAME: `${getPrefix(opts.solution)}MainKt`,
+          }),
+        }
       });
     },
-    testIntegration: function(run) {
-      throw new Error('Test framework is not supported');
-    }
+
+    testIntegration(runCode) {
+      fs.outputFileSync(path.join(opts.dir, 'build.gradle'), fs.readFileSync('/runner/frameworks/kotlin/build.gradle'));
+      if (opts.setup)
+        fs.outputFileSync(path.join(opts.dir, 'src', 'main', 'kotlin', 'setup.kt'), opts.setup);
+      fs.outputFileSync(path.join(opts.dir, 'src', 'main', 'kotlin', 'solution.kt'), opts.solution);
+      fs.outputFileSync(path.join(opts.dir, 'src', 'test', 'kotlin', 'fixture.kt'), opts.fixture);
+      runCode({
+        name: 'gradle',
+        args: [
+          process.env.KOTLIN_GRADLE_DAEMON || '--no-daemon',
+          '--no-search-upward',
+          '--project-cache-dir', '/runner/frameworks/kotlin',
+          '--quiet',
+          'test',
+        ],
+        options: {
+          cwd: opts.dir,
+        }
+      });
+    },
+
+    sanitizeStdErr(err) {
+      return err.replace(/\n\d+ tests? completed, \d+ failed\n\nFAILURE: Build failed with an exception\.\n\n\* What went wrong:\nExecution failed for task ':test'\.\n> There were failing tests\n\n\* Try:\nRun with --stacktrace option to get the stack trace\. Run with --info or --debug option to get more log output\.\n\nBUILD FAILED in \d+s\n/, '');
+    },
   });
 };
+
+
+function getPrefix(code) {
+  // TODO improve pattern and fail early if invalid
+  const m = code.match(/^\s*package\s+(\S+)/m);
+  return (m === null) ? '' : m[1] + '.';
+}

--- a/listen.js
+++ b/listen.js
@@ -7,6 +7,11 @@ const net = require('net'),
 if (fs.existsSync('/runner/prewarm.sh')) {
   console.log(execSync('sh /runner/prewarm.sh').toString());
 }
+else if (fs.existsSync('/runner/frameworks/kotlin/build.gradle')) {
+  execSync('gradle --daemon test', {cwd: '/runner/frameworks/kotlin'});
+  process.env.KOTLIN_GRADLE_DAEMON = '--daemon';
+}
+
 
 
 // Creates a new TCP server. The handler argument is automatically set as a listener for the 'connection' event

--- a/test/runners/kotlin_spec.js
+++ b/test/runners/kotlin_spec.js
@@ -1,39 +1,351 @@
-var expect = require('chai').expect;
-var runner = require('../runner');
+"use strict";
 
+const expect = require('chai').expect;
+const runner = require('../runner');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const exec = require('child_process').exec;
 
-describe('kotlin runner', function() {
-  describe('.run', function() {
+describe('kotlin-runner', function() {
+  before(function startDaemon(done) {
+    this.timeout(0);
+    console.log('Starting Gradle daemon');
+    process.env.KOTLIN_GRADLE_DAEMON = '--no-daemon';
+    exec('gradle --daemon test', {
+      cwd: '/runner/frameworks/kotlin',
+    }, (err) => {
+      if (err) return done(err);
+      process.env.KOTLIN_GRADLE_DAEMON = '--daemon';
+      done();
+    });
+  });
+
+  describe('running', function() {
+    afterEach(function cleanup(done) {
+      exec('rm -rf /home/codewarrior/src', function(err) {
+        if (err) return done(err);
+        done();
+      });
+    });
+
     it('should handle basic code evaluation', function(done) {
+      this.timeout(0);
       runner.run({
         language: 'kotlin',
-        code: `
-fun main(args : Array<String>) {
-    println(42)
-}
-`
+        solution: [
+          `fun main(args: Array<String>) {`,
+          `    println(42)`,
+          `}`,
+        ].join('\n'),
       }, function(buffer) {
         expect(buffer.stdout).to.equal('42\n');
         done();
       });
     });
+
     it('should handle setup code', function(done) {
+      this.timeout(0);
       runner.run({
         language: 'kotlin',
-        setup: `
-fun greet(name : String) : String {
-    return "Hello, " + name
-}
-`,
-        code: `
-fun main(args : Array<String>) {
-    println(greet("Joe"))
-}
-`
+        setup: [
+          `fun greet(name: String): String {`,
+          `    return "Hello, " + name`,
+          `}`,
+        ].join('\n'),
+        solution: [
+          `fun main(args: Array<String>) {`,
+          `    println(greet("Joe"))`,
+          `}`,
+        ].join('\n'),
+      }, function(buffer) {
+        expect(buffer.stdout).to.equal('Hello, Joe\n');
+        done();
+      });
+    });
+
+    it('can have package declaration', function(done) {
+      this.timeout(0);
+      runner.run({
+        language: 'kotlin',
+        setup: [
+          `package example`,
+          `fun greet(name: String): String {`,
+          `    return "Hello, " + name`,
+          `}`,
+        ].join('\n'),
+        solution: [
+          `package example`,
+          `fun main(args: Array<String>) {`,
+          `    println(greet("Joe"))`,
+          `}`,
+        ].join('\n'),
       }, function(buffer) {
         expect(buffer.stdout).to.equal('Hello, Joe\n');
         done();
       });
     });
   });
+
+  describe('testing with JUnit', function() {
+    afterEach(function cleanup(done) {
+      exec('rm -rf /home/codewarrior/src', function(err) {
+        if (err) return done(err);
+        done();
+      });
+    });
+
+    it('should handle basic assertion', function(done) {
+      this.timeout(0);
+      runner.run({
+        language: 'kotlin',
+        solution: [
+          `fun add(a: Int, b: Int) = a + b`,
+        ].join('\n'),
+        fixture: [
+          `import kotlin.test.assertEquals`,
+          `import org.junit.Test`,
+          ``,
+          `class TestAdd {`,
+          `  @Test`,
+          `  fun addTest() {`,
+          `    assertEquals(2, add(1, 1))`,
+          `  }`,
+          `}`,
+        ].join('\n'),
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<PASSED::>');
+        done();
+      });
+    });
+
+    it('should handle basic assertion with named package', function(done) {
+      this.timeout(0);
+      runner.run({
+        language: 'kotlin',
+        solution: [
+          `package kata`,
+          ``,
+          `fun add(a: Int, b: Int) = a + b`,
+        ].join('\n'),
+        fixture: [
+          `package kata`,
+          ``,
+          `import kotlin.test.assertEquals`,
+          `import org.junit.Test`,
+          ``,
+          `class TestAdd {`,
+          `  @Test`,
+          `  fun addTest() {`,
+          `    assertEquals(2, add(1, 1))`,
+          `  }`,
+          `}`,
+        ].join('\n'),
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<PASSED::>');
+        done();
+      });
+    });
+
+    it('should handle basic assertion failure', function(done) {
+      this.timeout(0);
+      runner.run({
+        language: 'kotlin',
+        solution: [
+          `package kata`,
+          ``,
+          `fun add(a: Int, b: Int) = a - b`,
+        ].join('\n'),
+        fixture: [
+          `package kata`,
+          ``,
+          `import kotlin.test.assertEquals`,
+          `import org.junit.Test`,
+          ``,
+          `class TestAdd {`,
+          `  @Test`,
+          `  fun addTest() {`,
+          `    assertEquals(2, add(1, 1))`,
+          `  }`,
+          `}`,
+        ].join('\n'),
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<FAILED::>');
+        done();
+      });
+    });
+
+    it('should handle basic assertion failure by error', function(done) {
+      this.timeout(0);
+      runner.run({
+        language: 'kotlin',
+        solution: [
+          `package kata`,
+          ``,
+          `fun add(a: Int, b: Int) = a / b`,
+        ].join('\n'),
+        fixture: [
+          `package kata`,
+          ``,
+          `import kotlin.test.assertEquals`,
+          `import org.junit.Test`,
+          ``,
+          `class TestAdd {`,
+          `  @Test`,
+          `  fun addTest() {`,
+          `    assertEquals(1, add(1, 0))`,
+          `  }`,
+          `}`,
+        ].join('\n'),
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<ERROR::>');
+        done();
+      });
+    });
+
+    it('should handle basic assertion failure with message', function(done) {
+      this.timeout(0);
+      runner.run({
+        language: 'kotlin',
+        solution: [
+          `package kata`,
+          ``,
+          `fun add(a: Int, b: Int) = a - b`,
+        ].join('\n'),
+        fixture: [
+          `package kata`,
+          ``,
+          `import kotlin.test.assertEquals`,
+          `import org.junit.Test`,
+          ``,
+          `class TestAdd {`,
+          `  @Test`,
+          `  fun addTest() {`,
+          `    assertEquals(2, add(1, 1), "add(1, 1) should return 2")`,
+          `  }`,
+          `}`,
+        ].join('\n'),
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('<FAILED::>');
+        expect(buffer.stdout).to.contain('add(1, 1) should return 2');
+        done();
+      });
+    });
+
+    it('can have multiple suites', function(done) {
+      this.timeout(0);
+      runner.run({
+        language: 'kotlin',
+        solution: [
+          `package kata`,
+          `fun add(a: Int, b: Int): Int {`,
+          `  return a + b`,
+          `}`,
+        ].join('\n'),
+        fixture: [
+          `package kata`,
+          `import kotlin.test.assertEquals`,
+          `import org.junit.Test`,
+          `class TestAddPositive {`,
+          `  @Test`,
+          `  fun addTest() {`,
+          `    assertEquals(2, add(1, 1))`,
+          `  }`,
+          `}`,
+          `class TestAddNegative {`,
+          `  @Test`,
+          `  fun addTest() {`,
+          `    assertEquals(-2, add(-1, -1))`,
+          `  }`,
+          `}`,
+        ].join('\n'),
+      }, function(buffer) {
+        const expected = [
+          '<DESCRIBE::>',
+          '  <IT::><PASSED::><COMPLETEDIN::>',
+          '<COMPLETEDIN::>',
+          '<DESCRIBE::>',
+          '  <IT::><PASSED::><COMPLETEDIN::>',
+          '<COMPLETEDIN::>',
+        ].join('').replace(/\s/g, '');
+        expect(buffer.stdout.match(/<(?:DESCRIBE|IT|PASSED|FAILED|COMPLETEDIN)::>/g).join('')).to.equal(expected);
+        done();
+      });
+    });
+
+    it('should allow logging', function(done) {
+      this.timeout(0);
+      runner.run({
+        language: 'kotlin',
+        solution: [
+          `package kata`,
+          ``,
+          `fun add(a: Int, b: Int): Int {`,
+          '  println("a = ${a}, b = ${b}")',
+          `  return a + b`,
+          `}`,
+        ].join('\n'),
+        fixture: [
+          `package kata`,
+          ``,
+          `import kotlin.test.assertEquals`,
+          `import org.junit.Test`,
+          ``,
+          `class TestAdd {`,
+          `  @Test`,
+          `  fun addTest() {`,
+          `    assertEquals(2, add(1, 1))`,
+          `  }`,
+          `}`,
+        ].join('\n'),
+      }, function(buffer) {
+        expect(buffer.stdout).to.contain('a = 1, b = 1');
+        expect(buffer.stdout).to.contain('<PASSED::>');
+        done();
+      });
+    });
+  });
+
+  describe('Example Challenges', function() {
+    afterEach(function cleanup(done) {
+      exec('rm -rf /home/codewarrior/src', function(err) {
+        if (err) return done(err);
+        done();
+      });
+    });
+
+    forEachExamples(function(framework, name, example) {
+      describe(`example ${name}`, function() {
+        it('should define an initial code block', function() {
+          expect(example.initial).to.be.a('string');
+        });
+
+        it('should have a passing solution', function(done) {
+          this.timeout(0);
+          runner.run({
+            language: 'kotlin',
+            setup: example.setup,
+            solution: example.answer,
+            fixture: example.fixture,
+            testFramework: framework,
+          }, function(buffer) {
+            expect(buffer.stdout).to.contain('<PASSED::>');
+            expect(buffer.stdout).to.not.contain('<FAILED::>');
+            expect(buffer.stdout).to.not.contain('<ERROR::>');
+            done();
+          });
+        });
+      });
+    });
+  });
 });
+
+
+function forEachExamples(cb) {
+  const examples = yaml.safeLoad(fs.readFileSync(path.join(__dirname, `../../examples/kotlin.yml`), 'utf8'));
+  for (const framework of Object.keys(examples)) {
+    for (const example of Object.keys(examples[framework])) {
+      cb(framework, example, examples[framework][example]);
+    }
+  }
+}


### PR DESCRIPTION
Kotlin 1.1.3-2, tests with JUnit 4.12.

Tried to make a clean and simple starting point. Most of the work is defined in `build.gradle` and this simply does `gradle run/test`. Maybe java-runner can do something similar to simplify things?

- code can be in default unnamed package or arbitrarily named package
- tests can have multiple suites
- should be easy to extend this to support `opts.files`, just output files to correct locations
- `KOTLIN_GRADLE_DAEMON` environment variable decides when to use Gradle daemon

---

Closes #165