### PR TITLE
Disable instrumentation by karma-typescript

### DIFF
--- a/lib/runners/typescript.js
+++ b/lib/runners/typescript.js
@@ -152,7 +152,12 @@ function prepareKarma(opts, interfaceType, runCode, fail) {
             '/runner/node_modules/*',
           ],
         },
-      }
+      },
+      coverageOptions: {
+        // A boolean indicating whether the code should be instrumented,
+        // set this property to false to see the original Typescript code when debugging.
+        instrumentation: false,
+      },
     },
   };
 


### PR DESCRIPTION
- `/workspace/coverage` is no longer produced