### PR TITLE
Lock mongoose version to 4.10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "mathf": "0.0.3",
     "mkdirp": "^0.5.1",
     "mongodb": "^2.1.18",
-    "mongoose": "^4.4.14",
+    "mongoose": "4.10.x",
     "mongoose-mock": "^0.4.0",
     "mysql": "^2.11.1",
     "natural": "^0.4.0",

--- a/test/runners/javascript_spec.js
+++ b/test/runners/javascript_spec.js
@@ -123,6 +123,7 @@ describe('javascript runner', function() {
                     `
         }, function(buffer) {
           expect(buffer.stdout).to.contain('meow');
+          expect(buffer.stderr).to.be.empty;
           done();
         });
       });


### PR DESCRIPTION
`DeprecationWarning` in `mongoose >= 4.11.0` breaks existing content.
Filtering out `DeprecationWarning` in general will be separate issue.