### PR TITLE
Fix to enable running TS/Karma with a version

### DIFF
--- a/documentation/environments/node.md
+++ b/documentation/environments/node.md
@@ -54,7 +54,7 @@ The solution, test fixture and optional setup/preloaded code are all combined in
 
 ## TypeScript
 
-Typescript 2.4 is supported. Only the Mocha test framework is available for testing.
+Typescript 2.4 is supported. The Mocha test framework and Karma+Mocha are available for testing.
  
 The following typings are available:
 

--- a/lib/runners/typescript.js
+++ b/lib/runners/typescript.js
@@ -156,7 +156,11 @@ function prepareKarma(opts, interfaceType, runCode, fail) {
     },
   };
 
-  runKarma(opts, runCode, fail, interfaceType, config);
+  const nodeOpts = Object.assign({}, opts);
+  // run on the default node version
+  delete nodeOpts.languageVersion;
+
+  runKarma(nodeOpts, runCode, fail, interfaceType, config);
 }
 
 function _tsc(opts) {

--- a/test/runners/typescript_spec.js
+++ b/test/runners/typescript_spec.js
@@ -120,6 +120,7 @@ describe('typescript runner', function() {
     it('basic test', function(done) {
       runner.run({
         language: 'typescript',
+        languageVersion: '2.4',
         code: 'export var a = {b: 2};',
         fixture: `\
           /// <reference path="/runner/typings/mocha/index.d.ts" />
@@ -142,6 +143,7 @@ describe('typescript runner', function() {
       it('handle successes', function(done) {
         runner.run({
           language: 'typescript',
+          languageVersion: '2.4',
           code: `\
             import 'core-js';
             import { Component } from "@angular/core";
@@ -222,6 +224,7 @@ describe('typescript runner', function() {
       it('handles failure', function(done) {
         runner.run({
           language: 'typescript',
+          languageVersion: '2.4',
           code: `\
             import 'core-js';
             import { Component } from "@angular/core";
@@ -300,6 +303,7 @@ describe('typescript runner', function() {
     it('basic test', function(done) {
       runner.run({
         language: 'typescript',
+        languageVersion: '2.4',
         code: 'export var a = {b: 2};',
         fixture: `\
           /// <reference path="/runner/typings/mocha/index.d.ts" />
@@ -322,6 +326,7 @@ describe('typescript runner', function() {
       it('handle successes', function(done) {
         runner.run({
           language: 'typescript',
+          languageVersion: '2.4',
           code: `\
             import 'core-js';
             import { Component } from "@angular/core";
@@ -402,6 +407,7 @@ describe('typescript runner', function() {
       it('handles failure', function(done) {
         runner.run({
           language: 'typescript',
+          languageVersion: '2.4',
           code: `\
             import 'core-js';
             import { Component } from "@angular/core";


### PR DESCRIPTION
- Now the `languageVersion` is not passed into the Karma/Node runner code, so we don't get Node version errors.
- Updated Node docs to mention Karma testing on TS