### PR TITLE
Add compile tools from jvm as dependency

### DIFF
--- a/frameworks/java/build.gradle
+++ b/frameworks/java/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   compile 'org.springframework.boot:spring-boot-starter-data-jpa:1.5.4.RELEASE'
   compile 'org.springframework.boot:spring-boot-starter-data-rest:1.5.4.RELEASE'
   compile 'org.springframework.boot:spring-boot-starter-validation:1.5.4.RELEASE'
+  compile files(org.gradle.internal.jvm.Jvm.current().toolsJar)
 }
 
 compileJava.options.encoding = 'UTF-8'


### PR DESCRIPTION
For very high level katas it can enable to access all of the set of compiling tools programatically.


Some ideas of usages are:

* create Katas to test you junit tests for a preloaded java class
* perhaps a Kata about creating your own progamming language that runs on the Java Virtual Machine
* create tests that actually detects trashy code ( e.g unused imports, unused methods )
* Run [Dynamic code](http://www.javaworld.com/article/2071777/design-patterns/add-dynamic-java-code-to-your-application.html)
* create katas to test Javadoc i.e. the quality of generated documentation
* Creation of custom annotations??? ( an annotation processor class should be addeded to gradle build task but.. you could personalize how the compiler works  )
* create your custom jvm runner kata