### PR TITLE
[Swift] Fix invalid reference `test.framework`

### DIFF
--- a/lib/runners/swift.js
+++ b/lib/runners/swift.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const shovel = require('../shovel');
 const exec = require('child_process').exec;
 const fs = require('fs');
@@ -33,7 +35,7 @@ module.exports.run = function run(opts, cb) {
 
     testIntegration: function(runCode, fail) {
       if (opts.testFramework != 'xctest')
-        throw new Error(`test framework ${test.framework} is not supported`);
+        throw new Error(`Test framework '${opts.testFramework}' is not supported`);
 
       const args = [
         "swiftc",


### PR DESCRIPTION
Minor bug fix. I wrote `test.framework` instead of `opts.testFramework` for some reason :/
I thought ESLint catches these bugs.