### PR TITLE
Fix r-base install

### DIFF
--- a/docker/r.docker
+++ b/docker/r.docker
@@ -6,7 +6,7 @@ RUN set -ex \
  && gpg -a --export E084DAB9 | apt-key add - \
  && echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list \
  && apt-get -q update \
- && apt-get -q -y --no-install-recommends install 'r-base=3.4.1-*'
+ && apt-get -q -y --no-install-recommends install 'r-base=3.4.*' 'r-base-dev=3.4.*'
 
 # TODO version lock. need `devtools` package?
 RUN R -q -e 'install.packages("testthat", repo="https://cran.rstudio.com/")' && rm -rf /tmp/*


### PR DESCRIPTION
Fix apt-get install error:

```
The following packages have unmet dependencies:
r-base : Depends: r-recommended (= 3.4.1-2trusty0) but 3.4.2-1trusty1 is to be installed
```

To be honest, I'm not sure why `3.4.1-*` isn't working, but changing that to `3.4.*` seems to fix it. Also adding `r-base-dev` because I saw this in the documentation:

> Users who need to compile R packages from source [e.g. package maintainers, or anyone installing packages with install.packages()] should also install the r-base-dev package: