### PR TITLE
Fix karma-typescript errors

### DIFF
--- a/lib/runners/typescript.js
+++ b/lib/runners/typescript.js
@@ -152,7 +152,12 @@ function prepareKarma(opts, interfaceType, runCode, fail) {
             '/runner/node_modules/*',
           ],
         },
-      }
+      },
+      coverageOptions: {
+        // A boolean indicating whether the code should be instrumented,
+        // set this property to false to see the original Typescript code when debugging.
+        instrumentation: false,
+      },
     },
   };
 

--- a/test/runners/typescript_spec.js
+++ b/test/runners/typescript_spec.js
@@ -1,8 +1,16 @@
 var expect = require('chai').expect;
 var runner = require('../runner');
+var exec = require('child_process').exec;
 
 
 describe('typescript runner', function() {
+  afterEach(function cleanup(done) {
+    exec('rm -f /workspace/*.ts /workspace/*.js /workspace/*.txt /workspace/*.css', function(err) {
+      if (err) return done(err);
+      done();
+    });
+  });
+
   runner.assertCodeExamples('typescript');
 
   describe('.run', function() {


### PR DESCRIPTION
`/workspace/spec.ts` left from test cases causes strange errors when running TypeScript with Karma. This resolves the issue by removing files after each test case. Also disables instrumentation.

---

```
27 10 2017 21:28:17.613:ERROR [compiler.karma-typescript]: spec.ts(8,58): error TS2339: Property 'a' does not exist on type 'typeof "/home/codewarrior/solution"'.
```

This is caused by `spec.ts` containing `require('./solution')` which is overwritten by submitted code and does not export `a`.

```
27 10 2017 21:28:17.618:ERROR [compiler.karma-typescript]: ../../runner/typings/chai/index.d.ts(386,18): error TS2300: Duplicate identifier 'AssertionError'.
```

`error TS2300` is caused by including the type definition in `fixture.spec.ts` and `spec.ts`.