### PR TITLE
Turn off term rewriting macros for Nim

### DIFF
--- a/lib/runners/nim.js
+++ b/lib/runners/nim.js
@@ -53,6 +53,7 @@ function nimArgs(file) {
     '--stackTrace:on',  // turn stack tracing on
     '--lineTrace:on',   // turn line tracing on
     '--checks:on',      // turn all runtime checks on
+    '--trmacros:off',   // turn off term rewriting macros
     '--path:/runner/frameworks/nim',
     file
   ];


### PR DESCRIPTION
Term rewriting macros make it easy to cheat Nim tests. There are no katas that require their use and they're an experimental feature in the first place.