### PR TITLE
[Rust] Avoid crates to be recompiled

### DIFF
--- a/docker/rust.docker
+++ b/docker/rust.docker
@@ -1,20 +1,13 @@
 FROM codewars/base-runner
 
+# based on the Dockerfile for https://hub.docker.com/_/rust/
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain 1.15.1; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME;
+
 RUN ln -s /home/codewarrior /workspace
-
-COPY frameworks/rust/skeleton /workspace/rust
-RUN chown -R codewarrior:codewarrior /workspace/rust
-
-USER codewarrior
-ENV USER=codewarrior HOME=/home/codewarrior
-
-# Install rustup with the Rust v1.15.1 toolchain
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.15.1
-# ~/.cargo/env
-ENV PATH $HOME/.cargo/bin:$PATH
-RUN cd /workspace/rust && cargo build && rm src/lib.rs
-
-USER root
 ENV NPM_CONFIG_LOGLEVEL warn
 
 WORKDIR /runner
@@ -33,9 +26,20 @@ COPY test/runners/rust_spec.js test/runners/
 COPY entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 
+COPY frameworks/rust/skeleton /workspace/rust
+RUN chown -R codewarrior:codewarrior /workspace/rust
+
 USER codewarrior
-ENV USER=codewarrior HOME=/home/codewarrior
-ENV PATH=$HOME/.cargo/bin:$PATH
+ENV USER=codewarrior \
+    HOME=/home/codewarrior \
+# set RUSTFLAGS (for backward compatibility) here
+# compiling with different RUSTFLAGS for submitted solution causes downloaded crates to be recompiled
+    RUSTFLAGS='-Adead_code -Aunused_imports -Aunused_variables -Anon_snake_case'
+# download and compile crates
+RUN set -ex; \
+    cd /workspace/rust; \
+    cargo build; \
+    rm src/lib.rs
 
 RUN mocha -t 10000 test/runners/rust_spec.js
 

--- a/lib/runners/rust.js
+++ b/lib/runners/rust.js
@@ -11,9 +11,6 @@ module.exports = {
       args: ['run'],
       options: {
         cwd: '/workspace/rust',
-        env: Object.assign({}, process.env, {
-          RUSTFLAGS: rustFlags(),
-        }),
       },
     });
   },
@@ -44,9 +41,6 @@ module.exports = {
       args: ['test'],
       options: {
         cwd: '/workspace/rust',
-        env: Object.assign({}, process.env, {
-          RUSTFLAGS: rustFlags(),
-        }),
       },
     });
   },
@@ -106,14 +100,3 @@ module.exports = {
     return stderr;
   },
 };
-
-// ignore some warnings for backward compatibility
-function rustFlags() {
-  const flags = [];
-  if (process.env.RUSTFLAGS !== '') flags.push(process.env.RUSTFLAGS);
-  flags.push('-A', 'dead_code');
-  flags.push('-A', 'unused_imports');
-  flags.push('-A', 'unused_variables');
-  flags.push('-A', 'non_snake_case');
-  return flags.join(' ');
-}


### PR DESCRIPTION
Change in RUSTFLAGS causes everything to be recompiled.
Avoid this by setting it before downloading and compiling crates.

---

It's hard to measure the performance penalties of crates being recompiled, but on Travis

![image](https://user-images.githubusercontent.com/639336/31877963-4c85875a-b78d-11e7-99eb-be8e5dca1077.png)
https://travis-ci.org/Codewars/codewars-runner-cli/jobs/284824746#L845-L848

became

![image](https://user-images.githubusercontent.com/639336/31877980-5a7b84a4-b78d-11e7-85aa-671e896c32c6.png)
https://travis-ci.org/kazk/codewars-runner-cli/jobs/291411040#L842-L845
![image](https://user-images.githubusercontent.com/639336/31879370-1790f87c-b792-11e7-9a27-463f9fd16d55.png)
https://travis-ci.org/Codewars/codewars-runner-cli/jobs/291417135#L843-L846

Note that only the first test case is relevant because tests share the container.

---

The effect should be even more significant on less powerful machines.

#534