### PR TITLE
Updated JSDom to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "hyperscript": "^2.0.2",
     "immutable": "^3.8.1",
     "joi": "^9.0.4",
-    "jsdom": "^11.3.0",
+    "jsdom": "^10.1.0",
     "jwt-simple": "^0.2.0",
     "karma": "^1.1.2",
     "karma-chai": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "hyperscript": "^2.0.2",
     "immutable": "^3.8.1",
     "joi": "^9.0.4",
-    "jsdom": "^9.12.0",
+    "jsdom": "^11.3.0",
     "jwt-simple": "^0.2.0",
     "karma": "^1.1.2",
     "karma-chai": "^0.1.0",


### PR DESCRIPTION
Might as well update JSDom to the latest version before we start utilizing it. 

**Note** that if someone somewhere did reference this version in a challenge, the API has breaking changes but can still be accessed. [See changelog](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#1000)