### PR TITLE
Fix UnitKit with setup code

### DIFF
--- a/lib/runners/objc.js
+++ b/lib/runners/objc.js
@@ -188,7 +188,7 @@ function prepareUnitKit(opts) {
       }
   `;
 
-  codeWriteSync('objc', getCode(opts), opts.dir, 'solution.m');
+  codeWriteSync('objc', opts.solution, opts.dir, 'solution.m');
   if (opts.setup) codeWriteSync('objc', opts.setup, opts.dir, 'setup.m');
   const fixtureFile = codeWriteSync('objc', fixture, opts.dir, 'fixture.m');
   const mainFile = codeWriteSync('objc', main, opts.dir, 'main.m');

--- a/test/runners/objc_spec.js
+++ b/test/runners/objc_spec.js
@@ -631,6 +631,79 @@ describe('objc runner', function() {
           done();
         });
       });
+
+      it('should support setup code', function(done) {
+        // https://github.com/Codewars/codewars.com/issues/1221
+        runner.run({
+          language: 'objc',
+          testFramework: 'unitkit',
+          setup: `
+#import <Foundation/Foundation.h>
+
+@interface Node: NSObject
+{
+  int data;
+  Node *next;
+}
+@property (readonly) int data;
+@property (readonly) Node *next;
+- (id)initWithData: (int)d andNext: (Node *)n;
+- (id)initWithData: (int)d;
++ (Node *)nodeWithData: (int)d andNext: (Node *)n;
++ (Node *)nodeWithData: (int)d;
+@end
+
+@implementation Node
+@synthesize data;
+@synthesize next;
+- (id)initWithData: (int)d andNext: (Node *)n
+{
+  data = d;
+  next = n;
+  return self;
+}
+- (id)initWithData: (int)d
+{
+  data = d;
+  next = NULL;
+  return self;
+}
++ (Node *)nodeWithData: (int)d andNext: (Node *)n
+{
+  return [[Node alloc] initWithData: d andNext: n];
+}
++ (Node *)nodeWithData: (int)d
+{
+  return [[Node alloc] initWithData: d];
+}
+@end
+          `,
+          solution: `
+#import <Foundation/Foundation.h>
+
+NSString *stringify(Node *list) {
+  // TODO: Return a string representation of the list passed in
+  return @"";
+}
+          `,
+          fixture: `
+@implementation TestSuite
+- (void)testNULL
+{
+  UKStringsEqual(@"", stringify(NULL));
+}
+- (void)testSingle
+{
+  UKStringsEqual(@"1", stringify([Node nodeWithData: 1]));
+}
+@end
+          `,
+        }, function(buffer) {
+          expect(buffer.stdout).to.contain('<PASSED::>');
+          expect(buffer.stdout).to.contain('<FAILED::>');
+          done();
+        });
+      });
     });
 
     describe('CW', function() {


### PR DESCRIPTION
Make `solution.m` to only contain `opts.solution` and let `fixture.m` handle importing `setup.m`.

Resolves https://github.com/Codewars/codewars.com/issues/1221