### PR TITLE
Java Output Cleanup

### DIFF
--- a/frameworks/java/src/test/java/CwRunListener.java
+++ b/frameworks/java/src/test/java/CwRunListener.java
@@ -56,7 +56,7 @@ public class CwRunListener extends RunListener
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         ex.printStackTrace(pw);
-        return sw.toString();
+        return sw.toString().replaceAll("\tat (?:org.junit.(?:internal|runners?)|sun.reflect|org.gradle|java|com.sun|Start.start).*\n", "");
     }
     private static String formatMessage(final String s)
     {

--- a/lib/runners/java.js
+++ b/lib/runners/java.js
@@ -99,6 +99,14 @@ module.exports = {
     }
 
     buildOutput = tagHelpers.log('-Build Output', buildOutput);
+
+    // replace Spring specific boot log with a shortened version and collapse it.
+    // do this by finding the first describe with the log message, split the log message on some common text which acts as a good trim point. We also reverse the describe with the log
+    stdout = stdout.replace(
+      /(<DESCRIBE::>.*\n)(\d{2}:\d{2}:\d{2}.\d{2,3} \[Test worker\].*)/,
+      (_, a, b) => `${a}<LOG::-Startup Logs>${b}`
+    );
+
     buffer.stdout = buildOutput + stdout;
   }
 };

--- a/test/runners/java_spec.js
+++ b/test/runners/java_spec.js
@@ -92,6 +92,7 @@ describe('java runner', function() {
           }}`
       }, function(buffer) {
         expect(buffer.stdout).to.contain('<IT::>myTestFunction(TestFixture)\n<FAILED::>Failed Message expected:<5> but was:<3>\n');
+        expect(buffer.stdout).to.not.contain('at java.lang.reflect.Method');
         done();
       });
     });
@@ -339,12 +340,14 @@ describe('java runner', function() {
               private HomeController controller;
           
               @Test
-              public void contexLoads() throws Exception {
+              public void contexLoads() throws Exception {                 
                   assertThat(controller).isNotNull();
               }
           }`
       }, function(buffer) {
+        console.log(buffer.stdout);
         console.log(buffer.stderr);
+        expect(buffer.stdout).to.contain('<LOG::-Startup Logs>');
         expect(buffer.stdout).to.contain('<PASSED::>Test Passed\n');
         done();
       });


### PR DESCRIPTION
- Assertion ExceptionDetails logs are less verbose
- Spring boot logs are now collapsed by default